### PR TITLE
Pluggable Authentication via Passport

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "connect-flash": "^0.1.1",
     "cookie-session": "1.0.x",
     "ejs": "1.0.x",
+    "errorhandler": "^1.4.0",
     "express": "4.x.x",
     "json2csv": "2.2.x",
     "keymaster": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "1.2.x",
     "cookie-parser": "1.1.x",
+    "connect-flash": "^0.1.1",
     "cookie-session": "1.0.x",
     "ejs": "1.0.x",
     "express": "4.x.x",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mysql": "2.x.x",
     "nedb": "1.x.x",
     "passport": "^0.2.2",
+    "passport-google-oauth2": "^0.1.6",
     "passport-local": "^1.0.0",
     "pg": "^4.1.0",
     "pg-cursor": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "mssql": "1.x.x",
     "mysql": "2.x.x",
     "nedb": "1.x.x",
+    "passport": "^0.2.2",
+    "passport-local": "^1.0.0",
     "pg": "^4.1.0",
     "pg-cursor": "^1.0.0",
     "rc": "^0.5.4",

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -15,18 +15,24 @@ a {
   text-align: center;
 }
 
-.form-signin {
+.signin {
   max-width: 330px;
-  padding: 15px;
   margin: 0 auto;
+  padding: 15px;
 }
 
-.form-signin h2 {
-    text-align: center; padding-bottom:20px
+.signin h2 {
+    text-align: center;
+    padding-bottom:20px
 }
+
+.signin a:hover, .signin a:focus, .signin a:active {
+  text-decoration: none;
+}
+
 .form-signin-footer {
     text-align: center;
-    margin-top: 30px;
+    margin-top: 15px;
 }
 .form-signin .form-signin-heading,
 .form-signin .checkbox {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -11,6 +11,10 @@ a {
   color: #00B7FF;
 }
 
+.error {
+  text-align: center;
+}
+
 .form-signin {
   max-width: 330px;
   padding: 15px;

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -7,13 +7,18 @@
 ============================================================================= */
 module.exports = function (app) {
     var db = app.get('db');
-    app.get('/', function(req, res){
+    app.get('/', function(req, res) {
+        var connectionExists = false;
         db.connections.findOne({}, function (err, doc) {
             if (doc) {
-                res.redirect('/queries');
-            } else {
-                res.redirect('/connections');
+                connectionExists = true;
             }
         });
+
+        if (!connectionExists && res.locals.user.admin) {
+            res.redirect('/connections');
+        } else {
+            res.redirect('/queries');
+        }
     });  
 };

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -13,7 +13,7 @@ module.exports = function (app, passport) {
     passport.use(new passportGoogleStrategy({
         clientID          : process.env.GOOGLE_CLIENT_ID,
         clientSecret      : process.env.GOOGLE_CLIENT_SECRET,
-        callbackURL       : "http://localhost:3000/auth/google/callback",
+        callbackURL       : process.env.PUBLIC_URL + "/auth/google/callback",
         passReqToCallback : true
     },
         function(request, accessToken, refreshToken, profile, done) {

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -1,0 +1,73 @@
+var passportGoogleStrategy = require('passport-google-oauth2').Strategy;
+
+module.exports = function (app, passport) {  
+    var db = app.get('db');
+
+    if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
+        console.log("Disabling Google authentication streategy, since there's no GOOGLE_CLIENT_ID or no GOOGLE_CLIENT_SECRET in ENV.");
+        return;
+    } else {
+        console.log("Enabling Google authentication Strategy.")
+    }
+
+    passport.use(new passportGoogleStrategy({
+        clientID          : process.env.GOOGLE_CLIENT_ID,
+        clientSecret      : process.env.GOOGLE_CLIENT_SECRET,
+        callbackURL       : "http://localhost:3000/auth/google/callback",
+        passReqToCallback : true
+    },
+        function(request, accessToken, refreshToken, profile, done) {
+            db.users.findOne({ email: profile.email }, function(err, user){
+                if (err) { return done(err, null); }
+                if (user) {
+                    if (!user.createdDate) {
+                        db.users.update({_id: user._id}, {$set: {createdDate: new Date()}}, function (err) {
+                            if (err) console.log(err);
+                            return done(null, {
+                                id: user._id,
+                                email: user.email,
+                                admin: user.admin
+                            });
+                        });
+                    } else {
+                        return done(null, {
+                            id: user._id,
+                            email: user.email,
+                            admin: user.admin
+                        });
+                    }
+                } else {
+                    if (app.get('openAdminRegistration')){
+                        var user = {
+                            email: profile.email,
+                            admin: true, 
+                            createdDate: new Date()
+                        }
+                        db.users.insert(user, function (err, newUser) {
+                            if (err == null){
+                                app.set('openAdminRegistration', false);
+                            } else {
+                                console.log("Error: ", err);
+                            }
+                            return done(null, {
+                                id: user._id,
+                                email: user.email,
+                                admin: user.admin                                
+                            });
+                        });
+                    } else {
+                        return done(null, false, {message: "You haven't been invited by an admin yet."});
+                    }
+                }
+            })
+        }
+    ));
+    
+    app.get("/auth/google", passport.authenticate('google', { scope: ['email'] }));
+
+    app.get('/auth/google/callback', 
+        passport.authenticate('google', { 
+            successRedirect: '/',
+            failureRedirect: '/signin'
+    }));
+};

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -136,7 +136,7 @@ module.exports = function (app) {
     app.post('/signin',
         passport.authenticate('local', {
             successRedirect: '/',
-            failureRedirect: '/error',
+            failureRedirect: '/signin',
             failureFlash: true
         })
     );

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -6,124 +6,121 @@ module.exports = function (app) {
     
     var db = app.get('db');
     
-    /*    Sign Up
-    ============================================================================= */
-    function signupBodyToLocals (req, res, next) {
-        res.locals.password = req.body.password || '';
-        res.locals.passwordConfirmation = req.body.passwordConfirmation || '';
-        res.locals.email = req.body.email || '';
-        next();
-    }
-    
-    function notIfSignedIn (req, res, next) {
-        if (isAuthenticated()) {
-            res.locals.debug = {message: "Already signed in - why do you need to sign up?"};
-            res.location('/');
-            res.render('index');
-        } else {
+    if (!("DISABLE_USERPASS_AUTH" in process.env)) {
+        /*    Sign Up
+        ============================================================================= */
+        function signupBodyToLocals (req, res, next) {
+            res.locals.password = req.body.password || '';
+            res.locals.passwordConfirmation = req.body.passwordConfirmation || '';
+            res.locals.email = req.body.email || '';
             next();
         }
-    }
-    
-    app.get('/signup', notIfSignedIn, signupBodyToLocals, function (req, res) {
-        res.render('signup');
-    });
-    
-    app.post('/signup', signupBodyToLocals, function (req, res) {
-        if (req.body.password !== req.body.passwordConfirmation) {
-            res.render('signup', {message: 'passwords are not match'});
-        } else {
-            bcrypt.hash(req.body.password, null, null, function(err, hash) {
-                var bodyUser = {
-                    email: req.body.email,
-                    passhash: hash,
-                    modifiedDate: new Date(),
-                    createdDate: new Date()
-                };
-                db.users.findOne({email: bodyUser.email}, function (err, user) {
-                    if (user) {
-                        db.users.update({_id: user._id}, {$set: bodyUser}, {}, function (err) {
-                            if (err) console.log(err);
-                            req.session.userId = user._id;
-                            req.session.admin = user.admin;
-                            req.session.email = user.email;
-                            res.redirect('/');
-                        });
-                    } else if (err) {
-                        console.log(err);
-                        res.render('signup', {message: 'An error happened.'});
-                    } else if (app.get('openAdminRegistration')) {
-                        // first admin in the system, so allow it to go through
-                        // then once its in, turn openAdminRegistration off
-                        user = {
-                            email: bodyUser.email,
-                            admin: true,
-                            passhash: hash,
-                            createdDate: new Date(),
-                            modifiedDate: new Date()
-                        };
-                        db.users.insert(user, function (err, newUser) {
-                            // set session, turn open registration off
-                            if (err) {
-                                console.log(err);
-                                res.render('signup', {message: 'An error happened saving the new user to DB.'});
-                            } else {
-                                app.set('openAdminRegistration', false);
-                                req.session.userId = newUser._id;
-                                req.session.admin = newUser.admin;
-                                req.session.email = newUser.email;
-                                res.redirect('/');
-                            }
-                        });
-                    } else {
-                        // not whitelisted?
-                        console.log(user);
-                        res.render('signup', {message: 'Sorry, but that email address has not been whitelisted yet.'});
-                    }
-                });
-            });
-        }
-    });
-    
-    
-    /*    Sign In / Out
-    ============================================================================= */
-    function signinBodyToLocals (req, res, next) {
-        res.locals.email = req.body.email || '';
-        res.locals.password = req.body.password || '';
-        next();
-    }
-
-    app.get('/signin', signinBodyToLocals, function (req, res) {
-        res.render('signin', { strategies: passport._strategies });
-    });
-
-    passport.use(new passportLocalStrategy({
-        usernameField: 'email',
-      },
-      function(email, password, done) {
-        db.users.findOne({email: email}, function (err, doc) {
-            if (err) { return done(err); }
-            if (doc) {
-                bcrypt.compare(password, doc.passhash, function (err, isMatch) {
-                    if (err) { done(err); }
-                    if (isMatch) {
-                        // match! redirect home
-                        return done(null, {
-                            id: doc._id,
-                            admin: doc.admin,
-                            email: doc.email
-                        });
-                    } else {
-                        return done(null, false, { message: "wrong email or password" });
-                    }
-                });
+        
+        function notIfSignedIn (req, res, next) {
+            if (req.session && req.session.userId) {
+                res.locals.debug = {message: "Already signed in - why do you need to sign up?"};
+                res.location('/');
+                res.render('index');
             } else {
-                return done(null, false, { message: "wrong email or password" });
+                next();
+            }
+        }
+        
+        app.get('/signup', notIfSignedIn, signupBodyToLocals, function (req, res) {
+            res.render('signup');
+        });
+        
+        app.post('/signup', signupBodyToLocals, function (req, res) {
+            if (req.body.password !== req.body.passwordConfirmation) {
+                res.render('signup', {message: 'passwords are not match'});
+            } else {
+                bcrypt.hash(req.body.password, null, null, function(err, hash) {
+                    var bodyUser = {
+                        email: req.body.email,
+                        passhash: hash,
+                        modifiedDate: new Date(),
+                        createdDate: new Date()
+                    };
+                    db.users.findOne({email: bodyUser.email}, function (err, user) {
+                        if (user) {
+                            db.users.update({_id: user._id}, {$set: bodyUser}, {}, function (err) {
+                                if (err) console.log(err);
+                                req.session.userId = user._id;
+                                req.session.admin = user.admin;
+                                req.session.email = user.email;
+                                res.redirect('/');
+                            });
+                        } else if (err) {
+                            console.log(err);
+                            res.render('signup', {message: 'An error happened.'});
+                        } else if (app.get('openAdminRegistration')) {
+                            // first admin in the system, so allow it to go through
+                            // then once its in, turn openAdminRegistration off
+                            user = {
+                                email: bodyUser.email,
+                                admin: true,
+                                passhash: hash,
+                                createdDate: new Date(),
+                                modifiedDate: new Date()
+                            };
+                            db.users.insert(user, function (err, newUser) {
+                                // set session, turn open registration off
+                                if (err) {
+                                    console.log(err);
+                                    res.render('signup', {message: 'An error happened saving the new user to DB.'});
+                                } else {
+                                    app.set('openAdminRegistration', false);
+                                    req.session.userId = newUser._id;
+                                    req.session.admin = newUser.admin;
+                                    req.session.email = newUser.email;
+                                    res.redirect('/');
+                                }
+                            });
+                        } else {
+                            // not whitelisted?
+                            console.log(user);
+                            res.render('signup', {message: 'Sorry, but that email address has not been whitelisted yet.'});
+                        }
+                    });
+                });
             }
         });
-      }
-    ));
+
+        passport.use(new passportLocalStrategy({
+            usernameField: 'email',
+          },
+          function(email, password, done) {
+            db.users.findOne({email: email}, function (err, doc) {
+                if (err) { return done(err); }
+                if (doc) {
+                    bcrypt.compare(password, doc.passhash, function (err, isMatch) {
+                        if (err) { done(err); }
+                        if (isMatch) {
+                            // match! redirect home
+                            return done(null, {
+                                id: doc._id,
+                                admin: doc.admin,
+                                email: doc.email
+                            });
+                        } else {
+                            return done(null, false, { message: "wrong email or password" });
+                        }
+                    });
+                } else {
+                    return done(null, false, { message: "wrong email or password" });
+                }
+            });
+          }
+        ));
+
+        app.post('/signin',
+            passport.authenticate('local', {
+                successRedirect: '/',
+                failureRedirect: '/signin',
+                failureFlash: true
+            })
+        );
+    }
 
     passport.serializeUser(function(user, done) {
         done(null, user.id);
@@ -142,15 +139,19 @@ module.exports = function (app) {
             }
         });
     });
-    
-    app.post('/signin',
-        passport.authenticate('local', {
-            successRedirect: '/',
-            failureRedirect: '/signin',
-            failureFlash: true
-        })
-    );
 
+    /*    Sign In / Out
+    ============================================================================= */
+    function signinBodyToLocals (req, res, next) {
+        res.locals.email = req.body.email || '';
+        res.locals.password = req.body.password || '';
+        next();
+    }
+
+    app.get('/signin', signinBodyToLocals, function (req, res) {
+        res.render('signin', { strategies: passport._strategies });
+    });    
+    
     app.get('/signout', function (req, res) {
         req.logout();
         res.redirect('/');

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -126,11 +126,21 @@ module.exports = function (app) {
     ));
 
     passport.serializeUser(function(user, done) {
-        done(null, user);
+        done(null, user.id);
     });
 
-    passport.deserializeUser(function(user, done) {
-        done(null, user);
+    passport.deserializeUser(function(id, done) {
+        db.users.findOne({_id: id}, function (err, doc) {
+            if (doc) {
+                done(null, {
+                    id: doc._id,
+                    admin: doc.admin,
+                    email: doc.email
+                });
+            } else {
+                done(null, false);
+            }
+        });
     });
     
     app.post('/signin',

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -95,7 +95,7 @@ module.exports = function (app) {
     }
 
     app.get('/signin', signinBodyToLocals, function (req, res) {
-        res.render('signin');
+        res.render('signin', { strategies: passport._strategies });
     });
 
     passport.use(new passportLocalStrategy({

--- a/routes/queries.js
+++ b/routes/queries.js
@@ -132,12 +132,12 @@ module.exports = function (app) {
             queryText: req.body.queryText,
             chartConfiguration: req.body.chartConfiguration,
             modifiedDate: new Date(),
-            modifiedBy: req.session.email,
+            modifiedBy: req.user.email,
             lastAccessedDate: new Date()
         };
         if (req.params._id == "new") {
             bodyQuery.createdDate = new Date();
-            bodyQuery.createdBy = req.session.email;
+            bodyQuery.createdBy = req.user.email;
 
             db.queries.insert(bodyQuery, function (err, query) {
                 if (err) {

--- a/routes/user-admin.js
+++ b/routes/user-admin.js
@@ -37,7 +37,7 @@ module.exports = function (app) {
     
     app.post('/users/remove-admin/:_id', function (req, res) {
         // can't unadmin one's self
-        if (req.session.userId === req.params._id) {
+        if (req.user._id === req.params._id) {
             res.location('/users');
             res.locals.debug = "You can't unadmin yourself!";
             renderUsers(req, res);

--- a/server.js
+++ b/server.js
@@ -78,7 +78,7 @@ app.use(function (req, res, next) {
     // if not signed in redirect to sign in page
     if (req.isAuthenticated()) {
         next();
-    } else if (req._parsedUrl.pathname === '/signin' || req._parsedUrl.pathname === '/signup') {
+    } else if (req._parsedUrl.pathname === '/signin' || req._parsedUrl.pathname === '/signup' || req._parsedUrl.pathname.indexOf('/auth/') == 0) {
         next();
     } else if (app.get('openRegistration')) {
         // if there are no users whitelisted, direct to signup
@@ -127,6 +127,7 @@ app.use('/config', mustBeAdmin);
     update → PUT     /collection/id
     delete → DELETE  /collection/id
 ============================================================================= */
+require('./routes/oauth.js')(app, passport);
 require('./routes/homepage.js')(app);
 require('./routes/onboarding.js')(app);
 require('./routes/user-admin.js')(app);

--- a/server.js
+++ b/server.js
@@ -40,12 +40,18 @@ var cookieSession = require('cookie-session');
 var morgan = require('morgan');
 var passport = require('passport');
 var connectFlash = require('connect-flash');
+var errorhandler = require('errorhandler');
 
 app.locals.title = 'SqlPad';
 app.locals.version = packageJson.version;
 app.set('packageJson', packageJson);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
+
+if (process.env.NODE_ENV === 'development') {
+  // only use in development
+  app.use(errorhandler());
+}
 app.use(favicon(__dirname + '/public/images/favicon.ico'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
@@ -97,9 +103,7 @@ function mustBeAdmin (req, res, next) {
     if (req.user.admin) {
         next();
     } else {
-        res.location('/error');
-        res.locals.errorMessage = "You must be an admin to do that";
-        res.render('error');
+        throw "You must be an admin to do that";
     }
 }
 app.use('/connections', mustBeAdmin);
@@ -138,16 +142,6 @@ require('./routes/download-results.js')(app); // streams cached query results to
 require('./routes/schema-info.js')(app);
 require('./routes/configs.js')(app);
 require('./routes/tags.js')(app);
-
-app.get('/error', function (req, res) {
-    res.render('error', {errorMessage: "this is a message"});
-});
-
-function errorHandler(err, req, res, next) {
-    res.status(500);
-    res.render('error', { error: err });
-}
-app.use(errorHandler);
 
 /*	Start the Server
 ============================================================================= */

--- a/server.js
+++ b/server.js
@@ -54,12 +54,14 @@ app.use(bodyParser.urlencoded({
 app.use(methodOverride()); // simulate PUT/DELETE via POST in client by <input type="hidden" name="_method" value="put" />
 app.use(cookieParser(app.get('passphrase'))); // populates req.cookies with an object
 app.use(cookieSession({secret: app.get('passphrase')}));
+app.use(connectFlash());
 app.use(passport.initialize());
 app.use(passport.session());
 app.use(express.static(path.join(__dirname, 'public')));
 if (app.get('dev')) app.use(morgan('dev'));
 app.use(function (req, res, next) {
     // Boostrap res.locals with any common variables
+    res.locals.errors = req.flash('error');
     res.locals.message = null;
     res.locals.navbarConnections = [];
     res.locals.debug = null;

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,7 +1,0 @@
-<% include header %>
-    
-    <div>
-        <%= errorMessage %>
-    </div>
-    
-<% include footer %>

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -80,6 +80,11 @@
     <% } %>
     
     <div class="container-fluid">
+    <% if (errors.length > 0) { %>
+    <div class="row error">
+      <h3><%= errors %></h3>
+    </div>
+    <% } %>
     <div class="row">
             
       

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -25,6 +25,9 @@
 	
 	<!-- bootstrap tag input -->
     <link rel="stylesheet" href="/javascripts/vendor/bootstrap-tagsinput/bootstrap-tagsinput.css" type="text/css"/>
+
+    <!-- Font Awesome icons -->
+    <link rel='stylesheet', href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css" type="text/css"/>
 	
 	<!-- my css -->
     <link rel="stylesheet" href="/stylesheets/style.css">

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -33,7 +33,7 @@
 
   <body>
     
-    <% if (session && session.userId) { %>
+    <% if (isAuthenticated) { %>
       <!-- Static navbar -->
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
           <div class="container-fluid">
@@ -49,9 +49,9 @@
             
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">
-                <li class="<%= (pageTitle && pageTitle == "Queries" ? "active" : "") %>"><a href="/queries?createdBy=<%= encodeURIComponent(session.email) %>">Queries</a></li>
+                <li class="<%= (pageTitle && pageTitle == "Queries" ? "active" : "") %>"><a href="/queries?createdBy=<%= encodeURIComponent(user.email) %>">Queries</a></li>
                 <li><a href="/queries/new">New Query</a></li>
-                <% if (session && session.admin) { %>
+                <% if (isAuthenticated && user.admin) { %>
                 <li class="<%= (pageTitle && pageTitle == "Connections" ? "active" : "") %>"><a href="/connections">Connections</a></li>
                 <li class="<%= (pageTitle && pageTitle == "Users" ? "active" : "") %>"><a href="/users">Users</a></li>
                 <li class="<%= (pageTitle && pageTitle == "Configuration" ? "active" : "") %>"><a href="/configs">Configuration</a></li>
@@ -59,9 +59,9 @@
               </ul>
               
               <ul class="nav navbar-nav navbar-right">
-                <% if (session && session.userId && session.email) { %>
+                <% if (isAuthenticated) { %>
                   <li class="dropdown">
-                      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= session.email.split('@')[0] %> <b class="caret"></b></a>
+                      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= user.email.split('@')[0] %> <b class="caret"></b></a>
                        <ul class="dropdown-menu">
                          <li><a href="/signout">Sign Out</a></li>
                          <li role="presentation" class="divider"></li>

--- a/views/queries-table.ejs
+++ b/views/queries-table.ejs
@@ -28,7 +28,7 @@
                                         <%= connectionsById[query.connectionId].name %> 
                                     <% } %>
                                 </td>
-                                <td><%= (query.createdBy && query.createdBy == session.email ? "Me" : (query.createdBy || "")) %></td>
+                                <td><%= (query.createdBy && query.createdBy == user.email ? "Me" : (query.createdBy || "")) %></td>
                                 <!--<td><%= query.lastAccessedFromNow || "" %></td>-->
                                 <td><%= query.modifiedCalendar %></td>
                                 <td>

--- a/views/queries.ejs
+++ b/views/queries.ejs
@@ -44,7 +44,7 @@
                                     <option value="">Everyone</option>
                                     <% createdBys.forEach(function(createdBy) { %>
                                         <option value="<%= createdBy %>" <%=( filter && filter.createdBy && filter.createdBy===createdBy ? 'selected' : '') %>>
-                                            <%= (createdBy && createdBy == session.email ? "Me" : (createdBy || "")) %>
+                                            <%= (createdBy && createdBy == user.email ? "Me" : (createdBy || "")) %>
                                         </option>
                                     <% }) %>
                                 </select>

--- a/views/signin.ejs
+++ b/views/signin.ejs
@@ -2,9 +2,6 @@
   
 	<form class="form-signin" role="form" action="/signin" method="post">
 		<h2>SqlPad</h2>
-		<% if (message) { %>
-			<h3><%= message %></h3>
-		<% } %>
 		<input
 		    name="email"
 		    value="<%= email %>"

--- a/views/signin.ejs
+++ b/views/signin.ejs
@@ -1,31 +1,44 @@
 <% include header %>
-  
-	<form class="form-signin" role="form" action="/signin" method="post">
-		<h2>SqlPad</h2>
-		<input
-		    name="email"
-		    value="<%= email %>"
-		    type="email"
-		    class="form-control top-field"
-		    placeholder="Email address"
-		    required
-		    autofocus>
-		<input
-		    name="password"
-		    value="<%= password %>"
-		    type="password"
-		    class="form-control bottom-field"
-		    placeholder="Password"
-		    required>
-		<br>
-		<button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
-        <div class="form-signin-footer">
-            <p>
-                <a href="/signup">Need to Sign Up?</a>
-            </p>
-        </div>
-        
-	</form>
-	
+
+  <div class="signin">
+	<h2>SqlPad</h2>
+  	<% if ("local" in strategies) { %>
+  	<div>
+		<form class="form-signin" role="form" action="/signin" method="post">
+			<input
+			    name="email"
+			    value="<%= email %>"
+			    type="email"
+			    class="form-control top-field"
+			    placeholder="Email address"
+			    required
+			    autofocus>
+			<input
+			    name="password"
+			    value="<%= password %>"
+			    type="password"
+			    class="form-control bottom-field"
+			    placeholder="Password"
+			    required>
+			<br>
+			<button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+		</form>
+		<div class="form-signin-footer">
+			<p>
+				<a href="/signup">Need to Sign Up?</a>
+			</p>
+		</div>
+	</div>
+	<% } %>
+	<% if ("google" in strategies) { %>
+	<div>
+		<a href="/auth/google">
+			<button class="btn btn-lg btn-danger btn-block">
+				<i class="fa fa-google-plus"></i> Log in with Google
+			</button>
+		</a>
+	</div>
+	<% } %>
+  </div>
 
 <% include footer %>


### PR DESCRIPTION
We wanted to use sqlpad internally at Gumroad, but we wanted to use one of our existing identity solutions instead of username/password. To that extent, we integrated with Passport.js (a commonly used npm module that provides a multitude of authentication strategies). You can now:

  * turn off the username-password strategy (by setting the `DISABLE_USERPASS_AUTH` environment variable,
  * turn on the Google OAuth strategy (by setting `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`, and `PUBLIC_URL`.

Let us know if there's anything we can do to make this change more consumable/welcome :) 