### PR TITLE
Fix bugs with /homepage redirect & passport session removal on logout

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -153,7 +153,7 @@ module.exports = function (app) {
     });    
     
     app.get('/signout', function (req, res) {
-        req.logout();
+        req.session = null;
         res.redirect('/');
     });
     


### PR DESCRIPTION
Changed `req.logout()` to `req.session=null`. This is necessary because `logout()` wasn't clearing the session properly, leading to weird behavior if one tries to sign up for a different account afterwards.