### PR TITLE
Post to Slack webhook when a query is saved.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "1.2.x",
-    "cookie-parser": "1.1.x",
     "connect-flash": "^0.1.1",
+    "cookie-parser": "1.1.x",
     "cookie-session": "1.0.x",
     "ejs": "1.0.x",
     "errorhandler": "^1.4.0",
@@ -51,6 +51,7 @@
     "pg": "^4.1.0",
     "pg-cursor": "^1.0.0",
     "rc": "^0.5.4",
+    "request": "^2.58.0",
     "sanitize-filename": "1.1.x",
     "serve-favicon": "2.0.x",
     "ua-parser": "0.3.x",


### PR DESCRIPTION
We wanted to be able to be able to dump queries people were saving to a Slack channel, so this change allows an admin to set the `slackWebhook` config to a Slack Incoming WebHook URL to automatically post new queries that are saved to Slack.

![screen shot 2015-06-30 at 4 00 51 pm](https://cloud.githubusercontent.com/assets/5981363/8444034/52019a48-1f41-11e5-9026-cb97e3437587.png)

If the config is not set, the app behaves as normal.
