### PR TITLE
Whitelist some domains to allow through automatically.

### DIFF
--- a/lib/add-email-domain-whitelist-to-app.js
+++ b/lib/add-email-domain-whitelist-to-app.js
@@ -1,0 +1,27 @@
+/*  Set and check whitelisted email domains so that users with the appropriate
+ emails do not have to explicitly be invited.
+
+ This checks the WHITELISTED_DOMAINS env variable, which is a string of space
+ delimited domains.
+
+ Example: "baz.com foo.bar.com" will allow anyone with a @baz.com or @foo.bar.com
+ email to sign up. The domains and subdomains must match exactly (i.e. someone
+ with a @bar.com or @123.baz.com would not be able to sign up.)
+============================================================================= */
+module.exports = function(app){
+    
+    function checkWhitelist (email) {
+        if (process.env.WHITELISTED_DOMAINS) {
+            var whitelistDomains = process.env.WHITELISTED_DOMAINS.split(' ');
+            var domain = email.split('@')[1];
+            for (var i = 0; i < whitelistDomains.length; i++) {
+                if (domain == whitelistDomains[i]){
+                    return true;
+                }
+            }   
+        }
+        return false;
+    }
+
+    app.set('checkWhitelist', checkWhitelist);
+}

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -37,10 +37,10 @@ module.exports = function (app, passport) {
                         });
                     }
                 } else {
-                    if (app.get('openAdminRegistration')){
+                    if (app.get('openAdminRegistration') || app.get('checkWhitelist')(profile.email)){
                         var user = {
                             email: profile.email,
-                            admin: true, 
+                            admin: app.get('openAdminRegistration'), 
                             createdDate: new Date()
                         }
                         db.users.insert(user, function (err, newUser) {

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -53,12 +53,13 @@ module.exports = function (app) {
                         } else if (err) {
                             console.log(err);
                             res.render('signup', {message: 'An error happened.'});
-                        } else if (app.get('openAdminRegistration')) {
+                        } else if (app.get('openAdminRegistration') || app.get('checkWhitelist')(req.body.email)) {
                             // first admin in the system, so allow it to go through
+                            // also allow whitelisted emails
                             // then once its in, turn openAdminRegistration off
                             user = {
                                 email: bodyUser.email,
-                                admin: true,
+                                admin: app.get('openAdminRegistration'),
                                 passhash: hash,
                                 createdDate: new Date(),
                                 modifiedDate: new Date()

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ require('./lib/add-cli-config-to-app.js')(app);
 require('./lib/add-db-to-app.js')(app);
 require('./lib/add-cipher-decipher-to-app.js')(app);
 require('./lib/add-open-admin-registration-to-app.js')(app);
+require('./lib/add-email-domain-whitelist-to-app.js')(app);
 
 
 /*  Express setup


### PR DESCRIPTION
This change allows the `WHITELISTED_DOMAINS` env variable so that you don't have to explicitly invite users under certain domains.

I used an env variable instead of a config because it made the changes to the existing logic minimally invasive. 
