### PR TITLE
Enclose csv filename in quotes.

### DIFF
--- a/routes/download-results.js
+++ b/routes/download-results.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
                 db.cache.findOne({cacheKey: req.params.cacheKey}, function (err, cache) {
                     if (err) console.log(err);
                     var filename = cache.queryName + ".csv";
-                    res.setHeader('Content-disposition', 'attachment; filename=' + filename);
+                    res.setHeader('Content-disposition', 'attachment; filename="' + filename + '"');
                     res.setHeader('Content-Type', 'text/csv');
                     var csvPath = path.join(app.get('dbPath'), "/cache/", req.params.cacheKey + ".csv");
                     fs.createReadStream(csvPath).pipe(res);


### PR DESCRIPTION
This is necessary otherwise some browsers will treat filenames
with commas as multiple headers delimited by commas, and results in a Multiple
Content Disposition error.

The error in question:
![screen shot 2015-08-19 at 3 05 57 pm](https://cloud.githubusercontent.com/assets/5981363/9370269/d89311a4-4683-11e5-9844-2a83a6fa16db.png)
