### PR TITLE
Prevent DB password from being sent to the frontend.

### DIFF
--- a/routes/connections.js
+++ b/routes/connections.js
@@ -36,7 +36,7 @@ module.exports = function (app) {
                 connection = {};
             } else {
                 connection.username = decipher(connection.username);
-                connection.password = decipher(connection.password);
+                connection.password = "";
             }
             res.render('connection', {
                 connection: connection


### PR DESCRIPTION
Right now the application sends the DB password along with the connection username to the admin interface, which seems unnecessary and less secure. For example, if your deployment of SqlPad isn't using HTTPS for some reason, someone can snoop on your network and obtain your DB credentials.

The tradeoff is that admins won't be able to grab the password directly from the interface.