### PR TITLE
The user must be registered to compare the password hash.

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -88,10 +88,10 @@ module.exports = function (app) {
         });
 
         passport.use(new passportLocalStrategy({
-            usernameField: 'email',
+            usernameField: 'email'
           },
           function(email, password, done) {
-            db.users.findOne({email: email}, function (err, doc) {
+            db.users.findOne({email: email, createdDate: {$exists: true}}, function (err, doc) {
                 if (err) { return done(err); }
                 if (doc) {
                     bcrypt.compare(password, doc.passhash, function (err, isMatch) {


### PR DESCRIPTION
Trying to sign in  with an authorized account but not yet signed, the server will crash, because we are passing an empty password to the bcrypt compare.