### PR TITLE
Add support for binding to a specific IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 - Many client-side and server-side dependencies updated
+- Add ability to bind to a specific IP address via the --ip flag or the SQLPAD_IP environment variable
 
 ## 1.14.0
 - Add ability to turn off date localization (add config item "localize" set to "false")

--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ If you have highlighted just part of your query, only that part will be executed
 
 ## Configuration
 
+### IP Address
+
+By default SqlPad will listen from all available addresses (0.0.0.0). This may be overridden via the `--ip` flag or the `SQLPAD_IP` environment variable.
+
 ### Port
 
-By default SqlPad will use port 80. This my be overridden via cli parameter --port or environment variable SQLPAD_PORT.
+By default SqlPad will use port 80. This may be overridden via cli parameter `--port` or environment variable `SQLPAD_PORT`.
 
 ### Encryption Passphrase 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,7 @@ var configFilePath = path.join(userHome, '.sqlpadrc');
 // $HOME/.sqlpad/db
 //var configFile = path.join(userHome, '.sqlpad/config');
 var config = rc('sqlpad', {
+    ip: process.env.SQLPAD_IP || "0.0.0.0",
     port: process.env.SQLPAD_PORT || 80,
     dbPath: path.join(userHome, "sqlpad/db"),
     passphrase: process.env.SQLPAD_PASSPHRASE || "At least the sensitive bits won't be plain text?"
@@ -53,6 +54,7 @@ if (config.h || config.help) {
                  + "  --passphrase [phrase]   Passphrase for modest encryption  (recommended)\n"
                  + "                          environment variable: SQLPAD_PASSPHRASE\n"
                  + "  --dir [path]            Data directory (optional. Default is $HOME/sqlpad/db\n"
+                 + "  --ip [ip]               IP address to bind to (optional. Default is all IPs, i.e 0.0.0.0)\n"
                  + "  --port [port]           Port to run on (optional. Default is 80)\n"
                  + "                          environment variable: SQLPAD_PORT\n"
                  + "  --debug                 Enable extra console logging\n"
@@ -62,7 +64,7 @@ if (config.h || config.help) {
                  + " \n"
                  + "Example: \n"
                  + " \n"
-                 + "  sqlpad --dir ./SqlpadData --port 3000 --passphrase secr3t\n"
+                 + "  sqlpad --dir ./SqlpadData --ip 127.0.0.1 --port 3000 --passphrase secr3t\n"
                  + " \n";
                      
     console.log(helpText);

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ app.set('debug', config.debug);
 app.set('passphrase', config.passphrase);
 app.set('dbPath', config.dbPath);
 app.set('port', config.port);
+app.set('ip', config.ip);
 if (config.hasOwnProperty('dev')) app.set('dev', true);
 if (config.admin) app.set('admin', config.admin);
 
@@ -179,6 +180,6 @@ require('./routes/tags.js')(app);
 
 /*	Start the Server
 ============================================================================= */
-http.createServer(app).listen(app.get('port'), function(){
-	console.log('\nWelcome to ' + app.locals.title + '!. Visit http://localhost:' + app.get('port') + ' to get started');
+http.createServer(app).listen(app.get('port'), app.get('ip'), function(){
+	console.log('\nWelcome to ' + app.locals.title + '!. Visit http://'+(app.get('ip') == '0.0.0.0' ? 'localhost' : app.get('ip'))+':' + app.get('port') + ' to get started');
 });


### PR DESCRIPTION
Node's HTTP server binds to 0.0.0.0 by default, but there are situations where you want to bind to a specific address (multiple interfaces on a single host, SSL without SNI etc.). This commit adds support for that while preserving BC.

@rickbergfalk I'd like to merge this to master soon, but I'm open to changes/feedback in the meantime.