### PR TITLE
use generated id instead of undefined

### DIFF
--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -50,7 +50,7 @@ module.exports = function (app, passport) {
                                 console.log("Error: ", err);
                             }
                             return done(null, {
-                                id: user._id,
+                                id: newUser._id,
                                 email: user.email,
                                 admin: user.admin                                
                             });


### PR DESCRIPTION
When a new user is created via Google authentication, this user gets the serialisation error:
```
Error: Failed to serialize user into session
  at pass (/usr/lib/node_modules/sqlpad/node_modules/passport/lib/authenticator.js:277:19)
  at serialized (/usr/lib/node_modules/sqlpad/node_modules/passport/lib/authenticator.js:282:7)
  at /usr/lib/node_modules/sqlpad/routes/onboarding.js:127:9
  at pass (/usr/lib/node_modules/sqlpad/node_modules/passport/lib/authenticator.js:290:9)
  at Authenticator.serializeUser (/usr/lib/node_modules/sqlpad/node_modules/passport/lib/authenticator.js:295:5)
  at IncomingMessage.req.login.req.logIn (/usr/lib/node_modules/sqlpad/node_modules/passport/lib/http/request.js:48:29)
  at Strategy.strategy.success (/usr/lib/node_modules/sqlpad/node_modules/passport/lib/middleware/authenticate.js:228:13)
  at verified (/usr/lib/node_modules/sqlpad/node_modules/passport-google-oauth2/node_modules/passport-oauth2/lib/strategy.js:179:18)
  at /usr/lib/node_modules/sqlpad/routes/oauth.js:52:36
  at callback (/usr/lib/node_modules/sqlpad/node_modules/nedb/lib/executor.js:30:17)
```
User is created and and can be used after you retry logging in, but explaining this to new users is non-optimal.

The reason is that `user` object doesn’t contain `_id`, since it’s created by `db.users.insert` function and returned via `newUser` object. Changing `user` to `newUser` in this one line fixes the issue.
