### PR TITLE
Adding a docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+web:
+  build: docker
+  environment:
+    SQL_PAD_PASSWORD: somepassword
+  ports:
+    - "3000:3000"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:jessie
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV NODEJS_VERSION 4.2.6
+
+RUN apt-get update \
+ && apt-get dist-upgrade --no-install-recommends -q -o Dpkg::Options::="--force-confold" --force-yes -y \
+ && apt-get install --no-install-recommends -q -o Dpkg::Options::="--force-confold" --force-yes -y \
+    wget \
+    xz-utils \
+ && apt-get clean
+
+RUN wget --no-check-certificate https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz -O /tmp/node-v${NODEJS_VERSION}-linux-x64.tar.xz \
+ && tar --lzma -xvf /tmp/node-v${NODEJS_VERSION}-linux-x64.tar.xz -C /opt \
+ && ln -s /opt/node-v${NODEJS_VERSION}-linux-x64/bin/node /usr/bin/node \
+ && ln -s /opt/node-v${NODEJS_VERSION}-linux-x64/bin/npm /usr/bin/npm \
+ && rm /tmp/node-v${NODEJS_VERSION}-linux-x64.tar.xz
+
+RUN npm install sqlpad -g \
+ && ln -s /opt/node-v${NODEJS_VERSION}-linux-x64/bin/sqlpad /usr/bin/sqlpad
+
+WORKDIR /var/lib/sqlpad
+COPY docker-entrypoint /
+RUN chmod +x /docker-entrypoint
+ENTRYPOINT ["/docker-entrypoint"]

--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sqlpad --dir /var/lib/sqlpad --port 3000 --passphrase $SQL_PAD_PASSWORD


### PR DESCRIPTION
Ref.: https://github.com/rickbergfalk/sqlpad/issues/90

Just test it using: `docker-compose up`

You'll need docker & docker-compose ;).