### PR TITLE
[docker] Adding a Makefile for pushing to docker hub registry

### DIFF
--- a/docker/Dockerfile.tpl
+++ b/docker/Dockerfile.tpl
@@ -1,7 +1,6 @@
 FROM debian:jessie
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV NODEJS_VERSION 4.2.6
 
 RUN apt-get update \
  && apt-get dist-upgrade --no-install-recommends -q -o Dpkg::Options::="--force-confold" --force-yes -y \
@@ -10,13 +9,15 @@ RUN apt-get update \
     xz-utils \
  && apt-get clean
 
+ENV NODEJS_VERSION __NODEJS_VERSION__
 RUN wget --no-check-certificate https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz -O /tmp/node-v${NODEJS_VERSION}-linux-x64.tar.xz \
  && tar --lzma -xvf /tmp/node-v${NODEJS_VERSION}-linux-x64.tar.xz -C /opt \
  && ln -s /opt/node-v${NODEJS_VERSION}-linux-x64/bin/node /usr/bin/node \
  && ln -s /opt/node-v${NODEJS_VERSION}-linux-x64/bin/npm /usr/bin/npm \
  && rm /tmp/node-v${NODEJS_VERSION}-linux-x64.tar.xz
 
-RUN npm install sqlpad -g \
+ENV SQLPAD_VERSION __SQLPAD_VERSION__
+RUN npm install sqlpad@${SQLPAD_VERSION} -g \
  && ln -s /opt/node-v${NODEJS_VERSION}-linux-x64/bin/sqlpad /usr/bin/sqlpad
 
 WORKDIR /var/lib/sqlpad

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,23 @@
+NODEJS_VERSION?=4.3.0
+SQLPAD_VERSION?=1.15.0
+DOCKER_NAME=sqlpad/sqlpad
+
+all: template build version push clean
+
+template:
+	cp Dockerfile.tpl Dockerfile
+	sed -i -e 's/__NODEJS_VERSION__/$(NODEJS_VERSION)/' Dockerfile
+	sed -i -e 's/__SQLPAD_VERSION__/$(SQLPAD_VERSION)/' Dockerfile
+
+build:
+	docker build -t $(DOCKER_NAME):latest .
+
+version:
+	docker tag -f $(DOCKER_NAME):latest $(DOCKER_NAME):$(SQLPAD_VERSION)
+
+push:
+	docker push $(DOCKER_NAME):latest
+	docker push $(DOCKER_NAME):$(SQLPAD_VERSION)
+
+clean:
+	rm -f Dockerfile


### PR DESCRIPTION
Ref.: https://github.com/rickbergfalk/sqlpad/issues/90#issuecomment-182150570

Just running `make` will create then upload the new docker image to docker hub for those having the right to push to sqlpad organisation.

To specify the version to build, just add the version as an argument to `make`, for example:
```
make SQLPAD_VERSION=1.0.0
```