### PR TITLE
Update docker to support base url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,6 @@ web:
   build: docker
   environment:
     SQL_PAD_PASSWORD: somepassword
+    SQL_PAD_BASE_URL: /path
   ports:
     - "3000:3000"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 NODEJS_VERSION?=4.3.0
-SQLPAD_VERSION?=1.15.0
+SQLPAD_VERSION?=1.17.3
 DOCKER_NAME=sqlpad/sqlpad
 
 all: template build version push clean

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,7 +13,7 @@ build:
 	docker build -t $(DOCKER_NAME):latest .
 
 version:
-	docker tag -f $(DOCKER_NAME):latest $(DOCKER_NAME):$(SQLPAD_VERSION)
+	docker tag $(DOCKER_NAME):latest $(DOCKER_NAME):$(SQLPAD_VERSION)
 
 push:
 	docker push $(DOCKER_NAME):latest

--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sqlpad --dir /var/lib/sqlpad --port 3000 --passphrase $SQL_PAD_PASSWORD
+sqlpad --dir /var/lib/sqlpad --port 3000 --passphrase $SQL_PAD_PASSWORD --base-url $SQL_PAD_BASE_URL


### PR DESCRIPTION
This PR is meant to include `base-url` in docker deployment.
The SqlPad version `1.17.3` is required.