### PR TITLE
Support non English characters when downloading files

### DIFF
--- a/routes/download-results.js
+++ b/routes/download-results.js
@@ -14,7 +14,7 @@ router.get('/download-results/:cacheKey.csv', function (req, res, next) {
         return next(new Error('Cache not found'))
       }
       var filename = cache.queryName + '.csv'
-      res.setHeader('Content-disposition', 'attachment; filename="' + filename + '"')
+      res.setHeader('Content-disposition', 'attachment; filename="' + encodeURIComponent(filename) + '"')
       res.setHeader('Content-Type', 'text/csv')
       fs.createReadStream(cache.csvFilePath()).pipe(res)
     })
@@ -32,7 +32,7 @@ router.get('/download-results/:cacheKey.xlsx', function (req, res, next) {
         return next(new Error('Cache not found'))
       }
       var filename = cache.queryName + '.xlsx'
-      res.setHeader('Content-disposition', 'attachment; filename="' + filename + '"')
+      res.setHeader('Content-disposition', 'attachment; filename="' + encodeURIComponent(filename) + '"')
       res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
       fs.createReadStream(cache.xlsxFilePath()).pipe(res)
     })


### PR DESCRIPTION
If the HTTP header contains non English characters, an error will be thrown about "invalid characters" and the application will be terminated. This problem is probably caused by enhanced check by Node.js

Related issues: 
https://github.com/indexzero/http-server/issues/244
https://github.com/npm/npm/issues/11515

So I use encodeURIComponent to encode the file name. Files with Chinese characters could be downloaded now.

Thanks.