### PR TITLE
Fix disabling of links on query details modal

### DIFF
--- a/client-js/QueryEditor.js
+++ b/client-js/QueryEditor.js
@@ -64,7 +64,7 @@ var QueryDetailsModal = React.createClass({
   },
   render: function () {
     var modalNavLink = (href, text) => {
-      var saved = (this.props.query._id != null)
+      var saved = !!this.props.query._id
       if (saved) {
         return (
           <li role='presentation'>


### PR DESCRIPTION
The query and chart links on the `QueryDetailsModal` are meant to be disabled when the query is not yet saved, with this check:

```
var saved = (this.props.query._id != null)
```

But the query id is initially an empty string, rather than null or undefined.