### PR TITLE
Render chart lazily

### DIFF
--- a/client-js/QueryEditor.js
+++ b/client-js/QueryEditor.js
@@ -380,25 +380,19 @@ var QueryEditor = React.createClass({
     })
   },
   sqlpadTauChart: undefined,
+  hasRows: function () {
+    var queryResult = this.state.queryResult
+    return !!(queryResult && queryResult.rows && queryResult.rows.length)
+  },
+  isChartable: function () {
+    var pending = this.state.isRunning || this.state.queryError
+    return !pending && this.state.activeTabKey === 'vis' && this.hasRows()
+  },
   onVisualizeClick: function (e) {
     this.sqlpadTauChart.renderChart(true)
   },
   onTabSelect: function (tabkey) {
     this.setState({activeTabKey: tabkey})
-    var renderChartIfVisible = () => {
-      var chartEl = document.getElementById('chart')
-      if (chartEl.clientHeight > 0) {
-        try {
-          this.sqlpadTauChart.renderChart()
-        } catch (e) {
-          console.log('tauchart rendering failed')
-          console.log(e)
-        }
-      } else {
-        setTimeout(renderChartIfVisible, 20)
-      }
-    }
-    if (tabkey === 'vis') renderChartIfVisible()
   },
   onSaveImageClick: function (e) {
     if (this.sqlpadTauChart && this.sqlpadTauChart.chart) {
@@ -529,7 +523,13 @@ var QueryEditor = React.createClass({
                           queryResult={this.state.queryResult} />
                       </div>
                       <div className='sidebar-footer'>
-                        <Button onClick={this.onVisualizeClick} className={'btn-block'} bsSize={'sm'}>Visualize</Button>
+                        <Button
+                          onClick={this.onVisualizeClick}
+                          disabled={!this.isChartable()}
+                          className={'btn-block'}
+                          bsSize={'sm'}>
+                          Visualize
+                        </Button>
                         <Button onClick={this.onSaveImageClick} className={'btn-block'} bsSize={'sm'}>
                           <Glyphicon glyph='save' />{' '}
                           Save Chart Image
@@ -543,6 +543,7 @@ var QueryEditor = React.createClass({
                         queryResult={this.state.queryResult}
                         queryError={this.state.queryError}
                         isRunning={this.state.isRunning}
+                        renderChart={this.isChartable()}
                         ref={(ref) => {
                           this.sqlpadTauChart = ref
                         }} />

--- a/client-js/components/SqlpadTauChart.js
+++ b/client-js/components/SqlpadTauChart.js
@@ -7,10 +7,9 @@ var Alert = require('react-s-alert').default
 
 var SqlpadTauChart = React.createClass({
   componentDidUpdate: function (prevProps) {
-    var prevResultId = (prevProps.queryResult ? prevProps.queryResult.id : null)
-    var currentResultId = (this.props.queryResult ? this.props.queryResult.id : null)
-    if (prevResultId !== currentResultId) {
-      console.log('rendering because queryResults changed')
+    if (this.props.isRunning || this.props.queryError) {
+      this.destroyChart()
+    } else if (this.props.renderChart && !this.chart) {
       this.renderChart()
     }
   },
@@ -23,6 +22,12 @@ var SqlpadTauChart = React.createClass({
     left: 0,
     right: 0
   },
+  destroyChart() {
+    if (this.chart) {
+      this.chart.destroy()
+      this.chart = null
+    }
+  },
   renderChart: function (rerender) {
     // This is invoked during following:
     //  - Vis tab enter
@@ -34,8 +39,8 @@ var SqlpadTauChart = React.createClass({
     var selectedFields = this.props.query.chartConfiguration.fields
     var chartDefinition = _.findWhere(chartDefinitions, {chartType: chartType})
 
-    if (this.chart && (!dataRows.length || !chartDefinition)) {
-      this.chart.destroy()
+    if (rerender || !dataRows.length || !chartDefinition) {
+      this.destroyChart()
     }
 
     // If there's no data just exit the chart render
@@ -202,10 +207,6 @@ var SqlpadTauChart = React.createClass({
     if (!this.chart) {
       this.chart = new tauCharts.Chart(chartConfig)
       this.chart.renderTo('#chart')
-    } else if (this.chart && rerender) {
-      this.chart.destroy()
-      this.chart = new tauCharts.Chart(chartConfig)
-      this.chart.renderTo('#chart')
     } else {
       this.chart.setData(dataRows)
     }
@@ -214,7 +215,7 @@ var SqlpadTauChart = React.createClass({
     this.chart.setData(chartData)
   },
   componentWillUnmount () {
-    if (this.chart) this.chart.destroy()
+    this.destroyChart()
   },
   render: function () {
     var runResultNotification = () => {


### PR DESCRIPTION
We found Taucharts has problems with big datasets, freezing or even crashing the browser. And because sqlpad renders the Vis tab even when it's not visible - at the same time as rendering the result table - this meant we weren't able to view query results either.

With this PR, the chart is only rendered (once) if the Vis tab is active. Like before, the chart is kept around to preserve its internal state, so the user can switch tabs back and forth.

When the user re-runs the query, the chart is destroyed. Rather than rendering when the query results change, we destroy when the results are *about to* change. So at that point we're back to the initial state and can render lazily again.

Moving the first `renderChart` call to `componentDidUpdate`, i.e. when the DOM has been updated to make the chart `div` visible, also means you no longer need the `setTimeout` hack.

Additionally, the Visualize button is disabled when there's nothing to chart.