### PR TITLE
Vis tab: hide error on rerun

### DIFF
--- a/client-js/components/SqlpadTauChart.js
+++ b/client-js/components/SqlpadTauChart.js
@@ -228,7 +228,7 @@ var SqlpadTauChart = React.createClass({
       return null
     }
     var runResultErrorNotification = () => {
-      if (this.props.queryError) {
+      if (this.props.queryError && !this.props.isRunning) {
         return (
           <div className='run-result-notification label-danger'>
             {this.props.queryError}

--- a/client-js/components/SqlpadTauChart.js
+++ b/client-js/components/SqlpadTauChart.js
@@ -224,22 +224,19 @@ var SqlpadTauChart = React.createClass({
             <SpinKitCube />
           </div>
         )
-      }
-      return null
-    }
-    var runResultErrorNotification = () => {
-      if (this.props.queryError && !this.props.isRunning) {
+      } else if (this.props.queryError) {
         return (
           <div className='run-result-notification label-danger'>
             {this.props.queryError}
           </div>
         )
+      } else {
+        return null
       }
     }
     return (
       <div id='chart' style={this.chartStyle}>
         {runResultNotification()}
-        {runResultErrorNotification()}
       </div>
     )
   }


### PR DESCRIPTION
This PR makes the Vis tab behave the same as the query tab, in that it shows the loading indicator when you hit "Run", regardless of whether the previous run errored or not.