### PR TITLE
Style querylist columns with flexbox

### DIFF
--- a/client-js/FilterableQueryList.js
+++ b/client-js/FilterableQueryList.js
@@ -154,7 +154,7 @@ var FilterableQueryList = React.createClass({
     }
 
     return (
-      <div>
+      <div className='QueryListContainer'>
         <QueryListSidebar
           currentUser={this.props.currentUser}
           connections={this.state.connections}

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -286,22 +286,20 @@ input[type=checkbox], input[type=radio] {
 
 /*  React Queries
 ============================================================================ */
-.QueryListSidebar {
-    position: absolute;
-    left: 0px;
-    width: 20%;
-    top:  0px;
-    bottom: 0px;
-    background-color: #FDFDFD;
-    overflow-y: auto;
-    padding: 10px;
+.QueryListContainer {
+    display: flex;
+    flex-wrap: wrap;
 }
+
+.QueryListSidebar {
+    background-color: #FDFDFD;
+    padding: 10px;
+    flex-basis: 20%;
+}
+
 .QueryList {
-    position: absolute;
-    top: 0px;
-    bottom: 0px;
-    left: 20%;
-    width: 40%;
+    flex-basis: 40%;
+    position: relative;
     background-color: #FDFDFD;
     
     padding: 10px;
@@ -326,14 +324,9 @@ input[type=checkbox], input[type=radio] {
     margin-bottom: 0px;
 }
 .QueryPreview {
-    position: absolute;
-    top: 0px;
-    bottom: 0px;
-    left: 60%;
-    width: 40%;
     background-color: #FDFDFD;
-    overflow-y: auto;
     padding: 10px;
+    flex-basis: 40%;
 }
 #query-preview-ace-editor {
     border-radius: 4px;


### PR DESCRIPTION
By using flexbox instead of absolute positioning for the columns, it becomes easier to customize the layout. We liked the old horizontal layout (of what is now called the sidebar), so we have some custom CSS (like a theme) that gives the first column a width of 100%. Without flexbox, we would have to override more CSS rules to achieve that.