### PR TITLE
Support for postgre SSL CA

### DIFF
--- a/client-js/connections/ConnectionForm.js
+++ b/client-js/connections/ConnectionForm.js
@@ -63,6 +63,11 @@ const fields = {
     formType: TEXT,
     label: 'Database Key Path'
   },
+  postgresCA: {
+    key: 'postgresCA',
+    formType: TEXT,
+    label: 'Database CA Path'
+  },
   mysqlInsecureAuth: {
     key: 'mysqlInsecureAuth',
     formType: CHECKBOX,
@@ -101,7 +106,8 @@ const driverFields = {
     fields.password,
     fields.postgresSsl,
     fields.postgresCert,
-    fields.postgresKey
+    fields.postgresKey,
+    fields.postgresCA
   ],
   presto: [
     fields.host,

--- a/lib/run-query.js
+++ b/lib/run-query.js
@@ -163,6 +163,9 @@ clients.postgres = function (query, connection, queryResult, callback) {
       key: fs.readFileSync(connection.postgresKey),
       cert: fs.readFileSync(connection.postgresCert)
     }
+    if (connection.postgresCA) {
+      pgConfig.ssl['ca'] = fs.readFileSync(connection.postgresCA)
+    }
   }
   if (connection.port) pgConfig.port = connection.port
 

--- a/models/Connection.js
+++ b/models/Connection.js
@@ -16,6 +16,7 @@ var schema = {
   postgresSsl: Joi.boolean().default(false, 'Postgres SSL'),
   postgresCert: Joi.string().optional(),
   postgresKey: Joi.string().optional(),
+  postgresCA: Joi.string().optional(),
   mysqlInsecureAuth: Joi.boolean().default(false, 'Mysql Insecure Auth'),
   prestoCatalog: Joi.string().optional().allow(''),
   prestoSchema: Joi.string().optional().allow(''),

--- a/routes/connections.js
+++ b/routes/connections.js
@@ -20,6 +20,7 @@ function connectionFromBody (body) {
     postgresSsl: (body.postgresSsl === true),
     postgresCert: body.postgresCert,
     postgresKey: body.postgresKey,
+    postgresCA: body.postgresCA,
     mysqlInsecureAuth: (body.mysqlInsecureAuth === true),
     prestoCatalog: body.prestoCatalog,
     prestoSchema: body.prestoSchema
@@ -114,6 +115,7 @@ router.put('/api/connections/:_id', mustBeAdmin, function (req, res) {
     connection.postgresSsl = (req.body.postgresSsl === true)
     connection.postgresCert = req.body.postgresCert
     connection.postgresKey = req.body.postgresKey
+    connection.postgresCA = req.body.postgresCA
     connection.mysqlInsecureAuth = (req.body.mysqlInsecureAuth === true)
     connection.prestoCatalog = req.body.prestoCatalog
     connection.prestoSchema = req.body.prestoSchema


### PR DESCRIPTION
Based on @nikicat 's work, added support for a CA field.

I was able to successfully connect to my database after this change, however, the 'Test' button still shows the connection fails even though it works once saved.