### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:6
+ENV NPM_CONFIG_LOGLEVEL warn
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ADD package.json ./
+RUN npm install
+
+ADD . .
+RUN npm run build
+
+EXPOSE 80
+CMD ["node", "./server.js"]


### PR DESCRIPTION
I've added this to let me run sqlpad in production using Docker. Perhaps this is useful to add to the main repo? If published to the Docker Hub, users could simply execute `docker run rickbergfalk/sqlpad` (plus ports/env settings) to pull and run sqlpad.