### PR TITLE
Option to connect to postgres through SOCKS proxy

### DIFF
--- a/client-js/connections/ConnectionForm.js
+++ b/client-js/connections/ConnectionForm.js
@@ -68,6 +68,31 @@ const fields = {
     formType: TEXT,
     label: 'Database CA Path'
   },
+  useSocks: {
+    key: 'useSocks',
+    formType: CHECKBOX,
+    label: 'Connect through SOCKS proxy'
+  },
+  socksHost: {
+    key: 'socksHost',
+    formType: TEXT,
+    label: 'Proxy hostname'
+  },
+  socksPort: {
+    key: 'socksPort',
+    formType: TEXT,
+    label: 'Proxy port'
+  },
+  socksUsername: {
+    key: 'socksUsername',
+    formType: TEXT,
+    label: 'Username for socks proxy'
+  },
+  socksPassword: {
+    key: 'socksPassword',
+    formType: TEXT,
+    label: 'Password for socks proxy'
+  },
   mysqlInsecureAuth: {
     key: 'mysqlInsecureAuth',
     formType: CHECKBOX,
@@ -107,7 +132,12 @@ const driverFields = {
     fields.postgresSsl,
     fields.postgresCert,
     fields.postgresKey,
-    fields.postgresCA
+    fields.postgresCA,
+    fields.useSocks,
+    fields.socksHost,
+    fields.socksPort,
+    fields.socksUsername,
+    fields.socksPassword
   ],
   presto: [
     fields.host,

--- a/lib/run-query.js
+++ b/lib/run-query.js
@@ -8,16 +8,18 @@ var crate = require('node-crate')
 var presto = require('presto-client')
 var config = require('./config.js')
 var QueryResult = require('../models/QueryResult.js')
+var createSocksConnection = require('./socks.js')
 
 module.exports = function runQuery (query, connection, callback) {
   var queryResult = new QueryResult()
   queryResult.timerStart()
-  clients[connection.driver](query, connection, queryResult, function (err, queryResult) {
+  var conn = Object.assign({}, connection, {stream: createSocksConnection(connection)});
+  clients[conn.driver](query, conn, queryResult, function (err, queryResult) {
     queryResult.timerStop()
     if (config.get('debug')) {
       var resultRowCount = (queryResult && queryResult.rows && queryResult.rows.length ? queryResult.rows.length : 0)
       console.log('\n--- lib/run-query.js ---')
-      console.log('CONNECTION: ' + connection.name)
+      console.log('CONNECTION: ' + conn.name)
       console.log('START TIME: ' + queryResult.startTime.toISOString())
       console.log('END TIME: ' + queryResult.stopTime.toISOString())
       console.log('ELAPSED MS: ' + queryResult.queryRunTime)
@@ -155,7 +157,8 @@ clients.postgres = function (query, connection, queryResult, callback) {
     password: connection.password,
     database: connection.database,
     host: connection.host,
-    ssl: connection.postgresSsl
+    ssl: connection.postgresSsl,
+    stream: connection.stream
   }
   // TODO cache key/cert values
   if (connection.postgresKey && connection.postgresCert) {

--- a/lib/socks.js
+++ b/lib/socks.js
@@ -1,0 +1,16 @@
+var SocksConnection = require('socksjs');
+
+module.exports = function(connection) {
+  if (connection.useSocks) {
+    return new SocksConnection({
+      host: connection.host,
+      port: connection.port
+    }, {
+      host: connection.socksHost,
+      port: connection.socksPort,
+      user: connection.socksUsername,
+      pass: connection.socksPassword
+    });
+  }
+}
+

--- a/models/Connection.js
+++ b/models/Connection.js
@@ -17,6 +17,11 @@ var schema = {
   postgresCert: Joi.string().optional(),
   postgresKey: Joi.string().optional(),
   postgresCA: Joi.string().optional(),
+  useSocks: Joi.boolean().default(false, 'Connect to database through SOCKS proxy'),
+  socksHost: Joi.string().optional(),
+  socksPort: Joi.string().optional(),
+  socksUsername: Joi.string().optional(),
+  socksPassword: Joi.string().optional(),
   mysqlInsecureAuth: Joi.boolean().default(false, 'Mysql Insecure Auth'),
   prestoCatalog: Joi.string().optional().allow(''),
   prestoSchema: Joi.string().optional().allow(''),
@@ -38,6 +43,11 @@ var Connection = function Connection (data) {
   this.postgresSsl = data.postgresSsl
   this.postgresCert = data.postgresCert
   this.postgresKey = data.postgresKey
+  this.useSocks = data.useSocks
+  this.socksHost = data.socksHost
+  this.socksPort = data.socksPort
+  this.socksUsername = data.socksUsername
+  this.socksPassword = data.socksPassword
   this.mysqlInsecureAuth = data.mysqlInsecureAuth
   this.prestoCatalog = data.prestoCatalog
   this.prestoSchema = data.prestoSchema

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "sanitize-filename": "1.x.x",
     "semver-diff": "^2.1.0",
     "serve-favicon": "2.x.x",
+    "socksjs": "^0.5.0",
     "toml": "^2.3.0",
     "uuid": "^3.0.1",
     "vertica": "0.5.x"

--- a/routes/connections.js
+++ b/routes/connections.js
@@ -21,7 +21,12 @@ function connectionFromBody (body) {
     postgresCert: body.postgresCert,
     postgresKey: body.postgresKey,
     postgresCA: body.postgresCA,
-    mysqlInsecureAuth: (body.mysqlInsecureAuth === true),
+    useSocks: body.useSocks,
+    socksHost: body.socksHost,
+    socksPort: body.socksPort,
+    socksUsername: body.socksUsername,
+    socksPassword: body.socksPassword,
+    mysqlInsecureAuth: body.mysqlInsecureAuth === true,
     prestoCatalog: body.prestoCatalog,
     prestoSchema: body.prestoSchema
   }
@@ -103,23 +108,23 @@ router.put('/api/connections/:_id', mustBeAdmin, function (req, res) {
         error: 'connection not found.'
       })
     }
-    connection.username = cipher(req.body.username || '')
-    connection.password = cipher(req.body.password || '')
-    connection.name = req.body.name
-    connection.driver = req.body.driver
-    connection.host = req.body.host
-    connection.port = req.body.port
-    connection.database = req.body.database
-    connection.domain = req.body.domain
-    connection.sqlserverEncrypt = (req.body.sqlserverEncrypt === true)
-    connection.postgresSsl = (req.body.postgresSsl === true)
-    connection.postgresCert = req.body.postgresCert
-    connection.postgresKey = req.body.postgresKey
-    connection.postgresCA = req.body.postgresCA
-    connection.mysqlInsecureAuth = (req.body.mysqlInsecureAuth === true)
-    connection.prestoCatalog = req.body.prestoCatalog
-    connection.prestoSchema = req.body.prestoSchema
-    connection.save(function (err, connection) {
+    connection.username = cipher(req.body.username || "");
+    connection.password = cipher(req.body.password || "");
+    connection.name = req.body.name;
+    connection.driver = req.body.driver;
+    connection.host = req.body.host;
+    connection.port = req.body.port;
+    connection.database = req.body.database;
+    connection.domain = req.body.domain;
+    connection.sqlserverEncrypt = req.body.sqlserverEncrypt === true;
+    connection.postgresSsl = req.body.postgresSsl === true;
+    connection.postgresCert = req.body.postgresCert;
+    connection.postgresKey = req.body.postgresKey;
+    connection.postgresCA = req.body.postgresCA;
+    connection.mysqlInsecureAuth = req.body.mysqlInsecureAuth === true;
+    connection.prestoCatalog = req.body.prestoCatalog;
+    connection.prestoSchema = req.body.prestoSchema;
+    connection.save(function(err, connection) {
       if (err) {
         console.error(err)
         return res.json({


### PR DESCRIPTION
Don't merge this yet, I'm going to test it tomorrow.

Just wondering if you would be interested in something like this. I only did it because we have to deal with a database behind a SOCKS proxy at work and the node pg client is the *only* way I have been able to connect to it so far, and this seems to be the only pg admin tool that uses node.