### PR TITLE
Add systemd socket activation support

### DIFF
--- a/docs/_pages/installation-and-administration.md
+++ b/docs/_pages/installation-and-administration.md
@@ -135,4 +135,6 @@ A SQLPad query can be posted to a Slack webhook when saved. To enable, create a 
 
 An entire domain can be whitelisted for username administration by setting enviornment variable ```WHITELISTED_DOMAINS```
 
+### Systemd socket activation
 
+To use systemd socket activation set port to magic value ```systemd```. For more information see [this pull request](https://github.com/rickbergfalk/sqlpad/pull/185).


### PR DESCRIPTION
I have a situation where sqlpad is used only randomly by one person so to save server resources I want to spawn sqlpad only when it is actually being used.

Systemd can itself listen to the socket and start the application on demand when the socket is accessed. The socket itself is passed to the process as file descriptor 3 when the `LISTEN_FDS` env is defined by systemd.

Systemd configuration should be something  like following:

`/etc/systemd/system/sqlpad.service`
```
[Unit]
Description=sqlpad
After=network-online.target
Wants=network-online.target systemd-networkd-wait-online.service

[Service]
User=sqlpad
Group=sqlpad
Environment=NODE_ENV=production
WorkingDirectory=/apps/sqlpad/sqlpad
# Shutdown automatically after 8h
RuntimeMaxSec=28800
ExecStart=node server.js --port systemd --ip 127.0.0.1 --dir /apps/sqlpad/data --passphrase secret
```

and `/etc/systemd/system/sqlpad.socket`
```
[Socket]
ListenStream=127.0.0.1:3000 
[Install]
WantedBy=sockets.target
```


Reload the systemd daemon

    systemctl daemon-reload

Start the socket and enable it on boot

    systemctl start sqlpad.socket
    systemctl enable sqlpad.socket

Now the sqlpad node process is started only when the port 3000 is being accessed. This could be improved by implementing automatic inactivity shutdown in sqlpad but for now I just use the `RuntimeMaxSec` option to shutdown it after 8 hours.


