### PR TITLE
Add normal port binding fallback

### DIFF
--- a/docs/_pages/installation-and-administration.md
+++ b/docs/_pages/installation-and-administration.md
@@ -137,4 +137,4 @@ An entire domain can be whitelisted for username administration by setting envio
 
 ### Systemd socket activation
 
-To use systemd socket activation set port to magic value ```systemd```. For more information see [this pull request](https://github.com/rickbergfalk/sqlpad/pull/185).
+To use systemd socket activation add ```--systemd-socket``` flag. For more information see [this pull request](https://github.com/rickbergfalk/sqlpad/pull/185).

--- a/resources/config-items.toml
+++ b/resources/config-items.toml
@@ -23,6 +23,14 @@ description = "Port for SQLPad to listen on."
 
 [[configItems]]
 interface = "env"
+key = "systemdSocket"
+cliFlag = "systemd-socket"
+envVar = "SQLPAD_SYSTEMD_SOCKET"
+default = false
+description = "Acquire socket from systemd if available"
+
+[[configItems]]
+interface = "env"
 key = "httpsPort"
 cliFlag = "https-port"
 envVar = "SQLPAD_HTTPS_PORT"

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const PASSPHRASE = config.get('passphrase')
 const CERT_PASSPHRASE = config.get('certPassphrase')
 const KEY_PATH = config.get('keyPath')
 const CERT_PATH = config.get('certPath')
+const SYSTEMD_SOCKET = config.get('systemdSocket')
 
 if (DEBUG) {
   console.log('Config Values:')
@@ -136,21 +137,32 @@ if (fs.existsSync(htmlPath)) {
   console.error('If not running in dev mode please report this issue.\n')
 }
 
-// When --port=systemd is passed we will assume that sqlpad is launched as a
-// systemd service with socket activation. Systemd passes the socket as file
-// descriptor 3. As sqlpad listens to only one port no further action is
-// required.
+function isFdObject (ob) {
+  return ob && typeof ob.fd === 'number'
+}
+
+// When --systemd-socket is passed we will try to acquire the bound socket
+// directly from Systemd.
 //
 // More info
 //
+// https://github.com/rickbergfalk/sqlpad/pull/185
 // https://www.freedesktop.org/software/systemd/man/systemd.socket.html
 // https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
 function detectPortOrSystemd (port) {
-  if (String(port).trim() === 'systemd') {
-    if (process.env.LISTEN_FDS) {
-      console.error('Warning LISTEN_FDS is not defined! Port "systemd" should be only used when starting as a systemd service with socket activation.')
+  if (SYSTEMD_SOCKET) {
+    const passedSocketCount = parseInt(process.env.LISTEN_FDS) || 0
+
+    // LISTEN_FDS contains number of sockets passed by Systemd. At least one
+    // must be passed. The sockets are set to file descriptors starting from 3.
+    // We just crab the first socket from fd 3 since sqlpad binds only one
+    // port.
+    if (passedSocketCount > 0) {
+      console.log('Using port from Systemd')
+      return Promise.resolve({fd: 3})
+    } else {
+      console.error('Warning: Systemd socket asked but not found. Trying to bind port ' + port + ' manually')
     }
-    return Promise.resolve({fd: 3})
   }
 
   return detectPort(port)
@@ -165,7 +177,7 @@ require('./lib/db').load(function (err) {
   if (KEY_PATH && CERT_PATH) { // https only
     console.log('Launching server with SSL')
     detectPortOrSystemd(HTTPS_PORT).then(function (_port) {
-      if (HTTPS_PORT !== _port) {
+      if (!isFdObject(_port) && HTTPS_PORT !== _port) {
         console.log('\nPort %d already occupied. Using port %d instead.', HTTPS_PORT, _port)
         // Persist the new port to the in-memory store. This is kinda hacky
         // Assign value to cliValue since it overrides all other values
@@ -190,7 +202,7 @@ require('./lib/db').load(function (err) {
   } else { // http only
     console.log('Launching server WITHOUT SSL')
     detectPortOrSystemd(PORT).then(function (_port) {
-      if (PORT !== _port) {
+      if (!isFdObject(_port) && PORT !== _port) {
         console.log('\nPort %d already occupied. Using port %d instead.', PORT, _port)
         // Persist the new port to the in-memory store. This is kinda hacky
         // Assign value to cliValue since it overrides all other values


### PR DESCRIPTION
Found a nasty edge case with the `--port systemd` style. If the systemd socket unit is stopped and the service is started as a normal systemd service without the socket unit it will crash because it assumes it will get a port but it does not. So sqlpad must implement a fallback when the socket is not found.

So the systemd configuration must be like this


`/etc/systemd/system/sqlpad.service`
```
[Unit]
Description=sqlpad
After=network-online.target
Wants=network-online.target systemd-networkd-wait-online.service

[Service]
User=sqlpad
Group=sqlpad
Environment=NODE_ENV=production
WorkingDirectory=/apps/sqlpad/sqlpad
# Shutdown automatically after 8h
RuntimeMaxSec=28800
ExecStart=node server.js --systemd-socket --port 3000 --ip 127.0.0.1 --dir /apps/sqlpad/data --passphrase secret
```

and `/etc/systemd/system/sqlpad.socket`
```
[Socket]
ListenStream=127.0.0.1:3000 
[Install]
WantedBy=sockets.target
```

Maybe I should write a wiki page about this configuration? I have a feeling that this is a bit obscure setup for the sqlpad home page :) 