### PR TITLE
Docker updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Visit project page at [http://rickbergfalk.github.io/sqlpad/](http://rickbergfal
 Quickstart: 
 
 ```sh
+# Assuming node 6 or later is installed
 npm install sqlpad -g 
 sqlpad --help
 ```
@@ -26,7 +27,28 @@ npm install sqlpad -g
 
 ## Development
 
-See [wiki](https://github.com/rickbergfalk/sqlpad/wiki/Development-Guide) for development details and project information.
+**Using docker**
+```sh
+docker-compose run --rm web npm -i
+docker-compose up
+```
+
+**Locally**
+- Clone/download repo
+- Install node 6 or later
+- Install npm5
+- run `npm start` from command line 
+
+At this point you should have both backend and front-end development servers running.
+
+http://localhost:3000 serves react front-end in dev-mode
+http://localhost:3010 serves front-end compiled for production
+
+Both front-end/back-end should auto-refresh/auto-reload on file change.
+
+To build front-end production files run `npm run build`.
+
+See [wiki](https://github.com/rickbergfalk/sqlpad/wiki/Development-Guide) for additional development details and project information.
 
 
 ## Tips

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,37 @@
-# this file is for developping purpose only
+# This file is for developing purpose only
 #
 # HOWTO
-# fist install the node_modules with: docker-compose run --rm web npm -i
-# then run: docker-compose up
-# then you should be able to access the project on http://localhost:3000
-web:
-  image: node:4.5.0
-  ports:
-    - "3000:3000"
-  volumes:
-    - .:/var/www
-  working_dir: /var/www
-  command: npm run start
+#
+# First install the node_modules with: 
+#   docker-compose run --rm web npm -i
+#
+# Alternatively, you *might* be able to get away with installing node_modules locally
+#
+# Then run: 
+#   docker-compose up
+#
+# You should be able to access the project 
+#   http://localhost:3000 serving react files in dev mode via webpack
+#   http://localhost:3010 serves compiled react files for production
+#
+# TODO Other databases should be added as services (crate, mysql, etc)
+# It would be nice to have the populate with a bit of data and used for testing
+#
+version: '3'
+services:
+  web:
+    image: node:6.11-alpine
+    ports:
+      - "3000:3000"
+      - "3010:3010"
+    volumes:
+      - .:/var/www
+    working_dir: /var/www
+    command: npm start
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:9.6-alpine
+    environment:
+      POSTGRES_USER: sqlpad
+      POSTGRES_DB: sqlpad

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.5.0
+FROM node:6.11-alpine
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "rick.bergfalk@gmail.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "contributors": [
     {
@@ -37,16 +37,15 @@
   "proxy": "http://localhost:3010",
   "homepage": "http://BASEURL",
   "scripts": {
-    "standard": "standard --fix",
-    "test": "standard && mocha --recursive",
-    "test-client": "react-scripts test --env=jsdom",
-    "coverage": "istanbul cover _mocha -- --recursive",
-    "start-server-dev": "node-dev server.js --dir ./db --port 3010 --debug",
-    "start-client-dev": "react-scripts start",
-    "prepublish": "npm run build",
     "build": "react-scripts build",
-    "start": "npm run start-server-dev",
-    "build-dev": "npm run start-client-dev"
+    "coverage": "istanbul cover _mocha -- --recursive",
+    "prepublish": "npm run build",
+    "standard": "standard --fix",
+    "start-client-dev": "react-scripts start",
+    "start-server-dev": "node-dev server.js --dir ./db --port 3010 --debug",
+    "start": "concurrently \"npm run start-server-dev\" \"npm run start-client-dev\"",
+    "test-client": "react-scripts test --env=jsdom",
+    "test": "standard && mocha --recursive"
   },
   "dependencies": {
     "async": "^2.0.1",
@@ -97,6 +96,7 @@
     "babel-eslint": "^7.2.3",
     "brace": "^0.10.0",
     "chai": "^4.0.0",
+    "concurrently": "^3.5.0",
     "deep-equal": "^1.0.1",
     "ejs": "^2.5.6",
     "fixed-data-table": "^0.6.3",


### PR DESCRIPTION
Expanding on the existing docker compose file used for development, bringing it more in line with some of the changes to the front-end build tooling. 

On a mac, it appears to be possible to install all the modules locally, and then start things up with `docker-compose up`. 

In the future it would be nice if other databases were added to the compose file, and those used to test/develop against. 

I don't normally use docker during development, but I'd like to give it a shot, so this work is to get things in a place where that's possible. 

If anyone has any docker experience and knows of a better way of doing this by all means feel free to help out in this area :)