### PR TITLE
Dial presto back a bit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     links:
       - postgres
       - mariadb
-      - presto
   postgres:
     image: postgres:9.6-alpine
     environment:
@@ -35,10 +34,12 @@ services:
       MYSQL_PASSWORD: sqlpad
   presto:
     image: johandry/presto:0.167-t.0.3
+    expose: 
+      - "8080"
     ports: 
       - "8080:8080"
     environment:
       HTTP_SERVER_PORT: 8080
-      PRESTO_MAX_MEMORY: 50
-      PRESTO_MAX_MEMORY_PER_NODE: 1
-      PRESTO_JVM_HEAP_SIZE: 8
+      PRESTO_MAX_MEMORY: .25
+      PRESTO_MAX_MEMORY_PER_NODE: .25
+      PRESTO_JVM_HEAP_SIZE: 1


### PR DESCRIPTION
- Those numbers are in GBs! Since presto is more resource heavy it will
only start.
- Also removes from web link to prevent autostart on docker-compose up