### PR TITLE
Mysql schema

### DIFF
--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -81,16 +81,16 @@ class QueryResultDataTable extends React.PureComponent {
             key={field}
             header={<Cell>{field}</Cell>}
             cell={({rowIndex}) => {
-              var value = queryResult.rows[rowIndex][field]
-              var barStyle
-              var numberBar
+              const value = queryResult.rows[rowIndex][field]
+              let barStyle
+              let numberBar
               if (fieldMeta.datatype === 'number') {
-                value = Number(value)
-                var range = fieldMeta.max - (fieldMeta.min < 0 ? fieldMeta.min : 0)
-                var left = 0
-                if (fieldMeta.min < 0 && value < 0) {
-                  left = Math.abs(fieldMeta.min - value) / range * 100 + '%'
-                } else if (fieldMeta.min < 0 && value >= 0) {
+                const valueNumber = Number(value)
+                const range = fieldMeta.max - (fieldMeta.min < 0 ? fieldMeta.min : 0)
+                let left = 0
+                if (fieldMeta.min < 0 && valueNumber < 0) {
+                  left = Math.abs(fieldMeta.min - valueNumber) / range * 100 + '%'
+                } else if (fieldMeta.min < 0 && valueNumber >= 0) {
                   left = Math.abs(fieldMeta.min) / range * 100 + '%'
                 }
                 barStyle = {
@@ -98,7 +98,7 @@ class QueryResultDataTable extends React.PureComponent {
                   left: left,
                   top: 0,
                   bottom: 0,
-                  width: (Math.abs(value) / range) * 100 + '%',
+                  width: (Math.abs(valueNumber) / range) * 100 + '%',
                   backgroundColor: '#bae6f7'
                 }
                 numberBar = <div style={barStyle} />

--- a/resources/schema-mysql.sql
+++ b/resources/schema-mysql.sql
@@ -1,0 +1,17 @@
+SELECT 
+    (CASE t.table_type WHEN 'BASE TABLE' THEN 'Tables' WHEN 'VIEW' THEN 'Views' ELSE t.table_type END) AS table_type, 
+    t.table_schema, 
+    t.table_name, 
+    c.column_name, 
+    c.data_type, 
+    c.is_nullable 
+FROM 
+    INFORMATION_SCHEMA.tables t 
+    JOIN INFORMATION_SCHEMA.columns c ON t.table_schema = c.table_schema AND t.table_name = c.table_name 
+WHERE 
+    t.table_schema NOT IN ('mysql', 'performance_schema', 'information_schema') 
+ORDER BY 
+    t.table_type, 
+    t.table_schema, 
+    t.table_name, 
+    c.ordinal_position

--- a/routes/schema-info.js
+++ b/routes/schema-info.js
@@ -12,6 +12,7 @@ var mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
 var sqldir = path.join(__dirname, '/../resources/')
 
 var sqlSchemaPostgres = fs.readFileSync(sqldir + '/schema-postgres.sql', {encoding: 'utf8'})
+var sqlSchemaMysql = fs.readFileSync(sqldir + '/schema-mysql.sql', {encoding: 'utf8'})
 var sqlSchemaVertica = fs.readFileSync(sqldir + '/schema-vertica.sql', {encoding: 'utf8'})
 var sqlSchemaCrate = fs.readFileSync(sqldir + '/schema-crate.sql', {encoding: 'utf8'})
 var sqlSchemaCrateV0 = fs.readFileSync(sqldir + '/schema-crate.v0.sql', {encoding: 'utf8'})
@@ -84,6 +85,8 @@ router.get('/api/schema-info/:connectionId', mustBeAuthenticated,
       secondarySchemaSql = sqlSchemaCrateV0
     } else if (connection.driver === 'postgres') {
       primarySchemaSql = sqlSchemaPostgres
+    } else if (connection.driver === 'mysql') {
+      primarySchemaSql = sqlSchemaMysql
     } else {
       primarySchemaSql = sqlSchemaStandard
     }


### PR DESCRIPTION
This removes mysql-specific schemas `mysql` and `performance_schema` from the mysql schema info query partially in effort to address #198. 

Turns out in MySQL a schema and database are considered equivalent.