### PR TITLE
Resize columns

### DIFF
--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -117,10 +117,10 @@ class QueryResultDataTable extends React.PureComponent {
                 barStyle = {
                   position: 'absolute',
                   left: left,
-                  height: 2,
+                  height: 0,
                   bottom: 0,
                   width: (Math.abs(valueNumber) / range) * 100 + '%',
-                  backgroundColor: '#777'
+                  backgroundColor: '#bae6f7'
                 }
                 numberBar = <div style={barStyle} />
               }

--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -117,7 +117,7 @@ class QueryResultDataTable extends React.PureComponent {
                 barStyle = {
                   position: 'absolute',
                   left: left,
-                  height: 0,
+                  top: 0,
                   bottom: 0,
                   width: (Math.abs(valueNumber) / range) * 100 + '%',
                   backgroundColor: '#bae6f7'

--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Table, Column, Cell} from 'fixed-data-table'
+import {Table, Column, Cell} from 'fixed-data-table-2'
 import SpinKitCube from './SpinKitCube.js'
 import moment from 'moment'
 const _ = window._
@@ -117,10 +117,10 @@ class QueryResultDataTable extends React.PureComponent {
                 barStyle = {
                   position: 'absolute',
                   left: left,
-                  top: 0,
+                  height: 2,
                   bottom: 0,
                   width: (Math.abs(valueNumber) / range) * 100 + '%',
-                  backgroundColor: '#bae6f7'
+                  backgroundColor: '#777'
                 }
                 numberBar = <div style={barStyle} />
               }

--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -26,20 +26,31 @@ class QueryResultDataTable extends React.PureComponent {
     super(props)
     this.state = {
       gridWidth: 0,
-      gridHeight: 0
+      gridHeight: 0,
+      columnWidths: {}
     }
     // This binding is necessary to make `this` work in the callback
     this.handleResize = this.handleResize.bind(this)
+    this.handleColumnResizeEnd = this.handleColumnResizeEnd.bind(this)
   }
 
   handleResize (e) {
-    var resultGrid = document.getElementById('result-grid')
+    const resultGrid = document.getElementById('result-grid')
     if (resultGrid) {
       this.setState({
         gridHeight: resultGrid.clientHeight,
         gridWidth: resultGrid.clientWidth
       })
     }
+  }
+
+  handleColumnResizeEnd (newColumnWidth, columnKey) {
+    this.setState(({columnWidths}) => ({
+      columnWidths: {
+        ...columnWidths,
+        [columnKey]: newColumnWidth
+      }
+    }))
   }
 
   componentDidMount () {
@@ -65,20 +76,30 @@ class QueryResultDataTable extends React.PureComponent {
         </div>
       )
     } else if (this.props.queryResult && this.props.queryResult.rows) {
-      var queryResult = this.props.queryResult
-      var columnNodes = queryResult.fields.map(function (field) {
-        var fieldMeta = queryResult.meta[field]
-        var valueLength = fieldMeta.maxValueLength
+      const { columnWidths } = this.state
+      const queryResult = this.props.queryResult
+      const columnNodes = queryResult.fields.map(function (field) {
+        const fieldMeta = queryResult.meta[field]
+        let valueLength = fieldMeta.maxValueLength
 
-        if (field.length > valueLength) valueLength = field.length
-        var columnWidth = valueLength * 20
-        if (columnWidth < 200) columnWidth = 200
-        else if (columnWidth > 350) columnWidth = 350
-        var cellWidth = columnWidth - 10
+        if (field.length > valueLength) {
+          valueLength = field.length
+        }
+        let columnWidthGuess = valueLength * 20
+        if (columnWidthGuess < 200) {
+          columnWidthGuess = 200
+        } else if (columnWidthGuess > 350) {
+          columnWidthGuess = 350
+        }
+        const cellWidth = columnWidthGuess - 10
+
+        const columnWidth = columnWidths[field] || columnWidthGuess
 
         return (
           <Column
+            columnKey={field}
             key={field}
+            isResizable
             header={<Cell>{field}</Cell>}
             cell={({rowIndex}) => {
               const value = queryResult.rows[rowIndex][field]
@@ -123,7 +144,9 @@ class QueryResultDataTable extends React.PureComponent {
             rowsCount={queryResult.rows.length}
             width={this.state.gridWidth}
             height={this.state.gridHeight}
-            headerHeight={30}>
+            headerHeight={30}
+            onColumnResizeEndCallback={this.handleColumnResizeEnd}
+          >
             {columnNodes}
           </Table>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5352,6 +5352,16 @@
         "prop-types": "15.5.10"
       }
     },
+    "fixed-data-table-2": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fixed-data-table-2/-/fixed-data-table-2-0.8.0.tgz",
+      "integrity": "sha1-4V75rlwkhkYb8EUJ1naRYA6vWFg=",
+      "dev": true,
+      "requires": {
+        "create-react-class": "15.6.0",
+        "prop-types": "15.5.10"
+      }
+    },
     "flat": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5343,15 +5343,6 @@
         "locate-path": "2.0.0"
       }
     },
-    "fixed-data-table": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/fixed-data-table/-/fixed-data-table-0.6.4.tgz",
-      "integrity": "sha1-SMQg0FOxXYNoMjEfRw/61zVrZXM=",
-      "dev": true,
-      "requires": {
-        "prop-types": "15.5.10"
-      }
-    },
     "fixed-data-table-2": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/fixed-data-table-2/-/fixed-data-table-2-0.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "concurrently": "^3.5.0",
     "deep-equal": "^1.0.1",
     "ejs": "^2.5.6",
-    "fixed-data-table": "^0.6.3",
     "fixed-data-table-2": "^0.8.0",
     "fs-extra": "^4.0.1",
     "istanbul": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "deep-equal": "^1.0.1",
     "ejs": "^2.5.6",
     "fixed-data-table": "^0.6.3",
+    "fixed-data-table-2": "^0.8.0",
     "fs-extra": "^4.0.1",
     "istanbul": "^0.4.4",
     "keymaster": "^1.6.2",


### PR DESCRIPTION
Adds the ability to resize result grid columns. This works, but a bug currently exists where the drag indicator appears towards the left half of the grid after a column resize. 

I suspect it has something to do with the fixed/absolute positioning used on this page... This should probably move to use flexbox. 