### PR TITLE
Force no-cache on fetch requests (IE 11 fix)

### DIFF
--- a/client-js/utilities/fetch-json.js
+++ b/client-js/utilities/fetch-json.js
@@ -1,17 +1,20 @@
 import 'whatwg-fetch'
 
-export default function fetchJson (verb, url, body) {
-  var opts = {
-    method: 'GET',
+export default function fetchJson (method, url, body) {
+  const opts = {
+    method: method.toUpperCase(),
     credentials: 'same-origin',
     headers: {
       'Accept': 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-cache',
+      'Expires': '-1',
+      'Pragma': 'no-cache'
     }
   }
-  if (!verb) throw new Error('You must supply a verb to the fetch wrapper')
-  opts.method = verb.toUpperCase()
-  if (body) opts.body = JSON.stringify(body)
+  if (body) {
+    opts.body = JSON.stringify(body)
+  }
   return fetch(url, opts).then((response) => {
     if (response.status === 200) {
       return response.json()


### PR DESCRIPTION
Turns out IE 11 aggressively caches fetch / "ajax" requests, which meant SQLPad no longer worked when it switched to a single-page-app. This patch fixes SQLPad for Internet Explorer. IE support is not a focus of this project, but this fix isn't too much out of the way.

Closes #181 