### PR TITLE
Fix vis tab's show advanced link

### DIFF
--- a/client-js/queryEditor/ChartInputs.js
+++ b/client-js/queryEditor/ChartInputs.js
@@ -22,7 +22,8 @@ class ChartInputs extends React.Component {
     showAdvanced: false
   }
 
-  handleAdvancedClick = () => {
+  handleAdvancedClick = e => {
+    e.preventDefault()
     this.setState({
       showAdvanced: !this.state.showAdvanced
     })


### PR DESCRIPTION
Clicking show advanced on vis tab may cause inputs to flash back to initially set values. Preventing default on click addresses this weirdness.