### PR TITLE
Minimize data table markings for numbers

### DIFF
--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -121,10 +121,10 @@ class QueryResultDataTable extends React.PureComponent {
                 barStyle = {
                   position: 'absolute',
                   left: left,
-                  top: 0,
                   bottom: 0,
+                  height: '2px',
                   width: Math.abs(valueNumber) / range * 100 + '%',
-                  backgroundColor: '#bae6f7'
+                  backgroundColor: '#555'
                 }
                 numberBar = <div style={barStyle} />
               }


### PR DESCRIPTION
Changes the blue bar filling a data cell to a dark grey bar on bottom cell border. This seems to look cleaner yet still serves a purpose.

If this is annoying or not useful this could be something turned on via toggle in config. I have ideas for additional markings to add for text and dates based on where the values fall in the range of values…