### PR TITLE
Show cell content when expanded

### DIFF
--- a/client-js/components/QueryResultDataTable.js
+++ b/client-js/components/QueryResultDataTable.js
@@ -93,7 +93,6 @@ class QueryResultDataTable extends React.PureComponent {
         } else if (columnWidthGuess > 350) {
           columnWidthGuess = 350
         }
-        const cellWidth = columnWidthGuess - 10
 
         const columnWidth = columnWidths[field] || columnWidthGuess
 
@@ -131,15 +130,7 @@ class QueryResultDataTable extends React.PureComponent {
               return (
                 <Cell>
                   {numberBar}
-                  <div
-                    style={{
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      width: cellWidth,
-                      position: 'absolute'
-                    }}
-                  >
+                  <div style={{ whiteSpace: 'nowrap' }}>
                     {renderValue(value, fieldMeta)}
                   </div>
                 </Cell>


### PR DESCRIPTION
Removes ellipsis on data grid cells with long text, and replaces it with just cut off text. The benefit of this approach is that the text is visible if column is widened.

In future, some sort of view-row-as-card feature could be nice, to display long data.