### PR TITLE
Fix login bug

### DIFF
--- a/client-js/App.js
+++ b/client-js/App.js
@@ -7,7 +7,6 @@ import {
 } from 'react-router-dom'
 import Alert from 'react-s-alert'
 import fetchJson from './utilities/fetch-json.js'
-import AppNav from './AppNav.js'
 import UsersView from './users/UsersView'
 import ConnectionsView from './connections/ConnectionsView.js'
 import ConfigurationView from './configuration/ConfigurationView'
@@ -21,14 +20,13 @@ import PasswordResetRequested from './PasswordResetRequested.js'
 import QueryTableOnly from './QueryTableOnly.js'
 import QueryChartOnly from './QueryChartOnly.js'
 import NotFound from './NotFound.js'
+import Authenticated from './Authenticated'
 
 class App extends React.Component {
   state = {}
 
-  componentDidMount() {
-    // NOTE: this was previously run every route.
-    // This may need to be exposed or refreshed intelligently
-    fetchJson('GET', 'api/app').then(json => {
+  refreshAppContext = () => {
+    return fetchJson('GET', 'api/app').then(json => {
       // Assign config.baseUrl to global
       // It doesn't change and is needed for fetch requests
       // This allows us to simplify the fetch() call
@@ -45,43 +43,8 @@ class App extends React.Component {
     })
   }
 
-  // TODO eventually make this a not-authorized redirect
-  adminRoute(path, Component) {
-    const { config, currentUser } = this.state
-    return (
-      <Route
-        exact
-        path={path}
-        render={props =>
-          currentUser && currentUser.role === 'admin' ? (
-            // TODO App does own fetching for this stuff
-            // Can App useage just be used within each "page" component
-            <AppNav config={config} currentUser={currentUser}>
-              <Component {...props} />
-            </AppNav>
-          ) : (
-            <Redirect to={{ pathname: '/queries' }} />
-          )}
-      />
-    )
-  }
-
-  authenticatedRoute(path, Component) {
-    const { config, currentUser } = this.state
-    return (
-      <Route
-        exact
-        path={path}
-        render={props =>
-          currentUser ? (
-            <AppNav config={config} currentUser={currentUser}>
-              <Component {...props} />
-            </AppNav>
-          ) : (
-            <Redirect to={{ pathname: '/signin' }} />
-          )}
-      />
-    )
+  componentDidMount() {
+    this.refreshAppContext()
   }
 
   render() {
@@ -96,34 +59,52 @@ class App extends React.Component {
     if (!config) {
       return null
     }
+
     return (
       <Router basename={config.baseUrl}>
         <div className="flex-100">
           <Switch>
+            <Route exact path="/" render={() => <Redirect to={'/queries'} />} />
             <Route
               exact
-              path="/"
-              component={() => <Redirect to={'/queries'} />}
+              path="/queries"
+              render={props => <Authenticated component={QueriesView} />}
             />
-            {this.authenticatedRoute('/queries', () => (
-              <QueriesView config={config} currentUser={currentUser} />
-            ))}
-            {this.authenticatedRoute('/queries/:queryId', ({ match }) => (
-              <QueryEditor queryId={match.params.queryId} config={config} />
-            ))}
-            {this.adminRoute('/users', () => (
-              <UsersView config={config} currentUser={currentUser} />
-            ))}
-            {this.adminRoute('/connections', () => (
-              <ConnectionsView config={config} />
-            ))}
-            {this.adminRoute('/config-values', () => (
-              <ConfigurationView config={config} />
-            ))}
+            <Route
+              exact
+              path="/queries/:queryId"
+              render={({ match }) => (
+                <Authenticated
+                  queryId={match.params.queryId}
+                  component={QueryEditor}
+                />
+              )}
+            />
+            <Route
+              exact
+              path="/users"
+              render={() => (
+                <Authenticated admin={true} component={UsersView} />
+              )}
+            />
+            <Route
+              exact
+              path="/connections"
+              render={() => (
+                <Authenticated admin={true} component={ConnectionsView} />
+              )}
+            />
+            <Route
+              exact
+              path="/config-values"
+              render={() => (
+                <Authenticated admin={true} component={ConfigurationView} />
+              )}
+            />
             <Route
               exact
               path="/query-table/:queryId"
-              component={({ match }) => (
+              render={({ match }) => (
                 <QueryTableOnly
                   config={config}
                   queryId={match.params.queryId}
@@ -133,7 +114,7 @@ class App extends React.Component {
             <Route
               exact
               path="/query-chart/:queryId"
-              component={({ match }) => (
+              render={({ match }) => (
                 <QueryChartOnly
                   config={config}
                   queryId={match.params.queryId}
@@ -143,7 +124,7 @@ class App extends React.Component {
             <Route
               exact
               path="/signin"
-              component={() => (
+              render={() => (
                 <SignIn
                   config={config}
                   smtpConfigured={smtpConfigured}
@@ -154,7 +135,7 @@ class App extends React.Component {
             <Route
               exact
               path="/signup"
-              component={() => (
+              render={() => (
                 <SignUp
                   config={config}
                   adminRegistrationOpen={adminRegistrationOpen}
@@ -164,12 +145,12 @@ class App extends React.Component {
             <Route
               exact
               path="/forgot-password"
-              component={() => <ForgotPassword config={config} />}
+              render={() => <ForgotPassword config={config} />}
             />
             <Route
               exact
               path="/password-reset/:passwordResetId"
-              component={({ match }) => (
+              render={({ match }) => (
                 <PasswordReset
                   passwordResetId={match.params.passwordResetId}
                   config={config}
@@ -180,10 +161,10 @@ class App extends React.Component {
             <Route
               exact
               path="/password-reset"
-              component={() => <PasswordResetRequested />}
+              render={() => <PasswordResetRequested />}
             />
             <Route
-              component={() => (
+              render={() => (
                 <NotFound config={config} currentUser={currentUser} />
               )}
             />

--- a/client-js/Authenticated.js
+++ b/client-js/Authenticated.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Redirect } from 'react-router-dom'
+import fetchJson from './utilities/fetch-json.js'
+import AppNav from './AppNav.js'
+
+class Authenticated extends React.Component {
+  state = {
+    loading: true
+  }
+
+  componentDidMount() {
+    return fetchJson('GET', 'api/app').then(json => {
+      this.setState({
+        loading: false,
+        config: json.config,
+        smtpConfigured: json.smtpConfigured,
+        googleAuthConfigured: json.googleAuthConfigured,
+        currentUser: json.currentUser,
+        passport: json.passport,
+        adminRegistrationOpen: json.adminRegistrationOpen,
+        version: json.version
+      })
+    })
+  }
+
+  render() {
+    const { admin, component, ...rest } = this.props
+    const { config, currentUser, loading } = this.state
+
+    if (loading) {
+      return null
+    }
+
+    if (!currentUser) {
+      return <Redirect to={{ pathname: '/signin' }} />
+    }
+
+    if (admin && currentUser.role !== 'admin') {
+      return <Redirect to={{ pathname: '/queries' }} />
+    }
+
+    const Component = component
+
+    return (
+      <AppNav config={config} currentUser={currentUser}>
+        <Component config={config} currentUser={currentUser} {...rest} />
+      </AppNav>
+    )
+  }
+}
+
+Authenticated.propTypes = {
+  admin: PropTypes.bool,
+  Component: PropTypes.any
+}
+
+export default Authenticated

--- a/client-js/Authenticated.js
+++ b/client-js/Authenticated.js
@@ -52,7 +52,7 @@ class Authenticated extends React.Component {
 
 Authenticated.propTypes = {
   admin: PropTypes.bool,
-  Component: PropTypes.any
+  component: PropTypes.func.isRequired
 }
 
 export default Authenticated


### PR DESCRIPTION
Fixes bug where clicking sign-in doesn't progress to queries page. This behavior was introduced with the react router implementation. 

Previously each route pulled application information, but with react router this app info is pulled with only the initial page load (which may not get any user session info is user is not signed in). 

To counter this, an "Authenticated" component is introduced that pulls app/session info again on mount for a protected page. This component not only refreshes the data, but serves as a gatekeeper protecting routes requiring auth.