### PR TITLE
Navbar updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ docker system prune
 ```
 
 
-## Tips
-
-If you have highlighted just part of your query, only that part will be executed when you click Run Query.
-
-
 ## License 
 
 MIT

--- a/client-js/queryEditor/EditorNavBar.js
+++ b/client-js/queryEditor/EditorNavBar.js
@@ -63,7 +63,7 @@ class EditorNavBar extends React.Component {
             />
           </FormGroup>{' '}
           <Button onClick={onMoreClick} disabled={isRunning}>
-            ...
+            &hellip;
           </Button>
         </Navbar.Form>
       </Navbar>

--- a/client-js/queryEditor/EditorNavBar.js
+++ b/client-js/queryEditor/EditorNavBar.js
@@ -62,9 +62,7 @@ class EditorNavBar extends React.Component {
               value={queryName}
             />
           </FormGroup>{' '}
-          <Button onClick={onMoreClick} disabled={isRunning}>
-            &hellip;
-          </Button>
+          <Button onClick={onMoreClick}>&hellip;</Button>
         </Navbar.Form>
       </Navbar>
     )

--- a/client-js/queryEditor/EditorNavBar.js
+++ b/client-js/queryEditor/EditorNavBar.js
@@ -2,21 +2,29 @@ import React from 'react'
 import Navbar from 'react-bootstrap/lib/Navbar'
 import Nav from 'react-bootstrap/lib/Nav'
 import NavItem from 'react-bootstrap/lib/NavItem'
-import ControlLabel from 'react-bootstrap/lib/ControlLabel'
+import FormGroup from 'react-bootstrap/lib/FormGroup'
 import Button from 'react-bootstrap/lib/Button'
+import FormControl from 'react-bootstrap/lib/FormControl'
 
 class QueryEditor extends React.Component {
+  onQueryNameChange = e => {
+    this.props.onQueryNameChange(e.target.value)
+  }
+
   render() {
     const {
       activeTabKey,
       onTabSelect,
       isSaving,
       isRunning,
-      onQueryNameClick,
+      onMoreClick,
       onSaveClick,
       onRunClick,
-      queryName
+      queryName,
+      showValidation
     } = this.props
+
+    const validationState = showValidation && !queryName.length ? 'error' : null
 
     return (
       <Navbar fluid>
@@ -30,25 +38,30 @@ class QueryEditor extends React.Component {
         </Nav>
         <Navbar.Form>
           <Button
-            className="QueryEditorSubheaderItem"
+            style={{ marginLeft: 8 }}
             onClick={onSaveClick}
             disabled={isSaving}
           >
-            {isSaving ? 'Saving' : 'Save'}
-          </Button>
-          <Button
-            className="QueryEditorSubheaderItem"
-            onClick={onRunClick}
-            disabled={isRunning}
+            Save
+          </Button>{' '}
+          <Button onClick={onRunClick} disabled={isRunning}>
+            Run
+          </Button>{' '}
+          <FormGroup
+            validationState={validationState}
+            style={{ marginTop: '-1px' }}
           >
-            {isRunning ? 'Running' : 'Run'}
+            <FormControl
+              style={{ width: 300, color: '#111' }}
+              type="text"
+              placeholder="Query name"
+              onChange={this.onQueryNameChange}
+              value={queryName}
+            />
+          </FormGroup>{' '}
+          <Button onClick={onMoreClick} disabled={isRunning}>
+            ...
           </Button>
-          <ControlLabel
-            onClick={onQueryNameClick}
-            className="QueryEditorSubheaderItem QueryEditorQueryName"
-          >
-            {queryName || '(click to name query)'}
-          </ControlLabel>
         </Navbar.Form>
       </Navbar>
     )

--- a/client-js/queryEditor/EditorNavBar.js
+++ b/client-js/queryEditor/EditorNavBar.js
@@ -20,6 +20,7 @@ class QueryEditor extends React.Component {
       onMoreClick,
       onSaveClick,
       onRunClick,
+      onFormatClick,
       queryName,
       showValidation
     } = this.props
@@ -47,6 +48,7 @@ class QueryEditor extends React.Component {
           <Button onClick={onRunClick} disabled={isRunning}>
             Run
           </Button>{' '}
+          <Button onClick={onFormatClick}>Format</Button>{' '}
           <FormGroup
             validationState={validationState}
             style={{ marginTop: '-1px' }}

--- a/client-js/queryEditor/EditorNavBar.js
+++ b/client-js/queryEditor/EditorNavBar.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Navbar from 'react-bootstrap/lib/Navbar'
 import Nav from 'react-bootstrap/lib/Nav'
 import NavItem from 'react-bootstrap/lib/NavItem'
@@ -6,7 +7,7 @@ import FormGroup from 'react-bootstrap/lib/FormGroup'
 import Button from 'react-bootstrap/lib/Button'
 import FormControl from 'react-bootstrap/lib/FormControl'
 
-class QueryEditor extends React.Component {
+class EditorNavBar extends React.Component {
   onQueryNameChange = e => {
     this.props.onQueryNameChange(e.target.value)
   }
@@ -70,4 +71,17 @@ class QueryEditor extends React.Component {
   }
 }
 
-export default QueryEditor
+EditorNavBar.propTypes = {
+  activeTabKey: PropTypes.string.isRequired,
+  onTabSelect: PropTypes.func.isRequired,
+  isSaving: PropTypes.bool.isRequired,
+  isRunning: PropTypes.bool.isRequired,
+  onMoreClick: PropTypes.func.isRequired,
+  onSaveClick: PropTypes.func.isRequired,
+  onRunClick: PropTypes.func.isRequired,
+  onFormatClick: PropTypes.func.isRequired,
+  queryName: PropTypes.string.isRequired,
+  showValidation: PropTypes.bool.isRequired
+}
+
+export default EditorNavBar

--- a/client-js/queryEditor/EditorNavBar.js
+++ b/client-js/queryEditor/EditorNavBar.js
@@ -55,7 +55,12 @@ class EditorNavBar extends React.Component {
             style={{ marginTop: '-1px' }}
           >
             <FormControl
-              style={{ width: 300, color: '#111' }}
+              style={{
+                width: 300,
+                color: '#111',
+                padding: '5px 12px',
+                fontSize: '16px'
+              }}
               type="text"
               placeholder="Query name"
               onChange={this.onQueryNameChange}

--- a/client-js/queryEditor/QueryDetailsModal.js
+++ b/client-js/queryEditor/QueryDetailsModal.js
@@ -61,12 +61,17 @@ class QueryDetailsModal extends React.Component {
 
   render() {
     const {
+      config,
       onHide,
       onQueryTagsChange,
       query,
       showModal,
       tagOptions
     } = this.props
+
+    const tableUrl = `${config.baseUrl}/query-table/${query._id}`
+    const chartUrl = `${config.baseUrl}/query-chart/${query._id}`
+
     return (
       <Modal
         animation
@@ -111,8 +116,8 @@ class QueryDetailsModal extends React.Component {
           <p>Run only a portion of a query by highlighting it first.</p>
           <hr />
           <ul className="nav nav-pills nav-justified">
-            {this.renderNavLink('?format=table', 'Link to Table')}
-            {this.renderNavLink('?format=chart', 'Link to Chart')}
+            {this.renderNavLink(tableUrl, 'Link to Table')}
+            {this.renderNavLink(chartUrl, 'Link to Chart')}
           </ul>
         </Modal.Body>
         <Modal.Footer>
@@ -124,6 +129,7 @@ class QueryDetailsModal extends React.Component {
 }
 
 QueryDetailsModal.propTypes = {
+  config: PropTypes.object.isRequired,
   onHide: PropTypes.func.isRequired,
   onQueryTagsChange: PropTypes.func.isRequired,
   query: PropTypes.object.isRequired,

--- a/client-js/queryEditor/QueryDetailsModal.js
+++ b/client-js/queryEditor/QueryDetailsModal.js
@@ -2,14 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Creatable } from 'react-select'
 import FormGroup from 'react-bootstrap/lib/FormGroup'
-import FormControl from 'react-bootstrap/lib/FormControl'
 import ControlLabel from 'react-bootstrap/lib/ControlLabel'
 import Button from 'react-bootstrap/lib/Button'
 import Glyphicon from 'react-bootstrap/lib/Glyphicon'
 import Modal from 'react-bootstrap/lib/Modal'
 import Tooltip from 'react-bootstrap/lib/Tooltip'
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
-import HelpBlock from 'react-bootstrap/lib/HelpBlock'
 
 class QueryDetailsModal extends React.Component {
   input = undefined
@@ -66,15 +64,9 @@ class QueryDetailsModal extends React.Component {
       onHide,
       onQueryTagsChange,
       query,
-      saveOnClose,
       showModal,
       tagOptions
     } = this.props
-    const validationState = saveOnClose && !query.name.length ? 'warning' : null
-    const validationHelp =
-      saveOnClose && !query.name.length ? (
-        <HelpBlock>Query name is required to save query.</HelpBlock>
-      ) : null
     return (
       <Modal
         animation
@@ -85,19 +77,6 @@ class QueryDetailsModal extends React.Component {
         <Modal.Header closeButton />
         <Modal.Body>
           <form onSubmit={this.onSubmit}>
-            <FormGroup validationState={validationState}>
-              <ControlLabel>Query Name</ControlLabel>
-              <input
-                className="form-control"
-                onChange={this.onQueryNameChange}
-                ref={ref => (this.input = ref)}
-                type="text"
-                value={query.name}
-              />
-              <FormControl.Feedback />
-              {validationHelp}
-            </FormGroup>
-            <br />
             <FormGroup>
               <ControlLabel>Query Tags</ControlLabel>
               <Creatable
@@ -126,16 +105,13 @@ class QueryDetailsModal extends React.Component {
 
 QueryDetailsModal.propTypes = {
   onHide: PropTypes.func.isRequired,
-  onQueryNameChange: PropTypes.func.isRequired,
   onQueryTagsChange: PropTypes.func.isRequired,
   query: PropTypes.object.isRequired,
-  saveOnClose: PropTypes.bool,
   showModal: PropTypes.bool.isRequired,
   tagOptions: PropTypes.array
 }
 
 QueryDetailsModal.defaultProps = {
-  saveOnClose: false,
   tagOptions: []
 }
 

--- a/client-js/queryEditor/QueryDetailsModal.js
+++ b/client-js/queryEditor/QueryDetailsModal.js
@@ -88,12 +88,32 @@ class QueryDetailsModal extends React.Component {
                 value={query.tags}
               />
             </FormGroup>
-            <br />
-            <ul className="nav nav-pills nav-justified">
-              {this.renderNavLink('?format=table', 'Link to Table')}
-              {this.renderNavLink('?format=chart', 'Link to Chart')}
-            </ul>
           </form>
+          <hr />
+          <p>
+            <strong>Shortcuts</strong>
+          </p>
+          <ul style={{ paddingLeft: 0 }}>
+            <li style={{ listStyleType: 'none', marginBottom: 8 }}>
+              <code>ctrl+s</code> / <code>command+s</code> : Save
+            </li>
+            <li style={{ listStyleType: 'none', marginBottom: 8 }}>
+              <code>ctrl+return</code> / <code>command+return</code> : Run
+            </li>
+            <li style={{ listStyleType: 'none', marginBottom: 8 }}>
+              <code>shift+return</code> : Format
+            </li>
+          </ul>
+          <hr />
+          <p>
+            <strong>Tip</strong>
+          </p>
+          <p>Run only a portion of a query by highlighting it first.</p>
+          <hr />
+          <ul className="nav nav-pills nav-justified">
+            {this.renderNavLink('?format=table', 'Link to Table')}
+            {this.renderNavLink('?format=chart', 'Link to Chart')}
+          </ul>
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={onHide}>Close</Button>

--- a/client-js/queryEditor/QueryEditor.js
+++ b/client-js/queryEditor/QueryEditor.js
@@ -40,8 +40,8 @@ class QueryEditor extends React.Component {
     query: Object.assign({}, NEW_QUERY),
     queryResult: undefined,
     runQueryStartTime: undefined,
-    saveOnClose: false,
-    showModal: false
+    showModal: false,
+    showValidation: false
   }
 
   sqlpadTauChart = undefined
@@ -133,7 +133,8 @@ class QueryEditor extends React.Component {
     const { query } = this.state
     const { config } = this.props
     if (!query.name) {
-      this.setState({ showModal: true, saveOnClose: true })
+      Alert.error('Query name required')
+      this.setState({ showValidation: true })
       return
     }
     this.setState({ isSaving: true })
@@ -190,15 +191,12 @@ class QueryEditor extends React.Component {
   }
 
   handleModalHide = () => {
-    if (this.state.saveOnClose) {
-      this.saveQuery()
-    }
-    this.setState({ showModal: false, saveOnClose: false })
+    this.setState({ showModal: false })
   }
 
   handleQueryNameChange = name => this.setQueryState('name', name)
 
-  handleQueryNameClick = () => this.setState({ showModal: true })
+  handleMoreClick = () => this.setState({ showModal: true })
 
   handleQueryTagsChange = values =>
     this.setQueryState('tags', values.map(v => v.value))
@@ -307,8 +305,8 @@ class QueryEditor extends React.Component {
       queryResult,
       runQueryStartTime,
       runSeconds,
-      saveOnClose,
-      showModal
+      showModal,
+      showValidation
     } = this.state
 
     document.title = query.name || 'New Query'
@@ -319,11 +317,13 @@ class QueryEditor extends React.Component {
           activeTabKey={activeTabKey}
           isRunning={isRunning}
           isSaving={isSaving}
-          onQueryNameClick={this.handleQueryNameClick}
+          onMoreClick={this.handleMoreClick}
           onRunClick={this.runQuery}
           onSaveClick={this.saveQuery}
           onTabSelect={this.handleTabSelect}
           queryName={query.name}
+          onQueryNameChange={this.handleQueryNameChange}
+          showValidation={showValidation}
         />
         <div style={{ position: 'relative', flexGrow: 1 }}>
           <FlexTabPane tabKey="sql" activeTabKey={activeTabKey}>
@@ -422,10 +422,8 @@ class QueryEditor extends React.Component {
         </div>
         <QueryDetailsModal
           onHide={this.handleModalHide}
-          onQueryNameChange={this.handleQueryNameChange}
           onQueryTagsChange={this.handleQueryTagsChange}
           query={query}
-          saveOnClose={saveOnClose}
           showModal={showModal}
           tagOptions={this.getTagOptions()}
         />

--- a/client-js/queryEditor/QueryEditor.js
+++ b/client-js/queryEditor/QueryEditor.js
@@ -280,6 +280,10 @@ class QueryEditor extends React.Component {
     keymaster.unbind('alt+r')
   }
 
+  handleFormatClick = () => {
+    this.formatQuery()
+  }
+
   handlePaneResize = () => {
     if (this.editor) {
       this.editor.resize()
@@ -320,6 +324,7 @@ class QueryEditor extends React.Component {
           onMoreClick={this.handleMoreClick}
           onRunClick={this.runQuery}
           onSaveClick={this.saveQuery}
+          onFormatClick={this.handleFormatClick}
           onTabSelect={this.handleTabSelect}
           queryName={query.name}
           onQueryNameChange={this.handleQueryNameChange}

--- a/client-js/queryEditor/QueryEditor.js
+++ b/client-js/queryEditor/QueryEditor.js
@@ -440,6 +440,7 @@ class QueryEditor extends React.Component {
           </FlexTabPane>
         </div>
         <QueryDetailsModal
+          config={config}
           onHide={this.handleModalHide}
           onQueryTagsChange={this.handleQueryTagsChange}
           query={query}

--- a/client-js/queryEditor/QueryEditor.js
+++ b/client-js/queryEditor/QueryEditor.js
@@ -262,12 +262,24 @@ class QueryEditor extends React.Component {
     // rather something previously not run than something run more than once
     keymaster.unbind('ctrl+r, command+r, ctrl+e, command+e')
     keymaster('ctrl+r, command+r, ctrl+e, command+e', e => {
+      Alert.info('Shortcut changed to ctrl+return / command+return')
+      e.preventDefault()
+      return false
+    })
+    keymaster.unbind('ctrl+return, command+return')
+    keymaster('ctrl+return, command+return', e => {
       this.runQuery()
       e.preventDefault()
       return false
     })
     keymaster.unbind('alt+r')
     keymaster('alt+r', e => {
+      Alert.info('Shortcut changed to shift+return')
+      e.preventDefault()
+      return false
+    })
+    keymaster.unbind('shift+return')
+    keymaster('shift+return', e => {
       this.formatQuery()
       e.preventDefault()
       return false
@@ -275,9 +287,11 @@ class QueryEditor extends React.Component {
   }
 
   componentWillUnmount() {
+    keymaster.unbind('ctrl+return, command+return')
     keymaster.unbind('ctrl+s, command+s')
     keymaster.unbind('ctrl+r, command+r, ctrl+e, command+e')
     keymaster.unbind('alt+r')
+    keymaster.unbind('shift+return')
   }
 
   handleFormatClick = () => {


### PR DESCRIPTION
- Move query name input out of modal and into nav bar
- Add format button
- Update shortcuts:
  - run query is now control/command+return
  - format is shift+return
- Document shortcuts and query highlight tip in modal