### PR TITLE
Goodbye chai

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "react-app"
+  "extends": "react-app",
+  "env": {
+    "mocha": true
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,12 +607,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
-    },
     "ast-types": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
@@ -2184,20 +2178,6 @@
         }
       }
     },
-    "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.3"
-      }
-    },
     "chain-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
@@ -2230,12 +2210,6 @@
           "dev": true
         }
       }
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
@@ -3280,15 +3254,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.3"
-      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -5807,12 +5772,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-own-enumerable-property-symbols": {
@@ -9727,12 +9686,6 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
       }
-    },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
     },
     "pause": {
       "version": "0.0.1",
@@ -13804,12 +13757,6 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-      "dev": true
     },
     "type-is": {
       "version": "1.6.15",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "babel-runtime": "^6.26.0",
     "bootstrap": "^3.3.7",
     "brace": "^0.10.0",
-    "chai": "^4.1.2",
     "concurrently": "^3.5.0",
     "d3": "^3.5.17",
     "deep-equal": "^1.0.1",

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -1,7 +1,4 @@
-/* eslint-disable no-unused-expressions */
-/* eslint-env mocha */
-require('chai').should()
-
+const assert = require('assert')
 const config = require('../../lib/config.js')
 
 describe('lib/config.js', function() {
@@ -13,19 +10,18 @@ describe('lib/config.js', function() {
 
   describe('#get()', function() {
     it.skip('should get a value provided by default', function() {
-      config.get('port').should.equal(80)
+      assert.equal(config.get('port'), 80, 'port=80')
     })
     it.skip('should get a value provided by environment', function() {
-      config.get('googleClientId').should.equal('google-client-id')
+      assert.equal(
+        config.get('googleClientId', 'google-client-id', 'googleClientId')
+      )
     })
     it.skip('cli should override env var', function() {
-      config.get('debug').should.equal(true)
+      assert.equal(config.get('debug'), true, 'debug=true')
     })
     it('should only accept key in config items', function() {
-      var fn = function() {
-        config.get('non-existent-key')
-      }
-      fn.should.throw(Error)
+      assert.throws(() => config.get('non-existent-key'), Error)
     })
   })
 })

--- a/test/models/ConfigItem.js
+++ b/test/models/ConfigItem.js
@@ -1,8 +1,4 @@
-/* eslint-disable no-unused-expressions */
-/* eslint-env mocha */
-const expect = require('chai').expect
-const should = require('chai').should()
-
+const assert = require('assert')
 const ConfigItem = require('../../models/ConfigItem.js')
 
 describe('models/ConfigItem.js', function() {
@@ -13,29 +9,35 @@ describe('models/ConfigItem.js', function() {
     // process.env.SQLPAD_DEBUG = 'FALSE'
     it.skip('should have expected values', function() {
       const debugItem = ConfigItem.findOneByKey('debug')
-      expect(debugItem.effectiveValue, 'effective').to.equal(true)
-      expect(debugItem.cliValue, 'cli').to.equal(true)
-      expect(debugItem.envValue, 'env').to.equal(false)
-      expect(debugItem.default, 'default').to.equal(false)
-      expect(debugItem.dbValue, 'dbValue').to.not.exist
+      assert.equal(debugItem.effectiveValue, true, 'effectiveValue')
+      assert.equal(debugItem.cliValue, true, 'cliValue')
+      assert.equal(debugItem.envValue, false, 'envValue')
+      assert.equal(debugItem.default, false, 'default')
+      assert.equal(debugItem.dbValue, undefined, 'dbValue')
     })
 
     it('should setDbValue', function() {
       const portItem = ConfigItem.findOneByKey('port')
       portItem.setDbValue('9000')
-      expect(portItem.dbValue).to.equal('9000')
+      assert.equal(portItem.dbValue, '9000', 'dbValue')
     })
 
     it('should throw error when saving a non-ui item', function() {
       const portItem = ConfigItem.findOneByKey('port')
-      portItem.save.should.throw(Error)
+      assert.throws(
+        () => {
+          portItem.save()
+        },
+        Error,
+        'portItem.save expect error'
+      )
     })
 
     it('should save without error', function(done) {
       const wrapItem = ConfigItem.findOneByKey('editorWordWrap')
       wrapItem.setDbValue(true)
       wrapItem.save(function(err) {
-        should.not.exist(err)
+        assert.ifError(err)
         done()
       })
     })
@@ -45,19 +47,19 @@ describe('models/ConfigItem.js', function() {
     const configItem = ConfigItem.findOneByKey('port')
 
     it('should get requested config item', function() {
-      expect(configItem.key).to.equal('port')
+      assert.equal(configItem.key, 'port', 'key is port')
     })
 
     it('should be instanceOf ConfigItem', function() {
-      expect(configItem).to.be.an.instanceOf(ConfigItem)
+      assert(configItem instanceof ConfigItem)
     })
   })
 
   describe('findAll()', function() {
     it('should get array of ConfigItems', function() {
       const configItems = ConfigItem.findAll()
-      configItems.should.have.length.above(1)
-      expect(configItems[0]).to.be.an.instanceOf(ConfigItem)
+      assert(configItems.length > 1, 'more than 1 item')
+      assert(configItems[0] instanceof ConfigItem)
     })
   })
 })

--- a/test/models/Connection.js
+++ b/test/models/Connection.js
@@ -1,10 +1,8 @@
-/* eslint-env mocha */
-var expect = require('chai').expect
-var should = require('chai').should()
-var Connection = require('../../models/Connection.js')
+const assert = require('assert')
+const Connection = require('../../models/Connection.js')
 
 describe('models/Connection.js', function() {
-  var testConnection
+  let testConnection
 
   before(function before(done) {
     Connection._removeAll(done)
@@ -13,8 +11,8 @@ describe('models/Connection.js', function() {
   describe('.findAll() with no connections', function() {
     it('should return an empty array', function(done) {
       Connection.findAll(function(err, connections) {
-        should.not.exist(err)
-        connections.should.have.lengthOf(0)
+        assert.ifError(err)
+        assert.equal(connections.length, 0, 'length = 0')
         done()
       })
     })
@@ -31,9 +29,9 @@ describe('models/Connection.js', function() {
         password: 'password'
       })
       testConnection.save(function(err, newConnection) {
-        should.not.exist(err)
-        expect(newConnection).to.be.an.instanceof(Connection)
-        should.exist(newConnection._id)
+        assert.ifError(err)
+        assert(newConnection instanceof Connection, 'should be Connection')
+        assert(newConnection._id, '_id should exist')
         testConnection = newConnection
         done()
       })
@@ -43,9 +41,12 @@ describe('models/Connection.js', function() {
   describe('.findOneById()', function() {
     it('should return requested connection', function(done) {
       Connection.findOneById(testConnection._id, function(err, connection) {
-        should.not.exist(err)
-        expect(connection).to.be.an.instanceof(Connection)
-        expect(connection._id).to.equal(testConnection._id)
+        assert.ifError(err)
+        assert(
+          connection instanceof Connection,
+          'Expect instance of Connection'
+        )
+        assert.equal(connection._id, testConnection._id, '_ids should match')
         done()
       })
     })
@@ -54,9 +55,12 @@ describe('models/Connection.js', function() {
   describe('.findAll()', function() {
     it('should return all connections', function(done) {
       Connection.findAll(function(err, connections) {
-        should.not.exist(err)
-        connections.should.have.lengthOf(1)
-        expect(connections[0]).to.be.an.instanceof(Connection)
+        assert.ifError(err)
+        assert(connections.length === 1, 'connections should have length of 1')
+        assert(
+          connections[0] instanceof Connection,
+          'connection should be instance of Connection'
+        )
         done()
       })
     })
@@ -65,10 +69,14 @@ describe('models/Connection.js', function() {
   describe('.removeOneById()', function() {
     it('should remove the connection', function(done) {
       Connection.removeOneById(testConnection._id, function(err) {
-        should.not.exist(err)
+        assert.ifError(err)
         Connection.findAll(function(err, connections) {
-          should.not.exist(err)
-          connections.should.have.lengthOf(0)
+          assert.ifError(err)
+          assert.equal(
+            connections.length,
+            0,
+            'connections should have lengthof 0'
+          )
           done()
         })
       })

--- a/test/models/Query.js
+++ b/test/models/Query.js
@@ -1,7 +1,5 @@
-/* eslint-env mocha */
-var expect = require('chai').expect
-var should = require('chai').should()
-var Query = require('../../models/Query.js')
+const assert = require('assert')
+const Query = require('../../models/Query.js')
 
 describe('models/Query.js', function() {
   before(function before(done) {
@@ -10,7 +8,7 @@ describe('models/Query.js', function() {
 
   describe('new Query', function() {
     it('should save with all the stuff', function(done) {
-      var query = new Query({
+      const query = new Query({
         _id: 'test-all',
         name: 'test query all',
         tags: ['tag1', 'tag2'],
@@ -27,25 +25,25 @@ describe('models/Query.js', function() {
         modifiedBy: 'test@test.com'
       })
       query.save(function(err, newQuery) {
-        should.not.exist(err)
-        should.exist(newQuery._id)
-        expect(newQuery).to.be.an.instanceof(Query)
+        assert.ifError(err)
+        assert(newQuery._id, '_id should exist')
+        assert(newQuery instanceof Query, 'should be Query')
         done()
       })
     })
 
     it('should save with the least amount of stuff', function(done) {
-      var query = new Query({
+      const query = new Query({
         _id: 'test-least',
         name: 'test query minimal',
         createdBy: 'test@test.com',
         modifiedBy: 'test@test.com'
       })
       query.save(function(err, newQuery) {
-        should.not.exist(err)
-        should.exist(newQuery._id)
-        newQuery.name.should.equal('test query minimal')
-        expect(newQuery).to.be.an.instanceof(Query)
+        assert.ifError(err)
+        assert(newQuery._id, '_id should exist')
+        assert.equal(newQuery.name, 'test query minimal', 'newQuery.name')
+        assert(newQuery instanceof Query, 'instanceOf Query')
         done()
       })
     })
@@ -54,9 +52,9 @@ describe('models/Query.js', function() {
   describe('.findAll', function() {
     it('should get all the queries', function(done) {
       Query.findAll(function(err, queries) {
-        should.not.exist(err)
-        queries.should.have.lengthOf(2)
-        expect(queries[0]).to.be.an.instanceof(Query)
+        assert.ifError(err)
+        assert.equal(queries.length, 2, 'queries.length')
+        assert(queries[0] instanceof Query, 'instance of Query')
         done()
       })
     })
@@ -65,12 +63,12 @@ describe('models/Query.js', function() {
   describe('.findOneById', function() {
     it('should get the query requested', function(done) {
       Query.findAll(function(err, queries) {
-        should.not.exist(err)
-        var id = queries[0]._id
+        assert.ifError(err)
+        const id = queries[0]._id
         Query.findOneById(id, function(err, query) {
-          should.not.exist(err)
-          expect(query).to.be.an.instanceof(Query)
-          query._id.should.equal(id)
+          assert.ifError(err)
+          assert(query instanceof Query, 'instance of Query')
+          assert.equal(query._id, id, '_id = id')
           done()
         })
       })
@@ -80,10 +78,10 @@ describe('models/Query.js', function() {
   describe('.removeOneById', function() {
     it('should remove the query requested', function(done) {
       Query.removeOneById('test-all', function(err) {
-        should.not.exist(err)
+        assert.ifError(err)
         Query.findAll(function(err, queries) {
-          should.not.exist(err)
-          queries.should.have.lengthOf(1)
+          assert.ifError(err)
+          assert.equal(queries.length, 1, 'queries.length')
           done()
         })
       })

--- a/test/models/User.js
+++ b/test/models/User.js
@@ -1,12 +1,10 @@
-/* eslint-env mocha */
-var expect = require('chai').expect
-var should = require('chai').should()
-var User = require('../../models/User.js')
+const assert = require('assert')
+const User = require('../../models/User.js')
 
 describe('models/User.js', function() {
-  var regularUser = new User({ email: 'regular@test.com', role: 'editor' })
-  var adminUser = new User({ email: 'admin@test.com', role: 'admin' })
-  var signedUpUser = new User({
+  const regularUser = new User({ email: 'regular@test.com', role: 'editor' })
+  const adminUser = new User({ email: 'admin@test.com', role: 'admin' })
+  const signedUpUser = new User({
     email: 'signedUp@test.com',
     role: 'editor',
     password: '1234'
@@ -19,17 +17,17 @@ describe('models/User.js', function() {
   describe('.openAdminRegistration()', function() {
     it('should return true if no admins exist', function(done) {
       User.adminRegistrationOpen(function(err, open) {
-        should.not.exist(err)
-        expect(open).to.equal(true)
+        assert.ifError(err)
+        assert.equal(open, true, 'open=true')
         done()
       })
     })
     it('should return false if admin exist', function(done) {
       adminUser.save(function(err) {
-        should.not.exist(err)
+        assert.ifError(err)
         User.adminRegistrationOpen(function(err, open) {
-          should.not.exist(err)
-          expect(open).to.equal(false)
+          assert.ifError(err)
+          assert.equal(open, false, 'open=false')
           done()
         })
       })
@@ -39,9 +37,9 @@ describe('models/User.js', function() {
   describe('new User', function() {
     it('should save without error', function(done) {
       regularUser.save(function(err) {
-        should.not.exist(err)
+        assert.ifError(err)
         adminUser.save(function(err) {
-          should.not.exist(err)
+          assert.ifError(err)
           signedUpUser.save(done)
         })
       })
@@ -50,11 +48,10 @@ describe('models/User.js', function() {
 
   describe('.findAll()', function() {
     it('should return all the existing users', function(done) {
-      // todo
       User.findAll(function(err, users) {
-        should.not.exist(err)
-        users.should.have.lengthOf(3)
-        expect(users[0]).to.be.an.instanceof(User)
+        assert.ifError(err)
+        assert.equal(users.length, 3, 'users.length')
+        assert(users[0] instanceof User, 'instanceof User')
         done()
       })
     })
@@ -63,10 +60,10 @@ describe('models/User.js', function() {
   describe('.findOneByEmail()', function() {
     it('should return requested user', function(done) {
       User.findOneByEmail('admin@test.com', function(err, user) {
-        should.not.exist(err)
-        expect(user).to.be.an.instanceof(User)
-        expect(user.email).to.equal('admin@test.com')
-        expect(user.role).to.equal('admin')
+        assert.ifError(err)
+        assert(user instanceof User, 'instanceof User')
+        assert.equal(user.email, 'admin@test.com', 'user.email')
+        assert.equal(user.role, 'admin', 'user.role')
         done()
       })
     })
@@ -74,18 +71,18 @@ describe('models/User.js', function() {
 
   describe('new User', function() {
     it('should save without error', function(done) {
-      var user = new User({ email: '2@test.com' })
+      const user = new User({ email: '2@test.com' })
       user.save(done)
     })
     it('should have defaults populated', function(done) {
       User.findOneByEmail('regular@test.com', function(err, user) {
-        should.not.exist(err)
-        should.exist(user)
-        should.exist(user.email)
-        expect(user.role).to.equal('editor')
-        expect(user).to.be.an.instanceof(User)
-        expect(user.createdDate).to.be.instanceof(Date)
-        expect(user.modifiedDate).to.be.instanceof(Date)
+        assert.ifError(err)
+        assert(user)
+        assert(user.email)
+        assert.equal(user.role, 'editor', 'user.role')
+        assert(user instanceof User, 'instanceOf User')
+        assert(user.createdDate instanceof Date)
+        assert(user.modifiedDate instanceof Date)
         done()
       })
     })
@@ -94,20 +91,20 @@ describe('models/User.js', function() {
   describe('.comparePasswordToHash()', function() {
     it('should return true if password is a match', function(done) {
       User.findOneByEmail('signedUp@test.com', function(err, user) {
-        should.not.exist(err)
+        assert.ifError(err)
         user.comparePasswordToHash('1234', function(err, isMatch) {
-          should.not.exist(err)
-          expect(isMatch).to.equal(true)
+          assert.ifError(err)
+          assert.equal(isMatch, true, 'isMatch')
           done()
         })
       })
     })
     it('should return false if password is not a match', function(done) {
       User.findOneByEmail('signedUp@test.com', function(err, user) {
-        should.not.exist(err)
+        assert.ifError(err)
         user.comparePasswordToHash('wrongpassword', function(err, isMatch) {
-          should.not.exist(err)
-          expect(isMatch).to.equal(false)
+          assert.ifError(err)
+          assert.equal(isMatch, false, 'isMatch')
           done()
         })
       })


### PR DESCRIPTION
This removes chai as a dependency for testing. Like the removal of toml in #282, nothing against chai. SQLPad isn't big enough, and (in my opinion) this project benefits from the simplification.