### PR TITLE
Remove table_type from schema queries

### DIFF
--- a/client-js/queryEditor/SchemaSidebar.js
+++ b/client-js/queryEditor/SchemaSidebar.js
@@ -243,14 +243,6 @@ class SchemaInfoTableItem extends React.Component {
         }
       })
     }
-    // this is hacky, but because of the way we're passing the schema info around
-    // we need to reach down into the columns to get the type of this object
-    const viewType = () => {
-      const type = columns[0].table_type
-      if (type.toLowerCase().split('')[0] === 'v') {
-        return <span className="silver"> (view)</span>
-      }
-    }
 
     const copyButtonClassName = showCopyButton
       ? 'right-2 pointer absolute bg-black hover-bg-hot-pink label'
@@ -280,7 +272,7 @@ class SchemaInfoTableItem extends React.Component {
           className="dib"
           style={{ minWidth: '230px' }}
         >
-          {table} {viewType()}
+          {table}
           {getCopyToClipboard()}
         </a>
         <ul className="pl3">{columnJsx}</ul>

--- a/lib/get-schema-for-connection.js
+++ b/lib/get-schema-for-connection.js
@@ -27,7 +27,6 @@ const sqlSchemaCrateV0 = fs.readFileSync(sqldir + '/schema-crate.v0.sql', {
 function getStandardSchemaSql(whereSql = '') {
   return `
     SELECT 
-      (CASE t.table_type WHEN 'BASE TABLE' THEN 'Tables' WHEN 'VIEW' THEN 'Views' ELSE t.table_type END) AS table_type, 
       t.table_schema, 
       t.table_name, 
       c.column_name, 
@@ -38,7 +37,6 @@ function getStandardSchemaSql(whereSql = '') {
       JOIN INFORMATION_SCHEMA.COLUMNS c ON t.table_schema = c.table_schema AND t.table_name = c.table_name 
     ${whereSql}
     ORDER BY 
-      t.table_type, 
       t.table_schema, 
       t.table_name, 
       c.ordinal_position
@@ -46,11 +44,9 @@ function getStandardSchemaSql(whereSql = '') {
 }
 
 function getPrestoSchemaSql(catalog, schema) {
-  // TODO make table_type optional
   const schemaSql = schema ? `AND table_schema = '${schema}'` : ''
   return `
     SELECT 
-      'BASE TABLE' AS table_type, 
       c.table_schema, 
       c.table_name, 
       c.column_name, 
@@ -70,7 +66,6 @@ function getPrestoSchemaSql(catalog, schema) {
 function getHANASchemaSql(whereSql = '') {
   return `
     SELECT 
-      tables.TABLE_TYPE AS table_type,
 	    columns.IS_NULLABLE as is_nullable, 
       columns.SCHEMA_NAME as table_schema, 
       columns.TABLE_NAME as table_name, 
@@ -179,7 +174,7 @@ function formatResults(queryResult, doneCallback) {
   /*
   At this point, tree should look like this:
     {
-      "schama-name": {
+      "schema-name": {
         "table-name": [
           {
             column_name: "the column name",

--- a/resources/schema-crate.sql
+++ b/resources/schema-crate.sql
@@ -1,5 +1,4 @@
 select 
-    'Tables' as table_type,
     'YES' as is_nullable, 
     tables.table_schema as table_schema, 
     tables.table_name as table_name, 

--- a/resources/schema-crate.v0.sql
+++ b/resources/schema-crate.v0.sql
@@ -1,5 +1,4 @@
 select 
-    'Tables' as table_type,
     'YES' as is_nullable, 
     tables.schema_name as table_schema, 
     tables.table_name as table_name, 

--- a/resources/schema-postgres.sql
+++ b/resources/schema-postgres.sql
@@ -1,5 +1,4 @@
 select 
-    case cls.relkind when 'r' then 'Tables' when 'v' then 'Views' when 'm' then 'Views' end as table_type,
     ns.nspname as table_schema, 
     cls.relname as table_name, 
     attr.attname as column_name,

--- a/resources/schema-vertica.sql
+++ b/resources/schema-vertica.sql
@@ -1,5 +1,4 @@
 SELECT 
-    (CASE vat.table_type WHEN 'TABLE' THEN 'Tables' WHEN 'VIEW' THEN 'Views' ELSE vat.table_type END) AS table_type, 
     vt.table_schema, 
     vt.table_name, 
     vc.column_name, 
@@ -12,7 +11,6 @@ FROM
 WHERE 
     vt.table_schema NOT IN ('V_CATALOG') AND vat.table_type = 'TABLE' 
 ORDER BY 
-    vat.table_type, 
     vt.table_schema, 
     vt.table_name, 
     vc.ordinal_position


### PR DESCRIPTION
Removes table_type from schema info queries, and the "(view)" marking on items in the schema explorer for things that are views. 

This slims down the schema queries and the results of the queries, allowing for more efficient schema refreshes. I'm also not too convinced "(view)" is very helpful particularly for a data exploration tool. It adds noise to the list and usually in my experience, people tend to name views following a convention that gives them some sort of distinction anyways.