### PR TITLE
Remove is_nullable from schema queries

### DIFF
--- a/lib/get-schema-for-connection.js
+++ b/lib/get-schema-for-connection.js
@@ -30,8 +30,7 @@ function getStandardSchemaSql(whereSql = '') {
       t.table_schema, 
       t.table_name, 
       c.column_name, 
-      c.data_type, 
-      c.is_nullable 
+      c.data_type
     FROM 
       INFORMATION_SCHEMA.TABLES t 
       JOIN INFORMATION_SCHEMA.COLUMNS c ON t.table_schema = c.table_schema AND t.table_name = c.table_name 
@@ -66,7 +65,6 @@ function getPrestoSchemaSql(catalog, schema) {
 function getHANASchemaSql(whereSql = '') {
   return `
     SELECT 
-	    columns.IS_NULLABLE as is_nullable, 
       columns.SCHEMA_NAME as table_schema, 
       columns.TABLE_NAME as table_name, 
       columns.COLUMN_NAME as column_name, 
@@ -170,7 +168,6 @@ function formatResults(queryResult, doneCallback) {
       }
     }
   }
-  // TODO get rid of is_nullable since no plans on using it in UI
   /*
   At this point, tree should look like this:
     {
@@ -178,8 +175,7 @@ function formatResults(queryResult, doneCallback) {
         "table-name": [
           {
             column_name: "the column name",
-            data_type: "string",
-            is_nullable: "no"
+            data_type: "string"
           }
         ]
       }

--- a/resources/schema-crate.sql
+++ b/resources/schema-crate.sql
@@ -1,5 +1,4 @@
 select 
-    'YES' as is_nullable, 
     tables.table_schema as table_schema, 
     tables.table_name as table_name, 
     column_name, 

--- a/resources/schema-crate.v0.sql
+++ b/resources/schema-crate.v0.sql
@@ -1,5 +1,4 @@
 select 
-    'YES' as is_nullable, 
     tables.schema_name as table_schema, 
     tables.table_name as table_name, 
     column_name, 

--- a/resources/schema-postgres.sql
+++ b/resources/schema-postgres.sql
@@ -2,8 +2,7 @@ select
     ns.nspname as table_schema, 
     cls.relname as table_name, 
     attr.attname as column_name,
-    trim(leading '_' from tp.typname) as data_type,
-    case attr.attnotnull when true then 'NO' when false then 'YES' end as is_nullable
+    trim(leading '_' from tp.typname) as data_type
 from 
 	pg_catalog.pg_attribute as attr
 	join pg_catalog.pg_class as cls on cls.oid = attr.attrelid

--- a/resources/schema-vertica.sql
+++ b/resources/schema-vertica.sql
@@ -2,8 +2,7 @@ SELECT
     vt.table_schema, 
     vt.table_name, 
     vc.column_name, 
-    vc.data_type, 
-    (CASE vc.is_nullable WHEN 't' THEN 'YES' ELSE 'NO' END)  as is_nullable 
+    vc.data_type
 FROM 
     V_CATALOG.TABLES vt 
     JOIN V_CATALOG.ALL_TABLES vat ON vt.table_id = vat.table_id 


### PR DESCRIPTION
Queries for the schema sidebar were providing a column is_nullable indicating whether the column was nullable or not. At some point I thought I'd use this, but never did. Today it adds bloat to the query, so it is being removed