### PR TITLE
Non circular migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run build",
     "lint": "eslint '**/*.js'",
     "start-client-dev": "react-scripts start",
-    "start-server-dev": "node-dev server/server.js --dir ../db --port 3010 --debug",
+    "start-server-dev": "node-dev server/server.js --dir ./db --port 3010 --debug",
     "start": "concurrently \"npm run start-server-dev\" \"npm run start-client-dev\"",
     "test-client": "react-scripts test --env=jsdom",
     "test": "npm run lint && mocha server/test --recursive --exit"

--- a/server/app.js
+++ b/server/app.js
@@ -7,7 +7,6 @@ const session = require('express-session')
 const MemoryStore = require('memorystore')(session)
 const configUtil = require('./lib/config')
 const db = require('./lib/db')
-const packageJson = require('../package.json')
 const {
   baseUrl,
   googleClientId,

--- a/server/lib/migrate-schema.js
+++ b/server/lib/migrate-schema.js
@@ -14,13 +14,13 @@ const migrations = {
       // user.signupDate should be used when user is initially signed up.
       // NOTE: using db directly here to avoid model schema conflicts
       // and extra model logic (like modified date updates)
-      db.users.find({}).exec(function(err, docs) {
+      db.users.find({}).exec((err, docs) => {
         if (err) {
           return reject(err)
         }
         async.eachSeries(
           docs,
-          function(doc, callback) {
+          (doc, callback) => {
             doc.signupDate = doc.createdDate
             doc.createdDate = doc.createdDate || new Date()
             doc.modifiedDate = doc.modifiedDate || new Date()
@@ -89,16 +89,14 @@ function runMigrations(db, currentVersion) {
       .then(() => {
         // write new schemaVersion file
         const json = JSON.stringify({ schemaVersion: nextVersion })
-        fs.writeFile(schemaVersionFilePath, json, function(err) {
+        fs.writeFile(schemaVersionFilePath, json, err => {
           if (err) {
             return reject(err)
           }
           resolve(runMigrations(db, nextVersion))
         })
       })
-      .catch(err => {
-        return reject(err)
-      })
+      .catch(reject)
   })
 }
 
@@ -109,7 +107,7 @@ function runMigrations(db, currentVersion) {
  */
 module.exports = function migrateSchema(db) {
   return new Promise((resolve, reject) => {
-    fs.readFile(schemaVersionFilePath, 'utf8', function(err, json) {
+    fs.readFile(schemaVersionFilePath, 'utf8', (err, json) => {
       if (err && err.code !== 'ENOENT') {
         return reject(err)
       }


### PR DESCRIPTION
This continues the work to remove circular dependencies! 

Now the migrations take the database as a function parameter instead of requiring it in the file. The migrations have also been wrapped in promises for future when the switch is made to node 8 and all this stuff can be made async/await. 

The migrations probably aren't relevant for anyone anymore unless you have an old SQLPad instance earlier than Fall 2016, but it doesn't hurt to leave them in place...