### PR TITLE
Fix cache migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start-server-dev": "node-dev server/server.js --dir ./db --port 3010 --debug",
     "start": "concurrently \"npm run start-server-dev\" \"npm run start-client-dev\"",
     "test-client": "react-scripts test --env=jsdom",
-    "test": "npm run lint && mocha server/test --timeout 10000 --recursive --exit"
+    "test": "rm -rf ./dbtest && npm run lint && SQLPAD_DB_PATH='./dbtest' mocha server/test --timeout 10000 --recursive --exit"
   },
   "prettier": {
     "semi": false,

--- a/server/lib/migrate-schema.js
+++ b/server/lib/migrate-schema.js
@@ -32,7 +32,13 @@ const migrations = {
           console.error(err)
           return reject(err)
         }
-        db.cache.remove({}, { multi: true }, resolve)
+        db.cache
+          .remove({}, { multi: true })
+          .then(() => resolve())
+          .catch(error => {
+            console.error(error)
+            return reject(error)
+          })
       })
     }),
   3: db =>

--- a/server/test/api/schema-info.js
+++ b/server/test/api/schema-info.js
@@ -24,7 +24,7 @@ describe('api/schema-info', function() {
 
   // This test fails in TravisCI during Cache.findOneByCacheKey(cacheKey)
   // This works locally however
-  it.skip('Gets schema-info', function() {
+  it('Gets schema-info', function() {
     return utils
       .get('admin', `/api/schema-info/${connection._id}`)
       .then(body => {


### PR DESCRIPTION
Fixes issue with initial sqlpad setup preventing cache db collection from functioning as expected. This was resulting in erratic behavior, most notably queries and schema-info fetches never returning.