### PR TITLE
Fix baseUrl of undefined error

### DIFF
--- a/client-js/App.js
+++ b/client-js/App.js
@@ -30,6 +30,9 @@ class App extends React.Component {
       // Assign config.baseUrl to global
       // It doesn't change and is needed for fetch requests
       // This allows us to simplify the fetch() call
+      if (!json.config) {
+        return
+      }
       window.BASE_URL = json.config.baseUrl
       this.setState({
         config: json.config,
@@ -56,8 +59,14 @@ class App extends React.Component {
       passport
     } = this.state
 
+    // If there is no config a lot of the app is not functional
+    // Instead just load the Alert component so alerts can fire if needed
     if (!config) {
-      return null
+      return (
+        <div className="flex w-100">
+          <Alert stack={{ limit: 3 }} position="bottom-right" />
+        </div>
+      )
     }
 
     return (

--- a/server/app.js
+++ b/server/app.js
@@ -97,7 +97,6 @@ require('./middleware/passport.js')
 ============================================================================= */
 const routers = [
   require('./routes/homepage.js'),
-  require('./routes/app.js'),
   require('./routes/drivers.js'),
   require('./routes/users.js'),
   require('./routes/forgot-password.js'),
@@ -121,11 +120,16 @@ if (googleClientId && googleClientSecret && publicUrl) {
   routers.push(require('./routes/oauth.js'))
 }
 
+// Add all core routes to the baseUrl except for the */api/app route
 routers.forEach(function(router) {
   app.use(baseUrl, router)
 })
 
+// Add '*/api/app' route last and without baseUrl
+app.use(require('./routes/app.js'))
+
 // For any missing api route, return a 404
+// NOTE - this cannot be a general catch-all because it might be a valid non-api route from a front-end perspective
 app.use(baseUrl + '/api/', function(req, res) {
   console.log('reached catch all api route')
   res.sendStatus(404)


### PR DESCRIPTION
If using a baseUrl ('/sqlpad' for example), navigating to the url root threw an error, stemming from the initial api/app discovery fetch request failing. This prevented the page from loading.

A few fixes have been put in to catch potential issues. `*/api/app` route has been moved out of the baseUrl scope. The front end also ensure config is received from the request, and also renders the Alert component to allow alerting on any errors that may be encountered