### PR TITLE
Fix zero string QueryResult meta logic

### DIFF
--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -89,6 +89,8 @@ requireValidate('../drivers/vertica')
 function runQuery(query, connection) {
   const driver = drivers[connection.driver]
 
+  // TODO change runQuery implementations to return rows collection
+  // and remove dependency on QueryResult
   return driver.runQuery(query, connection).then(queryResult => {
     if (!queryResult instanceof QueryResult) {
       throw new Error(`${connection.driver}.runQuery() must return QueryResult`)
@@ -117,6 +119,7 @@ function runQuery(query, connection) {
   })
 }
 
+// TODO change testConnection to return boolean
 /**
  * Test connection passed in using the driver implementation
  * Returns QueryResult of test query

--- a/server/lib/getMeta.js
+++ b/server/lib/getMeta.js
@@ -1,0 +1,121 @@
+const _ = require('lodash')
+
+/**
+ * Derive whether value is a number number or number as a string
+ * If value is a string, it'll determine whether the string is numeric
+ * Zero-padded number strings are not considered numeric
+ * @param {*} value
+ */
+function isNumeric(value) {
+  if (_.isNumber(value)) {
+    return true
+  }
+  if (_.isString(value)) {
+    if (!isFinite(value)) {
+      return false
+    }
+    // str is a finite number, but not all number strings should be numbers
+    // If the string starts with 0, is more than 1 character, and does not have a period, it should stay a string
+    // It could be an account number for example
+    if (value[0] === '0' && value.length > 1 && value.indexOf('.') === -1) {
+      return false
+    }
+
+    return true
+  }
+  return false
+}
+
+/**
+ * Iterate over collection of rows and derive metadata
+ * @param {array<object>} rows
+ */
+module.exports = function getMeta(rows) {
+  const meta = {}
+
+  rows.forEach(row => {
+    _.forOwn(row, (value, key) => {
+      if (!meta[key]) {
+        meta[key] = {
+          datatype: null,
+          max: null,
+          min: null,
+          maxValueLength: 0
+        }
+      }
+
+      // if there is no value none of what follows will be helpful
+      if (value == null) {
+        return
+      }
+
+      // if we don't have a data type and we have a value yet lets try and figure it out
+      if (!meta[key].datatype) {
+        if (_.isDate(value)) {
+          meta[key].datatype = 'date'
+        } else if (isNumeric(value)) {
+          meta[key].datatype = 'number'
+        } else if (_.isString(value)) {
+          meta[key].datatype = 'string'
+        }
+      }
+
+      // if the datatype is number-like,
+      // we should check to see if it ever changes to a string
+      // this is hacky, but sometimes data will be
+      // a mix of number-like and strings that aren't number like
+      // in the event that we get some data that's NOT NUMBER LIKE,
+      // then we should *really* be recording this as string
+      if (
+        meta[key].datatype === 'number' &&
+        _.isString(value) &&
+        !isNumeric(value)
+      ) {
+        meta[key].datatype = 'string'
+      }
+
+      // For strings, get max length of the string for display purposes
+      if (meta[key].datatype === 'string' && _.isString(value)) {
+        if (meta[key].maxValueLength < value.length) {
+          meta[key].maxValueLength = value.length
+        }
+      }
+
+      // if we have a value and are dealing with a number or date, we should get min and max
+      if (meta[key].datatype === 'number' && isNumeric(value)) {
+        value = Number(value)
+        // if we haven't yet defined a max and this row contains a number
+        if (!meta[key].max) {
+          meta[key].max = value
+        } else if (value > meta[key].max) {
+          // otherwise this field in this row contains a number, and we should see if its bigger
+          meta[key].max = value
+        }
+        // then do the same thing for min
+        if (!meta[key].min) {
+          meta[key].min = value
+        } else if (value < meta[key].min) {
+          meta[key].min = value
+        }
+      }
+
+      if (meta[key].datatype === 'date' && _.isDate(value)) {
+        // if we haven't yet defined a max and this row contains a number
+        if (!meta[key].max) {
+          meta[key].max = value
+        } else if (value > meta[key].max) {
+          // otherwise this field in this row contains a number, and we should see if its bigger
+          meta[key].max = value
+        }
+        // then do the same thing for min
+        if (!meta[key].min) {
+          meta[key].min = value
+        } else if (value < meta[key].min) {
+          meta[key].min = value
+        }
+      }
+    })
+  })
+
+  return meta
+}

--- a/server/models/QueryResult.js
+++ b/server/models/QueryResult.js
@@ -5,12 +5,8 @@
     Anything that handles a query result (be it a cache file, grid, chart)
     should expect the data to be in this format
 */
-const _ = require('lodash')
 const uuid = require('uuid')
-
-function isNumberLike(n) {
-  return !isNaN(parseFloat(n)) && isFinite(n)
-}
+const getMeta = require('../lib/getMeta')
 
 function QueryResult() {
   this.id = uuid.v1()
@@ -18,7 +14,6 @@ function QueryResult() {
   this.startTime = null
   this.stopTime = null
   this.queryRunTime = null
-  this.processedInitialHeader = false
 
   // Array of field names
   this.fields = []
@@ -44,111 +39,21 @@ function QueryResult() {
   this.stopTime = undefined
 }
 
-QueryResult.prototype.finalize = function() {
+QueryResult.prototype.finalize = function finalize() {
   this.stopTime = new Date()
   this.queryRunTime = this.stopTime - this.startTime
+  this.meta = getMeta(this.rows)
+  this.fields = Object.keys(this.meta)
 }
 
-QueryResult.prototype.addRows = function QueryResultAddRows(rows) {
+QueryResult.prototype.addRows = function addRows(rows) {
   if (rows && rows.length) {
     rows.forEach(row => this.addRow(row))
   }
 }
 
-QueryResult.prototype.addRow = function QueryResultAddRow(row) {
+QueryResult.prototype.addRow = function addRow(row) {
   this.rows.push(row)
-  _.forOwn(row, (value, key) => {
-    // if this is first row added, record fields in fields array
-    if (!this.processedInitialHeader) {
-      this.fields.push(key)
-    }
-
-    if (!this.meta[key]) {
-      this.meta[key] = {
-        datatype: null,
-        max: null,
-        min: null,
-        maxValueLength: 0
-      }
-    }
-
-    // if there is no value none of what follows will be helpful
-    if (value == null) {
-      return
-    }
-
-    // if we don't have a data type and we have a value yet lets try and figure it out
-    if (!this.meta[key].datatype) {
-      if (_.isDate(value)) {
-        this.meta[key].datatype = 'date'
-      } else if (_.isNumber(value)) {
-        this.meta[key].datatype = 'number'
-      } else if (isNumberLike(value)) {
-        // BIGINT and aggregate results sometimes come in as strings depending on db driver
-        // if they contain a numeric value we want to treat them as a numeric
-        this.meta[key].datatype = 'number'
-      } else if (_.isString(value)) {
-        this.meta[key].datatype = 'string'
-        if (this.meta[key].maxValueLength < value.length) {
-          this.meta[key].maxValueLength = value.length
-        }
-      }
-    }
-
-    // if the datatype is number-like,
-    // we should check to see if it ever changes to a string
-    // this is hacky, but sometimes data will be
-    // a mix of number-like and strings that aren't number like
-    // in the event that we get some data that's NOT NUMBER LIKE,
-    // then we should *really* be recording this as string
-    // also - if first character is 0 revert back to string
-    if (this.meta[key].datatype === 'number' && _.isString(value)) {
-      if (!isNumberLike(value) || value[0] === '0') {
-        this.meta[key].datatype = 'string'
-        this.meta[key].max = null
-        this.meta[key].min = null
-      }
-    }
-
-    // if we have a value and are dealing with a number or date, we should get min and max
-    if (this.meta[key].datatype === 'number' && isNumberLike(value)) {
-      value = Number(value)
-      // if we haven't yet defined a max and this row contains a number
-      if (!this.meta[key].max) {
-        this.meta[key].max = value
-      } else if (value > this.meta[key].max) {
-        // otherwise this field in this row contains a number, and we should see if its bigger
-        this.meta[key].max = value
-      }
-      // then do the same thing for min
-      if (!this.meta[key].min) {
-        this.meta[key].min = value
-      } else if (value < this.meta[key].min) {
-        this.meta[key].min = value
-      }
-    }
-
-    if (this.meta[key].datatype === 'date' && _.isDate(value)) {
-      // if we haven't yet defined a max and this row contains a number
-      if (!this.meta[key].max) {
-        this.meta[key].max = value
-      } else if (value > this.meta[key].max) {
-        // otherwise this field in this row contains a number, and we should see if its bigger
-        this.meta[key].max = value
-      }
-      // then do the same thing for min
-      if (!this.meta[key].min) {
-        this.meta[key].min = value
-      } else if (value < this.meta[key].min) {
-        this.meta[key].min = value
-      }
-    }
-  })
-
-  // if we haven't processed the header yet we have now
-  if (!this.processedInitialHeader) {
-    this.processedInitialHeader = true
-  }
 }
 
 module.exports = QueryResult

--- a/server/test/lib/getMeta.js
+++ b/server/test/lib/getMeta.js
@@ -14,7 +14,8 @@ describe('lib/getMeta.js', function() {
         decimalString: null,
         number: null,
         string: null,
-        date: null
+        date: null,
+        numberString: null
       },
       {
         alwaysNull: null,
@@ -22,7 +23,8 @@ describe('lib/getMeta.js', function() {
         decimalString: '0.999',
         number: 30,
         string: 'abcdefg',
-        date: d2
+        date: d2,
+        numberString: 100
       },
       {
         alwaysNull: null,
@@ -30,7 +32,8 @@ describe('lib/getMeta.js', function() {
         decimalString: '0.111',
         number: 0,
         string: '0',
-        date: d1
+        date: d1,
+        numberString: 0
       },
       {
         alwaysNull: null,
@@ -38,7 +41,8 @@ describe('lib/getMeta.js', function() {
         decimalString: null,
         number: null,
         string: 'abc',
-        date: null
+        date: null,
+        numberString: null
       }
     ]
 
@@ -67,5 +71,9 @@ describe('lib/getMeta.js', function() {
     assert.equal(meta.date.datatype, 'date', 'date.datatype')
     assert.equal(meta.date.max.getTime(), d2.getTime(), 'date.max')
     assert.equal(meta.date.min.getTime(), d1.getTime(), 'date.min')
+
+    assert.equal(meta.numberString.datatype, 'number', 'numberString.datatype')
+    assert.equal(meta.numberString.max, 100, 'numberString.max')
+    assert.equal(meta.numberString.min, 0, 'numberString.min')
   })
 })

--- a/server/test/lib/getMeta.js
+++ b/server/test/lib/getMeta.js
@@ -1,0 +1,71 @@
+const assert = require('assert')
+const getMeta = require('../../lib/getMeta.js')
+
+const d1 = new Date()
+const d2 = new Date(new Date().getTime() + 60000)
+
+describe('lib/getMeta.js', function() {
+  it('returns expected results', function() {
+    const rows = [
+      // To ensure nulls are handled appropriately start and end with them
+      {
+        alwaysNull: null,
+        accountNumber: null,
+        decimalString: null,
+        number: null,
+        string: null,
+        date: null
+      },
+      {
+        alwaysNull: null,
+        accountNumber: '099999',
+        decimalString: '0.999',
+        number: 30,
+        string: 'abcdefg',
+        date: d2
+      },
+      {
+        alwaysNull: null,
+        accountNumber: '0111',
+        decimalString: '0.111',
+        number: 0,
+        string: '0',
+        date: d1
+      },
+      {
+        alwaysNull: null,
+        accountNumber: null,
+        decimalString: null,
+        number: null,
+        string: 'abc',
+        date: null
+      }
+    ]
+
+    const meta = getMeta(rows)
+
+    assert.equal(meta.alwaysNull.datatype, null, 'null')
+
+    assert.equal(meta.accountNumber.datatype, 'string', 'accountNumber')
+    assert.equal(
+      meta.accountNumber.maxValueLength,
+      6,
+      'accountNumber.maxValueLength'
+    )
+
+    assert.equal(meta.decimalString.datatype, 'number', 'decimalString')
+    assert.equal(meta.decimalString.max, 0.999, 'decimalString.max')
+    assert.equal(meta.decimalString.min, 0.111, 'decimalString.min')
+
+    assert.equal(meta.number.datatype, 'number', 'number.datatype')
+    assert.equal(meta.number.max, 30, 'number.max')
+    assert.equal(meta.number.min, 0, 'number.min')
+
+    assert.equal(meta.string.datatype, 'string', 'string.datatype')
+    assert.equal(meta.string.maxValueLength, 7, 'string.maxValueLength')
+
+    assert.equal(meta.date.datatype, 'date', 'date.datatype')
+    assert.equal(meta.date.max.getTime(), d2.getTime(), 'date.max')
+    assert.equal(meta.date.min.getTime(), d1.getTime(), 'date.min')
+  })
+})


### PR DESCRIPTION
A previous fix to ensure numeric strings with leading zeroes was causing '0' strings to be considered string type instead of number type. This fixes that, adds tests, and moves the meta functionality into a function