### PR TITLE
Fix postgres max rows failure (and add tests)

### DIFF
--- a/server/drivers/postgres/docker-compose.yml
+++ b/server/drivers/postgres/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:9.6-alpine
+    environment:
+      POSTGRES_USER: sqlpad
+      POSTGRES_DB: sqlpad
+    ports: 
+      - "5432:5432"

--- a/server/drivers/postgres/index.js
+++ b/server/drivers/postgres/index.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const pg = require('pg')
 const PgCursor = require('pg-cursor')
 const SocksConnection = require('socksjs')
-const { formatSchemaQueryResults } = require('./utils')
+const { formatSchemaQueryResults } = require('../utils')
 
 const id = 'postgres'
 const name = 'Postgres'
@@ -108,7 +108,14 @@ function runQuery(query, connection) {
             console.log('error closing pg-cursor:')
             console.log(err)
           }
-          client.end()
+          // Calling end() without setImmediate causes error within node-pg
+          setImmediate(() => {
+            client.end(error => {
+              if (error) {
+                console.error(error)
+              }
+            })
+          })
         })
       })
     })

--- a/server/drivers/postgres/test.js
+++ b/server/drivers/postgres/test.js
@@ -1,0 +1,44 @@
+const assert = require('assert')
+const postgres = require('./index.js')
+
+const connection = {
+  name: 'test postgres',
+  driver: 'postgres',
+  host: 'localhost',
+  database: 'sqlpad',
+  username: 'sqlpad',
+  password: 'sqlpad',
+  maxRows: 100
+}
+
+describe('drivers/postgres', function() {
+  it('tests connection', function() {
+    return postgres.testConnection(connection)
+  })
+
+  it('getSchema()', function() {
+    return postgres.getSchema(connection).then(schemaInfo => {
+      // Should probably create tables and validate them here
+      // For now this is a smoke test of sorts
+      assert(schemaInfo)
+    })
+  })
+
+  it('runQuery under limit', function() {
+    return postgres
+      .runQuery('SELECT * FROM generate_series(1, 10) gs;', connection)
+      .then(results => {
+        assert(!results.incomplete, 'not incomplete')
+        assert.equal(results.rows.length, 10, 'row length')
+      })
+  })
+
+  it('runQuery over limit', function() {
+    return postgres
+      .runQuery('SELECT * FROM generate_series(1, 9000) gs;', connection)
+      .then(results => {
+        assert(results.incomplete, 'incomplete')
+        assert.equal(results.rows.length, 100, 'row length')
+      })
+  })
+})

--- a/server/drivers/postgres/test.sh
+++ b/server/drivers/postgres/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker-compose down
+docker-compose up -d postgres
+sleep 5
+npx mocha ./test.js
+docker-compose down


### PR DESCRIPTION
Fixes #335 by adding a setImmediate around client.end(). There seems to be an order of operations issue with the async closing/ending between pg-pool and the node-pg client.

Postgres driver implementation is also moved into its own directory with docker-compose file and test files. Eventually other drivers will move out to this model to facilitate testing