### PR TITLE
Use cdn for bootstrap css/fonts (fixes missing icons with baseUrl)

### DIFF
--- a/client-js/index.js
+++ b/client-js/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App.js'
-import 'bootstrap/dist/css/bootstrap.css'
 import './css/react-select.css'
 import './css/s-alert-default.css'
 import './css/react-split-pane.css'

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SQLPad</title>
   <link rel="shortcut icon" href="/images/favicon.ico">
+  <!-- Latest compiled and minified bootstrap CSS -->
+  <!-- This cannot be included/compiled by webpack because of glyphicons font and baseUrl consideration -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+    crossorigin="anonymous">
   <!-- tauCharts css must be in a known path we can ref for image exports -->
   <link rel="stylesheet" href="/javascripts/vendor/tauCharts/tauCharts.min.css" type="text/css" />
 </head>


### PR DESCRIPTION
This fixes missing icons when using baseUrl.

Compiling bootstrap css via webpack wasn't taking the baseUrl into consideration for the glyphicons web font url references. It would be considered if the baseUrl is defined in the package.json via the project's homepage, but because the baseUrl can be set by the user after the site is compiled, this is not something that is easily addressed. 

For now this reverts back to using bootstrap cdn. 