### PR TITLE
Implement HANA maxRows handling

### DIFF
--- a/server/drivers/hdb/test.js
+++ b/server/drivers/hdb/test.js
@@ -59,7 +59,7 @@ describe('drivers/hdb', function() {
   })
 
   // TODO not yet implemented
-  it.skip('runQuery over limit', function() {
+  it('runQuery over limit', function() {
     const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
     return hdb
       .runQuery('SELECT * FROM test;', limitedConnection)


### PR DESCRIPTION
Updates HANA implementation to honor connection.maxRows by switching to the streaming resultSet mode. If number of rows exceeds the limit, the response is sent as is, and client is disconnected.