### PR TITLE
Sql editor updates

### DIFF
--- a/client-js/common/SqlEditor.js
+++ b/client-js/common/SqlEditor.js
@@ -32,6 +32,15 @@ class SqlEditor extends React.Component {
     }
   }
 
+  handleSelection = selection => {
+    const { onSelectionChange } = this.props
+    const { editor } = this
+    if (editor && editor.session) {
+      const selectedText = editor.session.getTextRange(selection.getRange())
+      onSelectionChange(selectedText)
+    }
+  }
+
   render() {
     const { config, onChange, readOnly, value, height } = this.props
 
@@ -49,6 +58,7 @@ class SqlEditor extends React.Component {
         mode="sql"
         name="query-ace-editor"
         onChange={onChange || noop}
+        onSelectionChange={this.handleSelection}
         showGutter={false}
         showPrintMargin={false}
         theme="sqlserver"
@@ -67,12 +77,14 @@ SqlEditor.propTypes = {
   config: PropTypes.object.isRequired,
   height: PropTypes.string,
   onChange: PropTypes.func,
+  onSelectionChange: PropTypes.func,
   readOnly: PropTypes.bool,
   value: PropTypes.string
 }
 
 SqlEditor.defaultProps = {
   height: '100%',
+  onSelectionChange: () => {},
   readOnly: false,
   value: ''
 }

--- a/client-js/queryEditor/QueryEditor.js
+++ b/client-js/queryEditor/QueryEditor.js
@@ -41,7 +41,8 @@ class QueryEditor extends React.Component {
     queryResult: undefined,
     runQueryStartTime: undefined,
     showModal: false,
-    showValidation: false
+    showValidation: false,
+    selectedText: ''
   }
 
   sqlpadTauChart = undefined
@@ -95,10 +96,7 @@ class QueryEditor extends React.Component {
   }
 
   runQuery = () => {
-    const { cacheKey, query } = this.state
-    const selectedText = this.editor.session.getTextRange(
-      this.editor.getSelectionRange()
-    )
+    const { cacheKey, query, selectedText } = this.state
     this.setState({
       isRunning: true,
       runQueryStartTime: new Date()
@@ -211,6 +209,10 @@ class QueryEditor extends React.Component {
 
   handleQueryTextChange = queryText =>
     this.setQueryState('queryText', queryText)
+
+  handleQuerySelectionChange = selectedText => {
+    this.setState({ selectedText })
+  }
 
   handleSaveImageClick = e => {
     if (this.sqlpadTauChart && this.sqlpadTauChart.chart) {
@@ -388,6 +390,7 @@ class QueryEditor extends React.Component {
                   ref={ref => {
                     this.editor = ref ? ref.editor : null
                   }}
+                  onSelectionChange={this.handleQuerySelectionChange}
                 />
                 <div>
                   <QueryResultHeader

--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,6 +3336,12 @@
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
+      "dev": true
+    },
     "diffie-hellman": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
@@ -11366,12 +11372,13 @@
       }
     },
     "react-ace": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.10.0.tgz",
-      "integrity": "sha512-aEK/XZCowP8IXq91e2DYqOtGhabk1bbjt+fyeW0UBcIkzDzP/RX/MeJKeyW7wsZcwElACVwyy9nnwXBTqgky3A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-6.1.0.tgz",
+      "integrity": "sha512-nK7hhWuW7oZVS93/aaZ7UwN2qpBOfAgyxqnzjqUIuU8bXo0KH+3Fkd5iV9auSbGmlN7SQfpBZLwozvAnX6GyVw==",
       "dev": true,
       "requires": {
         "brace": "0.11.1",
+        "diff-match-patch": "1.0.0",
         "lodash.get": "4.4.2",
         "lodash.isequal": "4.5.0",
         "prop-types": "15.6.1"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "prettier": "^1.12.1",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
-    "react-ace": "^5.10.0",
+    "react-ace": "^6.1.0",
     "react-bootstrap": "^0.32.1",
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "^16.3.2",


### PR DESCRIPTION
* Updates react-ace to 6.1
* Adds onSelectionChange to return selected query text on selection change

This started off as an attempt to fix weird query editor behavior where the SQL editor refuses input after executing the query with shortcut `command+return`

This issue seems to only be in Chrome. Firefox does not experience it... 