### PR TITLE
Fix query loading issue if connections load slowly (#369)

### DIFF
--- a/client-js/queryEditor/QueryEditor.js
+++ b/client-js/queryEditor/QueryEditor.js
@@ -61,17 +61,19 @@ class QueryEditor extends React.Component {
   }
 
   loadConnectionsFromServer = () => {
-    const { query } = this.state
     fetchJson('GET', '/api/connections/').then(json => {
       const { error, connections } = json
       if (error) {
         Alert.error(error)
       }
       // if only 1 connection auto-select it
+      const { query } = this.state
       if (connections.length === 1 && query) {
         query.connectionId = connections[0]._id
+        this.setState({ connections, query })
+      } else {
+        this.setState({ connections })
       }
-      this.setState({ connections, query })
     })
   }
 


### PR DESCRIPTION
There are two parts to this fix:

* Get the query from state after the "connections" ajax call has completed
* Only set the query back to state if it has been modified

The first part would probably be enough to fix this issue, but it seemed like it might be safer to include the second part too?
