### PR TITLE
"SQLPad aims to a SQL" → "SQLPad aims to be a SQL"

### DIFF
--- a/docs-source/content/_index.md
+++ b/docs-source/content/_index.md
@@ -168,8 +168,8 @@ draft: false
         <div class="eight columns">
             <h6 class="docs-header">Is SQLPad For Me?</h6>
             <p>
-                SQLPad aims to a SQL query environment with a focus on exploring and analyzing data via SQL,
-                and will likely not adopt a dashboard use case. 
+                SQLPad aims to be a SQL query environment with a focus on exploring and analyzing data via SQL,
+                and it will likely not adopt a dashboard use case. 
                 If you're looking for open-source dashboard software or something more advanced, 
                 check out <a href="http://redash.io/">Re:dash</a>, 
                 <a href="http://www.metabase.com/">Metabase</a>, 


### PR DESCRIPTION
Should I also make the same change [on the .html page in the doc](https://github.com/rickbergfalk/sqlpad/blob/f7b3856cc7935792006007ff6296107594657646/docs/index.html#L215) ?