### PR TITLE
Fix editor resize

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7053,6 +7053,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
+    "get-node-dimensions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+      "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
@@ -13880,6 +13885,32 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-measure": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.2.4.tgz",
+      "integrity": "sha512-gpZA4J8sKy1TzTfnOXiiTu01GV8B5OyfF9k7Owt38T6Xxlll19PBE13HKTtauEmDdJO5u4o3XcTiGqCw5wpfjw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "get-node-dimensions": "^1.2.1",
+        "prop-types": "^15.6.2",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+          "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
     },
     "react-router": {
       "version": "4.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "^16.8.4",
     "react-draggable": "^3.2.1",
+    "react-measure": "^2.2.4",
     "react-router-dom": "^4.2.2",
     "react-scripts": "^2.1.8",
     "react-split-pane": "^0.1.84",

--- a/client/src/common/SqlEditor.js
+++ b/client/src/common/SqlEditor.js
@@ -5,12 +5,20 @@ import 'brace/mode/sql'
 import 'brace/theme/sqlserver'
 import PropTypes from 'prop-types'
 import React from 'react'
+import Measure from 'react-measure'
 import AceEditor from 'react-ace'
 import AppContext from '../containers/AppContext'
 
 const noop = () => {}
 
 class SqlEditor extends React.Component {
+  state = {
+    dimensions: {
+      width: -1,
+      height: -1
+    }
+  }
+
   componentDidMount() {
     const { config, onChange } = this.props
     const editor = this.editor
@@ -44,41 +52,54 @@ class SqlEditor extends React.Component {
     }
   }
 
+  handleRef = ref => {
+    this.editor = ref ? ref.editor : null
+  }
+
   render() {
-    const { config, onChange, readOnly, value, height } = this.props
+    const { config, onChange, readOnly, value } = this.props
+    const { width, height } = this.state.dimensions
 
     if (this.editor && config.editorWordWrap) {
       this.editor.session.setUseWrapMode(true)
     }
 
     return (
-      <AceEditor
-        editorProps={{ $blockScrolling: Infinity }}
-        enableBasicAutocompletion
-        enableLiveAutocompletion
-        height={height}
-        highlightActiveLine={false}
-        mode="sql"
-        name="query-ace-editor"
-        onChange={onChange || noop}
-        onSelectionChange={this.handleSelection}
-        showGutter={false}
-        showPrintMargin={false}
-        theme="sqlserver"
-        readOnly={readOnly}
-        value={value}
-        width="100%"
-        ref={ref => {
-          this.editor = ref ? ref.editor : null
+      <Measure
+        bounds
+        onResize={contentRect => {
+          this.setState({ dimensions: contentRect.bounds })
         }}
-      />
+      >
+        {({ measureRef }) => (
+          <div ref={measureRef} className="h-100 w-100">
+            <AceEditor
+              editorProps={{ $blockScrolling: Infinity }}
+              enableBasicAutocompletion
+              enableLiveAutocompletion
+              height={height + 'px'}
+              highlightActiveLine={false}
+              mode="sql"
+              name="query-ace-editor"
+              onChange={onChange || noop}
+              onSelectionChange={this.handleSelection}
+              showGutter={false}
+              showPrintMargin={false}
+              theme="sqlserver"
+              readOnly={readOnly}
+              value={value}
+              width={width + 'px'}
+              ref={this.handleRef}
+            />
+          </div>
+        )}
+      </Measure>
     )
   }
 }
 
 SqlEditor.propTypes = {
   config: PropTypes.object.isRequired,
-  height: PropTypes.string,
   onChange: PropTypes.func,
   onSelectionChange: PropTypes.func,
   readOnly: PropTypes.bool,
@@ -86,7 +107,6 @@ SqlEditor.propTypes = {
 }
 
 SqlEditor.defaultProps = {
-  height: '100%',
   onSelectionChange: () => {},
   readOnly: false,
   value: ''

--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -306,9 +306,6 @@ class QueryEditor extends React.Component {
   }
 
   handleSqlPaneResize = () => {
-    if (this.editor) {
-      this.editor.resize()
-    }
     if (this.dataTable) {
       this.dataTable.handleResize()
     }
@@ -377,9 +374,6 @@ class QueryEditor extends React.Component {
                   config={config}
                   value={query.queryText}
                   onChange={this.handleQueryTextChange}
-                  ref={ref => {
-                    this.editor = ref ? ref.editor : null
-                  }}
                   onSelectionChange={this.handleQuerySelectionChange}
                 />
                 <div>

--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -305,12 +305,6 @@ class QueryEditor extends React.Component {
     this.formatQuery()
   }
 
-  handleSqlPaneResize = () => {
-    if (this.dataTable) {
-      this.dataTable.handleResize()
-    }
-  }
-
   handleVisPaneResize = () => {
     if (this.sqlpadTauChart && this.sqlpadTauChart.chart) {
       this.sqlpadTauChart.chart.resize()
@@ -360,7 +354,6 @@ class QueryEditor extends React.Component {
               minSize={150}
               defaultSize={280}
               maxSize={-100}
-              onChange={this.handleSqlPaneResize}
             >
               <SchemaSidebar {...this.props} />
               <SplitPane
@@ -368,7 +361,6 @@ class QueryEditor extends React.Component {
                 minSize={100}
                 defaultSize={'60%'}
                 maxSize={-100}
-                onChange={this.handleSqlPaneResize}
               >
                 <SqlEditor
                   config={config}
@@ -399,7 +391,6 @@ class QueryEditor extends React.Component {
                       isRunning={isRunning}
                       queryError={queryError}
                       queryResult={queryResult}
-                      ref={ref => (this.dataTable = ref)}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Use react-measure to calculate size and handle element resizes instead of passing resize functions via ref. This is more reacty and simplifies the components by containing intended behavior instead of pushing them up the component tree. 

Ref passing is still used for the chart since it is also exposing the export-to-png function for the image. This will be refactored once charting lib is updated