### PR TITLE
Bring semicolons back!

### DIFF
--- a/client/src/AboutContent.js
+++ b/client/src/AboutContent.js
@@ -1,9 +1,9 @@
-import PropTypes from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class AboutContent extends React.Component {
   render() {
-    const { version } = this.props
+    const { version } = this.props;
     return (
       <div>
         <p>
@@ -67,16 +67,16 @@ class AboutContent extends React.Component {
           </li>
         </ul>
       </div>
-    )
+    );
   }
 }
 
 AboutContent.propTypes = {
   version: PropTypes.string
-}
+};
 
 AboutContent.defaultProps = {
   version: ''
-}
+};
 
-export default AboutContent
+export default AboutContent;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,33 +1,33 @@
-import message from 'antd/lib/message'
-import React from 'react'
+import message from 'antd/lib/message';
+import React from 'react';
 import {
   BrowserRouter as Router,
   Redirect,
   Route,
   Switch
-} from 'react-router-dom'
-import Authenticated from './Authenticated'
-import ConfigurationView from './configuration/ConfigurationView'
-import ConnectionsStore from './connections/ConnectionsStore'
-import AppContext from './containers/AppContext'
-import ForgotPassword from './ForgotPassword.js'
-import NotFound from './NotFound.js'
-import PasswordReset from './PasswordReset.js'
-import PasswordResetRequested from './PasswordResetRequested.js'
-import QueriesView from './queries/QueriesView'
-import QueryChartOnly from './QueryChartOnly.js'
-import QueryEditorContainer from './queryEditor/QueryEditorContainer.js'
-import QueryTableOnly from './QueryTableOnly.js'
-import SignIn from './SignIn.js'
-import SignUp from './SignUp.js'
-import UsersView from './users/UsersView'
+} from 'react-router-dom';
+import Authenticated from './Authenticated';
+import ConfigurationView from './configuration/ConfigurationView';
+import ConnectionsStore from './connections/ConnectionsStore';
+import AppContext from './containers/AppContext';
+import ForgotPassword from './ForgotPassword.js';
+import NotFound from './NotFound.js';
+import PasswordReset from './PasswordReset.js';
+import PasswordResetRequested from './PasswordResetRequested.js';
+import QueriesView from './queries/QueriesView';
+import QueryChartOnly from './QueryChartOnly.js';
+import QueryEditorContainer from './queryEditor/QueryEditorContainer.js';
+import QueryTableOnly from './QueryTableOnly.js';
+import SignIn from './SignIn.js';
+import SignUp from './SignUp.js';
+import UsersView from './users/UsersView';
 
 // Configure message notification globally
 message.config({
   top: 60,
   duration: 2,
   maxCount: 3
-})
+});
 
 class App extends React.Component {
   renderRoutes(config) {
@@ -109,7 +109,7 @@ class App extends React.Component {
           </Switch>
         </div>
       </Router>
-    )
+    );
   }
 
   render() {
@@ -121,13 +121,13 @@ class App extends React.Component {
               <ConnectionsStore>
                 {this.renderRoutes(appContext.config)}
               </ConnectionsStore>
-            )
+            );
           }
-          return null
+          return null;
         }}
       </AppContext.Consumer>
-    )
+    );
   }
 }
 
-export default App
+export default App;

--- a/client/src/AppNav.js
+++ b/client/src/AppNav.js
@@ -1,44 +1,44 @@
-import Icon from 'antd/lib/icon'
-import Layout from 'antd/lib/layout'
-import Menu from 'antd/lib/menu'
-import Modal from 'antd/lib/modal'
-import PropTypes from 'prop-types'
-import React from 'react'
-import { Redirect, Route } from 'react-router-dom'
-import AboutContent from './AboutContent'
-import AppContext from './containers/AppContext'
-import fetchJson from './utilities/fetch-json.js'
+import Icon from 'antd/lib/icon';
+import Layout from 'antd/lib/layout';
+import Menu from 'antd/lib/menu';
+import Modal from 'antd/lib/modal';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import AboutContent from './AboutContent';
+import AppContext from './containers/AppContext';
+import fetchJson from './utilities/fetch-json.js';
 
-const { Content, Sider } = Layout
+const { Content, Sider } = Layout;
 
 class AppNav extends React.Component {
   state = {
     collapsed: true,
     redirect: false
-  }
+  };
 
   onCollapse = collapsed => {
-    this.setState({ collapsed })
-  }
+    this.setState({ collapsed });
+  };
 
   signout = () => {
     fetchJson('GET', '/api/signout').then(json => {
-      this.setState({ redirect: true })
-    })
-  }
+      this.setState({ redirect: true });
+    });
+  };
 
   render() {
-    const { redirect } = this.state
-    const { pageMenuItems } = this.props
+    const { redirect } = this.state;
+    const { pageMenuItems } = this.props;
 
     if (redirect) {
-      return <Redirect push to="/signin" />
+      return <Redirect push to="/signin" />;
     }
 
     return (
       <AppContext.Consumer>
         {appContext => {
-          const { currentUser, version } = appContext
+          const { currentUser, version } = appContext;
 
           return (
             <Layout style={{ minHeight: '100vh' }}>
@@ -62,7 +62,7 @@ class AppNav extends React.Component {
                         <Menu.Item
                           key="queries"
                           onClick={() => {
-                            history.push('/queries')
+                            history.push('/queries');
                           }}
                         >
                           <Icon type="file-text" />
@@ -71,7 +71,7 @@ class AppNav extends React.Component {
                         <Menu.Item
                           key="new-query"
                           onClick={() => {
-                            history.push('/queries/new')
+                            history.push('/queries/new');
                           }}
                         >
                           <Icon type="plus" />
@@ -88,7 +88,7 @@ class AppNav extends React.Component {
                           <Menu.Item
                             key="users"
                             onClick={() => {
-                              history.push('/users')
+                              history.push('/users');
                             }}
                           >
                             <Icon type="team" />
@@ -99,7 +99,7 @@ class AppNav extends React.Component {
                           <Menu.Item
                             key="configuration"
                             onClick={() => {
-                              history.push('/config-values')
+                              history.push('/config-values');
                             }}
                           >
                             <Icon type="setting" />
@@ -124,7 +124,7 @@ class AppNav extends React.Component {
                                   </div>
                                 ),
                                 onOk() {}
-                              })
+                              });
                             }}
                           >
                             <Icon type="exclamation-circle-o" />
@@ -144,7 +144,7 @@ class AppNav extends React.Component {
                                 />
                               ),
                               onOk() {}
-                            })
+                            });
                           }}
                         >
                           <Icon type="question-circle-o" />
@@ -163,15 +163,15 @@ class AppNav extends React.Component {
                 <Content className="flex w-100">{this.props.children}</Content>
               </Layout>
             </Layout>
-          )
+          );
         }}
       </AppContext.Consumer>
-    )
+    );
   }
 }
 
 AppNav.propTypes = {
   pageMenuItems: PropTypes.arrayOf(PropTypes.node)
-}
+};
 
-export default AppNav
+export default AppNav;

--- a/client/src/Authenticated.js
+++ b/client/src/Authenticated.js
@@ -1,35 +1,35 @@
-import PropTypes from 'prop-types'
-import React from 'react'
-import { Redirect } from 'react-router-dom'
-import AppContext from './containers/AppContext'
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import AppContext from './containers/AppContext';
 
 class Authenticated extends React.Component {
-  static contextType = AppContext
+  static contextType = AppContext;
 
   componentDidMount() {
-    const appContext = this.context
-    appContext.refreshAppContext()
+    const appContext = this.context;
+    appContext.refreshAppContext();
   }
 
   render() {
-    const appContext = this.context
-    const { admin, children } = this.props
-    const { currentUser } = appContext
+    const appContext = this.context;
+    const { admin, children } = this.props;
+    const { currentUser } = appContext;
 
     if (!currentUser) {
-      return <Redirect to={{ pathname: '/signin' }} />
+      return <Redirect to={{ pathname: '/signin' }} />;
     }
 
     if (admin && currentUser.role !== 'admin') {
-      return <Redirect to={{ pathname: '/queries' }} />
+      return <Redirect to={{ pathname: '/queries' }} />;
     }
 
-    return children
+    return children;
   }
 }
 
 Authenticated.propTypes = {
   admin: PropTypes.bool
-}
+};
 
-export default Authenticated
+export default Authenticated;

--- a/client/src/ForgotPassword.js
+++ b/client/src/ForgotPassword.js
@@ -1,34 +1,34 @@
-import React from 'react'
-import { Redirect } from 'react-router-dom'
-import fetchJson from './utilities/fetch-json.js'
-import message from 'antd/lib/message'
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import fetchJson from './utilities/fetch-json.js';
+import message from 'antd/lib/message';
 
 class ForgotPassword extends React.Component {
   state = {
     email: '',
     redirect: false
-  }
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Forgot Password'
+    document.title = 'SQLPad - Forgot Password';
   }
 
   onEmailChange = e => {
-    this.setState({ email: e.target.value })
-  }
+    this.setState({ email: e.target.value });
+  };
 
   resetPassword = e => {
-    e.preventDefault()
+    e.preventDefault();
     fetchJson('POST', '/api/forgot-password', this.state).then(json => {
-      if (json.error) return message.error(json.error)
-      this.setState({ redirect: true })
-    })
-  }
+      if (json.error) return message.error(json.error);
+      this.setState({ redirect: true });
+    });
+  };
 
   render() {
-    const { redirect } = this.state
+    const { redirect } = this.state;
     if (redirect) {
-      return <Redirect to="/password-reset" />
+      return <Redirect to="/password-reset" />;
     }
     return (
       <div className="pt5 measure center" style={{ width: '300px' }}>
@@ -47,8 +47,8 @@ class ForgotPassword extends React.Component {
           </button>
         </form>
       </div>
-    )
+    );
   }
 }
 
-export default ForgotPassword
+export default ForgotPassword;

--- a/client/src/NotFound.js
+++ b/client/src/NotFound.js
@@ -1,24 +1,24 @@
-import React from 'react'
-import AppNav from './AppNav.js'
-import FullscreenMessage from './common/FullscreenMessage.js'
-import AppContext from './containers/AppContext'
+import React from 'react';
+import AppNav from './AppNav.js';
+import FullscreenMessage from './common/FullscreenMessage.js';
+import AppContext from './containers/AppContext';
 
 export default () => {
   return (
     <AppContext.Consumer>
       {appContext => {
-        document.title = 'SQLPad - Not Found'
-        const { currentUser } = appContext
+        document.title = 'SQLPad - Not Found';
+        const { currentUser } = appContext;
 
         if (currentUser) {
           return (
             <AppNav>
               <FullscreenMessage>Not Found</FullscreenMessage>
             </AppNav>
-          )
+          );
         }
-        return <FullscreenMessage>Not Found</FullscreenMessage>
+        return <FullscreenMessage>Not Found</FullscreenMessage>;
       }}
     </AppContext.Consumer>
-  )
-}
+  );
+};

--- a/client/src/PasswordReset.js
+++ b/client/src/PasswordReset.js
@@ -1,9 +1,9 @@
-import Button from 'antd/lib/button'
-import Input from 'antd/lib/input'
-import message from 'antd/lib/message'
-import React from 'react'
-import { Redirect } from 'react-router-dom'
-import fetchJson from './utilities/fetch-json.js'
+import Button from 'antd/lib/button';
+import Input from 'antd/lib/input';
+import message from 'antd/lib/message';
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import fetchJson from './utilities/fetch-json.js';
 
 class PasswordReset extends React.Component {
   state = {
@@ -11,42 +11,42 @@ class PasswordReset extends React.Component {
     password: '',
     passwordConfirmation: '',
     redirect: false
-  }
+  };
 
   onEmailChange = e => {
-    this.setState({ email: e.target.value })
-  }
+    this.setState({ email: e.target.value });
+  };
 
   onPasswordChange = e => {
-    this.setState({ password: e.target.value })
-  }
+    this.setState({ password: e.target.value });
+  };
 
   onPasswordConfirmationChange = e => {
-    this.setState({ passwordConfirmation: e.target.value })
-  }
+    this.setState({ passwordConfirmation: e.target.value });
+  };
 
   resetPassword = e => {
-    e.preventDefault()
+    e.preventDefault();
     fetchJson(
       'POST',
       '/api/password-reset/' + this.props.passwordResetId,
       this.state
     ).then(json => {
       if (json.error) {
-        return message.error(json.error)
+        return message.error(json.error);
       }
-      this.setState({ redirect: true })
-    })
-  }
+      this.setState({ redirect: true });
+    });
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Password Reset'
+    document.title = 'SQLPad - Password Reset';
   }
 
   render() {
-    const { redirect } = this.state
+    const { redirect } = this.state;
     if (redirect) {
-      return <Redirect to="/" />
+      return <Redirect to="/" />;
     }
     return (
       <div className="pt5 measure center" style={{ width: '300px' }}>
@@ -81,8 +81,8 @@ class PasswordReset extends React.Component {
           </Button>
         </form>
       </div>
-    )
+    );
   }
 }
 
-export default PasswordReset
+export default PasswordReset;

--- a/client/src/PasswordResetRequested.js
+++ b/client/src/PasswordResetRequested.js
@@ -1,12 +1,12 @@
-import React from 'react'
-import FullscreenMessage from './common/FullscreenMessage.js'
+import React from 'react';
+import FullscreenMessage from './common/FullscreenMessage.js';
 
 export default props => {
-  document.title = 'SQLPad - Password Reset'
+  document.title = 'SQLPad - Password Reset';
   return (
     <FullscreenMessage>
       <p>Password reset requested.</p>
       <p>An email has been sent with further instruction.</p>
     </FullscreenMessage>
-  )
-}
+  );
+};

--- a/client/src/QueryChartOnly.js
+++ b/client/src/QueryChartOnly.js
@@ -1,68 +1,68 @@
-import PropTypes from 'prop-types'
-import React from 'react'
-import ExportButton from './common/ExportButton.js'
-import IncompleteDataNotification from './common/IncompleteDataNotification'
-import SqlpadTauChart from './common/SqlpadTauChart.js'
-import fetchJson from './utilities/fetch-json.js'
+import PropTypes from 'prop-types';
+import React from 'react';
+import ExportButton from './common/ExportButton.js';
+import IncompleteDataNotification from './common/IncompleteDataNotification';
+import SqlpadTauChart from './common/SqlpadTauChart.js';
+import fetchJson from './utilities/fetch-json.js';
 
 class QueryChartOnly extends React.Component {
   state = {
     isRunning: false,
     runQueryStartTime: undefined,
     queryResult: undefined
-  }
+  };
 
   runQuery = queryId => {
     this.setState({
       isRunning: true,
       runQueryStartTime: new Date()
-    })
+    });
     fetchJson('GET', '/api/queries/' + queryId)
       .then(json => {
-        if (json.error) console.error(json.error)
+        if (json.error) console.error(json.error);
         this.setState({
           query: json.query
-        })
+        });
       })
       .then(() => {
-        return fetchJson('GET', '/api/query-result/' + queryId)
+        return fetchJson('GET', '/api/query-result/' + queryId);
       })
       .then(json => {
-        if (json.error) console.error(json.error)
+        if (json.error) console.error(json.error);
         this.setState({
           isRunning: false,
           queryError: json.error,
           queryResult: json.queryResult
-        })
-      })
-  }
+        });
+      });
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad'
-    this.runQuery(this.props.queryId)
+    document.title = 'SQLPad';
+    this.runQuery(this.props.queryId);
   }
 
   onSaveImageClick = e => {
     if (this.sqlpadTauChart && this.sqlpadTauChart.chart) {
-      this.sqlpadTauChart.chart.fire('exportTo', 'png')
+      this.sqlpadTauChart.chart.fire('exportTo', 'png');
     }
-  }
+  };
 
   hasRows = () => {
-    var queryResult = this.state.queryResult
-    return !!(queryResult && queryResult.rows && queryResult.rows.length)
-  }
+    var queryResult = this.state.queryResult;
+    return !!(queryResult && queryResult.rows && queryResult.rows.length);
+  };
 
   isChartable = () => {
-    var pending = this.state.isRunning || this.state.queryError
-    return !pending && this.hasRows()
-  }
+    var pending = this.state.isRunning || this.state.queryError;
+    return !pending && this.hasRows();
+  };
 
   render() {
-    const { query, queryResult, queryError, isRunning } = this.state
+    const { query, queryResult, queryError, isRunning } = this.state;
 
-    const incomplete = queryResult ? queryResult.incomplete : false
-    const cacheKey = queryResult ? queryResult.cacheKey : null
+    const incomplete = queryResult ? queryResult.incomplete : false;
+    const cacheKey = queryResult ? queryResult.cacheKey : null;
 
     return (
       <div
@@ -87,17 +87,17 @@ class QueryChartOnly extends React.Component {
             isRunning={isRunning}
             renderChart={this.isChartable()}
             ref={ref => {
-              this.sqlpadTauChart = ref
+              this.sqlpadTauChart = ref;
             }}
           />
         </div>
       </div>
-    )
+    );
   }
 }
 
 QueryChartOnly.propTypes = {
   queryId: PropTypes.string.isRequired
-}
+};
 
-export default QueryChartOnly
+export default QueryChartOnly;

--- a/client/src/QueryTableOnly.js
+++ b/client/src/QueryTableOnly.js
@@ -1,45 +1,45 @@
-import PropTypes from 'prop-types'
-import React from 'react'
-import ExportButton from './common/ExportButton.js'
-import IncompleteDataNotification from './common/IncompleteDataNotification'
-import QueryResultDataTable from './common/QueryResultDataTable.js'
-import fetchJson from './utilities/fetch-json.js'
+import PropTypes from 'prop-types';
+import React from 'react';
+import ExportButton from './common/ExportButton.js';
+import IncompleteDataNotification from './common/IncompleteDataNotification';
+import QueryResultDataTable from './common/QueryResultDataTable.js';
+import fetchJson from './utilities/fetch-json.js';
 
 class QueryTableOnly extends React.Component {
   state = {
     isRunning: false,
     runQueryStartTime: undefined,
     queryResult: undefined
-  }
+  };
 
   runQuery = queryId => {
     this.setState({
       isRunning: true,
       runQueryStartTime: new Date()
-    })
+    });
     fetchJson('GET', '/api/queries/' + queryId)
       .then(json => {
-        if (json.error) console.error(json.error)
+        if (json.error) console.error(json.error);
         this.setState({
           query: json.query
-        })
+        });
       })
       .then(() => {
-        return fetchJson('GET', '/api/query-result/' + queryId)
+        return fetchJson('GET', '/api/query-result/' + queryId);
       })
       .then(json => {
-        if (json.error) console.error(json.error)
+        if (json.error) console.error(json.error);
         this.setState({
           isRunning: false,
           queryError: json.error,
           queryResult: json.queryResult
-        })
-      })
-  }
+        });
+      });
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad'
-    this.runQuery(this.props.queryId)
+    document.title = 'SQLPad';
+    this.runQuery(this.props.queryId);
   }
 
   render() {
@@ -50,10 +50,10 @@ class QueryTableOnly extends React.Component {
       queryResult,
       querySuccess,
       runQueryStartTime
-    } = this.state
+    } = this.state;
 
-    const incomplete = queryResult ? queryResult.incomplete : false
-    const cacheKey = queryResult ? queryResult.cacheKey : null
+    const incomplete = queryResult ? queryResult.incomplete : false;
+    const cacheKey = queryResult ? queryResult.cacheKey : null;
 
     return (
       <div
@@ -79,12 +79,12 @@ class QueryTableOnly extends React.Component {
           </div>
         </div>
       </div>
-    )
+    );
   }
 }
 
 QueryTableOnly.propTypes = {
   queryId: PropTypes.string.isRequired
-}
+};
 
-export default QueryTableOnly
+export default QueryTableOnly;

--- a/client/src/SignIn.js
+++ b/client/src/SignIn.js
@@ -1,55 +1,55 @@
-import Button from 'antd/lib/button'
-import Icon from 'antd/lib/icon'
-import Input from 'antd/lib/input'
-import message from 'antd/lib/message'
-import React from 'react'
-import { Link, Redirect } from 'react-router-dom'
-import AppContext from './containers/AppContext'
-import fetchJson from './utilities/fetch-json.js'
+import Button from 'antd/lib/button';
+import Icon from 'antd/lib/icon';
+import Input from 'antd/lib/input';
+import message from 'antd/lib/message';
+import React from 'react';
+import { Link, Redirect } from 'react-router-dom';
+import AppContext from './containers/AppContext';
+import fetchJson from './utilities/fetch-json.js';
 
 class SignIn extends React.Component {
-  static contextType = AppContext
+  static contextType = AppContext;
 
   state = {
     email: '',
     password: '',
     redirect: false
-  }
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Sign In'
+    document.title = 'SQLPad - Sign In';
   }
 
   onEmailChange = e => {
-    this.setState({ email: e.target.value })
-  }
+    this.setState({ email: e.target.value });
+  };
 
   onPasswordChange = e => {
-    this.setState({ password: e.target.value })
-  }
+    this.setState({ password: e.target.value });
+  };
 
   signIn = async e => {
-    const appContext = this.context
-    e.preventDefault()
+    const appContext = this.context;
+    e.preventDefault();
 
-    const json = await fetchJson('POST', '/api/signin', this.state)
+    const json = await fetchJson('POST', '/api/signin', this.state);
     if (json.error) {
-      return message.error('Username or password incorrect')
+      return message.error('Username or password incorrect');
     }
-    await appContext.refreshAppContext()
-    this.setState({ redirect: true })
-  }
+    await appContext.refreshAppContext();
+    this.setState({ redirect: true });
+  };
 
   render() {
-    const appContext = this.context
-    const { redirect } = this.state
+    const appContext = this.context;
+    const { redirect } = this.state;
     if (redirect) {
-      return <Redirect push to="/" />
+      return <Redirect push to="/" />;
     }
 
-    const { config, smtpConfigured, passport } = appContext
+    const { config, smtpConfigured, passport } = appContext;
     if (!config) {
-      return
+      return;
     }
 
     const localForm = (
@@ -89,7 +89,7 @@ class SignIn extends React.Component {
           ) : null}
         </div>
       </div>
-    )
+    );
 
     const googleForm = (
       <div>
@@ -100,7 +100,7 @@ class SignIn extends React.Component {
           </Button>
         </a>
       </div>
-    )
+    );
 
     return (
       <div className="pt5 measure center" style={{ width: '300px' }}>
@@ -108,8 +108,8 @@ class SignIn extends React.Component {
         {'local' in passport.strategies && localForm}
         {'google' in passport.strategies && googleForm}
       </div>
-    )
+    );
   }
 }
 
-export default SignIn
+export default SignIn;

--- a/client/src/SignUp.js
+++ b/client/src/SignUp.js
@@ -1,10 +1,10 @@
-import Button from 'antd/lib/button'
-import Input from 'antd/lib/input'
-import message from 'antd/lib/message'
-import React from 'react'
-import { Redirect } from 'react-router-dom'
-import AppContext from './containers/AppContext'
-import fetchJson from './utilities/fetch-json.js'
+import Button from 'antd/lib/button';
+import Input from 'antd/lib/input';
+import message from 'antd/lib/message';
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import AppContext from './containers/AppContext';
+import fetchJson from './utilities/fetch-json.js';
 
 class SignUp extends React.Component {
   state = {
@@ -12,43 +12,43 @@ class SignUp extends React.Component {
     password: '',
     passwordConfirmation: '',
     redirect: false
-  }
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Sign Up'
+    document.title = 'SQLPad - Sign Up';
   }
 
   onEmailChange = e => {
-    this.setState({ email: e.target.value })
-  }
+    this.setState({ email: e.target.value });
+  };
 
   onPasswordChange = e => {
-    this.setState({ password: e.target.value })
-  }
+    this.setState({ password: e.target.value });
+  };
 
   onPasswordConfirmationChange = e => {
-    this.setState({ passwordConfirmation: e.target.value })
-  }
+    this.setState({ passwordConfirmation: e.target.value });
+  };
 
   signUp = e => {
-    e.preventDefault()
+    e.preventDefault();
     fetchJson('POST', '/api/signup', this.state).then(json => {
-      if (json.error) return message.error(json.error)
-      this.setState({ redirect: true })
-    })
-  }
+      if (json.error) return message.error(json.error);
+      this.setState({ redirect: true });
+    });
+  };
 
   render() {
-    const { redirect } = this.state
+    const { redirect } = this.state;
 
     if (redirect) {
-      return <Redirect to="/" />
+      return <Redirect to="/" />;
     }
 
     return (
       <AppContext.Consumer>
         {appContext => {
-          const { adminRegistrationOpen } = appContext
+          const { adminRegistrationOpen } = appContext;
 
           return (
             <div className="pt5 measure center" style={{ width: '300px' }}>
@@ -94,11 +94,11 @@ class SignUp extends React.Component {
                 </Button>
               </form>
             </div>
-          )
+          );
         }}
       </AppContext.Consumer>
-    )
+    );
   }
 }
 
-export default SignUp
+export default SignUp;

--- a/client/src/common/Button.js
+++ b/client/src/common/Button.js
@@ -1,29 +1,29 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Button extends React.Component {
   render() {
-    const { children, className, onClick, primary } = this.props
-    let classNames = ''
+    const { children, className, onClick, primary } = this.props;
+    let classNames = '';
     if (primary) {
       classNames = `
         pa4 tc pv3
         bg-animate bg-blue hover-bg-dark-blue white
         ${className}
-      `
+      `;
     } else {
       classNames = `
         pa4 tc pv3
         dim ba b--dark-gray black
         ${className}
-      `
+      `;
     }
 
     return (
       <button className={classNames} onClick={onClick}>
         {children}
       </button>
-    )
+    );
   }
 }
 
@@ -31,11 +31,11 @@ Button.propTypes = {
   className: PropTypes.string,
   onClick: PropTypes.func,
   primary: PropTypes.bool
-}
+};
 
 Button.defaultProps = {
   className: '',
   onClick: () => {}
-}
+};
 
-export default Button
+export default Button;

--- a/client/src/common/DocumentTitle.js
+++ b/client/src/common/DocumentTitle.js
@@ -1,18 +1,18 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class DocumentTitle extends React.Component {
   componentDidMount() {
-    document.title = this.props.children
+    document.title = this.props.children;
   }
 
   render() {
-    return null
+    return null;
   }
 }
 
 DocumentTitle.propTypes = {
   children: PropTypes.string.isRequired
-}
+};
 
-export default DocumentTitle
+export default DocumentTitle;

--- a/client/src/common/EditableTagGroup.js
+++ b/client/src/common/EditableTagGroup.js
@@ -1,43 +1,43 @@
-import AutoComplete from 'antd/lib/auto-complete'
-import Icon from 'antd/lib/icon'
-import Tag from 'antd/lib/tag'
-import PropTypes from 'prop-types'
-import React from 'react'
+import AutoComplete from 'antd/lib/auto-complete';
+import Icon from 'antd/lib/icon';
+import Tag from 'antd/lib/tag';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class EditableTagGroup extends React.Component {
   state = {
     inputVisible: false,
     inputValue: ''
-  }
+  };
 
   handleClose = removedTag => {
-    const { onChange, tags } = this.props
-    const newTags = tags.filter(tag => tag !== removedTag)
-    onChange(newTags)
-  }
+    const { onChange, tags } = this.props;
+    const newTags = tags.filter(tag => tag !== removedTag);
+    onChange(newTags);
+  };
 
   showInput = () => {
     this.setState({ inputValue: '', inputVisible: true }, () =>
       this.input.focus()
-    )
-  }
+    );
+  };
 
   handleInputChange = value => {
-    this.setState({ inputValue: value })
-  }
+    this.setState({ inputValue: value });
+  };
 
   handleInputBlur = () => {
     this.setState({
       inputValue: '',
       inputVisible: false
-    })
-  }
+    });
+  };
 
   handleInputSelect = value => {
-    let { tags, onChange } = this.props
+    let { tags, onChange } = this.props;
 
     if (value && tags.indexOf(value) === -1) {
-      tags = [...tags, value]
+      tags = [...tags, value];
     }
 
     this.setState(
@@ -46,23 +46,24 @@ class EditableTagGroup extends React.Component {
         inputVisible: false
       },
       () => {
-        onChange(tags)
+        onChange(tags);
       }
-    )
-  }
+    );
+  };
 
-  saveInputRef = input => (this.input = input)
+  saveInputRef = input => (this.input = input);
 
   filterOption = (inputValue, option) =>
-    option.props.children.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
+    option.props.children.toUpperCase().indexOf(inputValue.toUpperCase()) !==
+    -1;
 
   render() {
-    const { tags, tagOptions } = this.props
-    const { inputVisible, inputValue } = this.state
+    const { tags, tagOptions } = this.props;
+    const { inputVisible, inputValue } = this.state;
 
-    const dataSource = tagOptions.slice()
+    const dataSource = tagOptions.slice();
     if (inputValue && dataSource.indexOf(inputValue) === -1) {
-      dataSource.unshift(inputValue)
+      dataSource.unshift(inputValue);
     }
 
     return (
@@ -76,7 +77,7 @@ class EditableTagGroup extends React.Component {
             >
               {tag}
             </Tag>
-          )
+          );
         })}
         {inputVisible && (
           <AutoComplete
@@ -101,7 +102,7 @@ class EditableTagGroup extends React.Component {
           </Tag>
         )}
       </div>
-    )
+    );
   }
 }
 
@@ -109,12 +110,12 @@ EditableTagGroup.propTypes = {
   onChange: PropTypes.func,
   tagOptions: PropTypes.array,
   tags: PropTypes.array
-}
+};
 
 EditableTagGroup.defaultProps = {
   onChange: () => {},
   tagOptions: [],
   tags: []
-}
+};
 
-export default EditableTagGroup
+export default EditableTagGroup;

--- a/client/src/common/ExportButton.js
+++ b/client/src/common/ExportButton.js
@@ -1,35 +1,35 @@
-import Button from 'antd/lib/button'
-import Dropdown from 'antd/lib/dropdown'
-import Icon from 'antd/lib/icon'
-import Menu from 'antd/lib/menu'
-import PropTypes from 'prop-types'
-import React from 'react'
-import AppContext from '../containers/AppContext'
+import Button from 'antd/lib/button';
+import Dropdown from 'antd/lib/dropdown';
+import Icon from 'antd/lib/icon';
+import Menu from 'antd/lib/menu';
+import PropTypes from 'prop-types';
+import React from 'react';
+import AppContext from '../containers/AppContext';
 
 class ExportButton extends React.Component {
   render() {
-    const { cacheKey, onSaveImageClick } = this.props
+    const { cacheKey, onSaveImageClick } = this.props;
 
     if (!cacheKey) {
-      return null
+      return null;
     }
 
     return (
       <AppContext.Consumer>
         {appContext => {
-          const { config } = appContext
+          const { config } = appContext;
           if (!config) {
-            return
+            return;
           }
 
-          const { baseUrl, allowCsvDownload } = config
+          const { baseUrl, allowCsvDownload } = config;
 
           if (!cacheKey || !allowCsvDownload) {
-            return
+            return;
           }
 
-          const csvDownloadLink = `${baseUrl}/download-results/${cacheKey}.csv`
-          const xlsxDownloadLink = `${baseUrl}/download-results/${cacheKey}.xlsx`
+          const csvDownloadLink = `${baseUrl}/download-results/${cacheKey}.csv`;
+          const xlsxDownloadLink = `${baseUrl}/download-results/${cacheKey}.xlsx`;
 
           return (
             <Dropdown
@@ -55,16 +55,16 @@ class ExportButton extends React.Component {
                 Export <Icon type="down" />
               </Button>
             </Dropdown>
-          )
+          );
         }}
       </AppContext.Consumer>
-    )
+    );
   }
 }
 
 ExportButton.propTypes = {
   cacheKey: PropTypes.string,
   onSaveImageClick: PropTypes.func
-}
+};
 
-export default ExportButton
+export default ExportButton;

--- a/client/src/common/FullscreenMessage.js
+++ b/client/src/common/FullscreenMessage.js
@@ -1,7 +1,7 @@
-import React from 'react'
+import React from 'react';
 
 export default props => (
   <div className=" w-100 flex f1 flex-column items-center justify-center">
     {props.children}
   </div>
-)
+);

--- a/client/src/common/Header.js
+++ b/client/src/common/Header.js
@@ -1,26 +1,26 @@
-import Layout from 'antd/lib/layout'
-import PropTypes from 'prop-types'
-import React from 'react'
+import Layout from 'antd/lib/layout';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class Header extends React.Component {
   render() {
-    const { children, title } = this.props
+    const { children, title } = this.props;
 
     return (
       <Layout.Header className="pr4 pl4">
         <div className="f3 fl white">{title}</div>
         <div className="fr">{children}</div>
       </Layout.Header>
-    )
+    );
   }
 }
 
 Header.propTypes = {
   title: PropTypes.string
-}
+};
 
 Header.defaultProps = {
   title: ''
-}
+};
 
-export default Header
+export default Header;

--- a/client/src/common/IncompleteDataNotification.js
+++ b/client/src/common/IncompleteDataNotification.js
@@ -1,11 +1,11 @@
-import Icon from 'antd/lib/icon'
-import Tooltip from 'antd/lib/tooltip'
-import PropTypes from 'prop-types'
-import React from 'react'
+import Icon from 'antd/lib/icon';
+import Tooltip from 'antd/lib/tooltip';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 class IncompleteDataNotification extends React.Component {
   render() {
-    const { incomplete } = this.props
+    const { incomplete } = this.props;
     if (incomplete === true) {
       return (
         <Tooltip
@@ -17,14 +17,14 @@ class IncompleteDataNotification extends React.Component {
             Incomplete
           </span>
         </Tooltip>
-      )
+      );
     }
-    return null
+    return null;
   }
 }
 
 IncompleteDataNotification.propTypes = {
   incomplete: PropTypes.bool
-}
+};
 
-export default IncompleteDataNotification
+export default IncompleteDataNotification;

--- a/client/src/common/QueryResultDataTable.js
+++ b/client/src/common/QueryResultDataTable.js
@@ -1,34 +1,34 @@
-import React from 'react'
-import { MultiGrid } from 'react-virtualized'
-import Draggable from 'react-draggable'
-import Measure from 'react-measure'
-import SpinKitCube from './SpinKitCube.js'
-import moment from 'moment'
-import 'react-virtualized/styles.css'
+import React from 'react';
+import { MultiGrid } from 'react-virtualized';
+import Draggable from 'react-draggable';
+import Measure from 'react-measure';
+import SpinKitCube from './SpinKitCube.js';
+import moment from 'moment';
+import 'react-virtualized/styles.css';
 
 const renderValue = (input, fieldMeta) => {
   if (input === null || input === undefined) {
-    return <em>null</em>
+    return <em>null</em>;
   } else if (input === true || input === false) {
-    return input.toString()
+    return input.toString();
   } else if (fieldMeta.datatype === 'date') {
-    return moment.utc(input).format('MM/DD/YYYY HH:mm:ss')
+    return moment.utc(input).format('MM/DD/YYYY HH:mm:ss');
   } else if (typeof input === 'object') {
-    return JSON.stringify(input, null, 2)
+    return JSON.stringify(input, null, 2);
   } else {
-    return input
+    return input;
   }
-}
+};
 
 const renderNumberBar = (value, fieldMeta) => {
   if (fieldMeta.datatype === 'number') {
-    const valueNumber = Number(value)
-    const range = fieldMeta.max - (fieldMeta.min < 0 ? fieldMeta.min : 0)
-    let left = 0
+    const valueNumber = Number(value);
+    const range = fieldMeta.max - (fieldMeta.min < 0 ? fieldMeta.min : 0);
+    let left = 0;
     if (fieldMeta.min < 0 && valueNumber < 0) {
-      left = (Math.abs(fieldMeta.min - valueNumber) / range) * 100 + '%'
+      left = (Math.abs(fieldMeta.min - valueNumber) / range) * 100 + '%';
     } else if (fieldMeta.min < 0 && valueNumber >= 0) {
-      left = (Math.abs(fieldMeta.min) / range) * 100 + '%'
+      left = (Math.abs(fieldMeta.min) / range) * 100 + '%';
     }
     const barStyle = {
       position: 'absolute',
@@ -37,10 +37,10 @@ const renderNumberBar = (value, fieldMeta) => {
       height: '2px',
       width: (Math.abs(valueNumber) / range) * 100 + '%',
       backgroundColor: '#555'
-    }
-    return <div style={barStyle} />
+    };
+    return <div style={barStyle} />;
   }
-}
+};
 
 // NOTE: PureComponent's shallow compare works for this component
 // because the isRunning prop will toggle with each query execution
@@ -52,38 +52,38 @@ class QueryResultDataTable extends React.PureComponent {
       height: -1
     },
     columnWidths: {}
-  }
+  };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const { queryResult } = nextProps
-    const { columnWidths } = prevState
+    const { queryResult } = nextProps;
+    const { columnWidths } = prevState;
 
     if (queryResult && queryResult.fields) {
       queryResult.fields.forEach(field => {
         if (!columnWidths[field]) {
-          const fieldMeta = queryResult.meta[field]
-          let valueLength = fieldMeta.maxValueLength
+          const fieldMeta = queryResult.meta[field];
+          let valueLength = fieldMeta.maxValueLength;
 
           if (field.length > valueLength) {
-            valueLength = field.length
+            valueLength = field.length;
           }
-          let columnWidthGuess = valueLength * 20
+          let columnWidthGuess = valueLength * 20;
           if (columnWidthGuess < 100) {
-            columnWidthGuess = 100
+            columnWidthGuess = 100;
           } else if (columnWidthGuess > 350) {
-            columnWidthGuess = 350
+            columnWidthGuess = 350;
           }
 
-          columnWidths[field] = columnWidthGuess
+          columnWidths[field] = columnWidthGuess;
         }
-      })
+      });
     }
-    return { columnWidths }
+    return { columnWidths };
   }
 
   headerCellRenderer = ({ columnIndex, key, style }) => {
-    const { queryResult } = this.props
-    const dataKey = queryResult.fields[columnIndex]
+    const { queryResult } = this.props;
+    const dataKey = queryResult.fields[columnIndex];
 
     // If dataKey is present this is an actual header to render
     if (dataKey) {
@@ -112,7 +112,7 @@ class QueryResultDataTable extends React.PureComponent {
             <span className="DragHandleIcon">⋮</span>
           </Draggable>
         </div>
-      )
+      );
     }
 
     // If this is a dummy header cell render an empty header cell
@@ -122,20 +122,20 @@ class QueryResultDataTable extends React.PureComponent {
         key={key}
         style={Object.assign({}, style, { lineHeight: '30px' })}
       />
-    )
-  }
+    );
+  };
 
   dataCellRenderer = ({ columnIndex, key, rowIndex, style }) => {
-    const { queryResult } = this.props
-    const dataKey = queryResult.fields[columnIndex]
-    const backgroundColor = rowIndex % 2 === 0 ? 'bg-near-white' : ''
+    const { queryResult } = this.props;
+    const dataKey = queryResult.fields[columnIndex];
+    const backgroundColor = rowIndex % 2 === 0 ? 'bg-near-white' : '';
 
     // If dataKey is present this is a real data cell to render
     if (dataKey) {
-      const fieldMeta = queryResult.meta[dataKey]
+      const fieldMeta = queryResult.meta[dataKey];
 
       // Account for extra row that was used for header row
-      const value = queryResult.rows[rowIndex - 1][dataKey]
+      const value = queryResult.rows[rowIndex - 1][dataKey];
 
       return (
         <div
@@ -146,7 +146,7 @@ class QueryResultDataTable extends React.PureComponent {
           {renderNumberBar(value, fieldMeta)}
           <div className="truncate">{renderValue(value, fieldMeta)}</div>
         </div>
-      )
+      );
     }
 
     // If no dataKey this is a dummy cell.
@@ -159,53 +159,53 @@ class QueryResultDataTable extends React.PureComponent {
       >
         <div className="truncate" />
       </div>
-    )
-  }
+    );
+  };
 
   cellRenderer = params => {
     if (params.rowIndex === 0) {
-      return this.headerCellRenderer(params)
+      return this.headerCellRenderer(params);
     }
-    return this.dataCellRenderer(params)
-  }
+    return this.dataCellRenderer(params);
+  };
 
   resizeColumn = ({ dataKey, deltaX }) => {
     this.setState(prevState => {
-      const prevWidths = prevState.columnWidths
-      const newWidth = prevWidths[dataKey] + deltaX
+      const prevWidths = prevState.columnWidths;
+      const newWidth = prevWidths[dataKey] + deltaX;
       return {
         columnWidths: {
           ...prevWidths,
           [dataKey]: newWidth > 100 ? newWidth : 100
         }
-      }
-    })
+      };
+    });
     if (this.ref) {
-      this.ref.recomputeGridSize()
+      this.ref.recomputeGridSize();
     }
-  }
+  };
 
   // NOTE
   // An empty dummy column is added to the grid for visual purposes
   // If dataKey was found this is a real column of data from the query result
   // If not, it's the dummy column at the end, and it should fill the rest of the grid width
   getColumnWidth = ({ index }) => {
-    const { columnWidths } = this.state
-    const { queryResult } = this.props
-    const dataKey = queryResult.fields[index]
-    const { width } = this.state.dimensions
+    const { columnWidths } = this.state;
+    const { queryResult } = this.props;
+    const dataKey = queryResult.fields[index];
+    const { width } = this.state.dimensions;
 
     if (dataKey) {
-      return columnWidths[dataKey]
+      return columnWidths[dataKey];
     }
 
     const totalWidthFilled = queryResult.fields
       .map(key => columnWidths[key])
-      .reduce((prev, curr) => prev + curr, 0)
+      .reduce((prev, curr) => prev + curr, 0);
 
-    const fakeColumnWidth = width - totalWidthFilled
-    return fakeColumnWidth < 10 ? 10 : fakeColumnWidth
-  }
+    const fakeColumnWidth = width - totalWidthFilled;
+    return fakeColumnWidth < 10 ? 10 : fakeColumnWidth;
+  };
 
   handleScrollBug = () => {
     // There's a strange bug when using Chrome.
@@ -214,16 +214,16 @@ class QueryResultDataTable extends React.PureComponent {
     // The frozen input behavior goes away if another element is given focus,
     // and then the user clicks on the Ace editor again.
     // Fortunately clearing focus on the focused element and refocusing it fixes this bug.
-    const element = document.activeElement
+    const element = document.activeElement;
     if (element) {
-      element.blur()
-      element.focus()
+      element.blur();
+      element.focus();
     }
-  }
+  };
 
   render() {
-    const { isRunning, queryError, queryResult } = this.props
-    const { height, width } = this.state.dimensions
+    const { isRunning, queryError, queryResult } = this.props;
+    const { height, width } = this.state.dimensions;
 
     if (isRunning) {
       return (
@@ -233,7 +233,7 @@ class QueryResultDataTable extends React.PureComponent {
         >
           <SpinKitCube />
         </div>
-      )
+      );
     }
 
     if (queryError) {
@@ -244,20 +244,20 @@ class QueryResultDataTable extends React.PureComponent {
         >
           {queryError}
         </div>
-      )
+      );
     }
 
     if (queryResult && queryResult.rows) {
       // Add extra row to account for header row
-      const rowCount = queryResult.rows.length + 1
+      const rowCount = queryResult.rows.length + 1;
       // Add extra column to fill remaining grid width if necessary
-      const columnCount = queryResult.fields.length + 1
+      const columnCount = queryResult.fields.length + 1;
 
       return (
         <Measure
           bounds
           onResize={contentRect => {
-            this.setState({ dimensions: contentRect.bounds })
+            this.setState({ dimensions: contentRect.bounds });
           }}
         >
           {({ measureRef }) => (
@@ -281,11 +281,11 @@ class QueryResultDataTable extends React.PureComponent {
             </div>
           )}
         </Measure>
-      )
+      );
     }
 
-    return <div id="result-grid" className="aspect-ratio--object" />
+    return <div id="result-grid" className="aspect-ratio--object" />;
   }
 }
 
-export default QueryResultDataTable
+export default QueryResultDataTable;

--- a/client/src/common/SecondsTimer.js
+++ b/client/src/common/SecondsTimer.js
@@ -1,34 +1,34 @@
-import React from 'react'
+import React from 'react';
 
 class SecondsTimer extends React.Component {
   state = {
     runSeconds: 0
-  }
+  };
 
-  _mounted = false
+  _mounted = false;
 
   timer = () => {
     if (this._mounted) {
-      var now = new Date()
+      var now = new Date();
       this.setState({
         runSeconds: ((now - this.props.startTime) / 1000).toFixed(0)
-      })
-      setTimeout(this.timer, 33)
+      });
+      setTimeout(this.timer, 33);
     }
-  }
+  };
 
   componentDidMount() {
-    this._mounted = true
-    this.timer()
+    this._mounted = true;
+    this.timer();
   }
 
   componentWillUnmount() {
-    this._mounted = false
+    this._mounted = false;
   }
 
   render() {
-    return <span>{this.state.runSeconds}</span>
+    return <span>{this.state.runSeconds}</span>;
   }
 }
 
-export default SecondsTimer
+export default SecondsTimer;

--- a/client/src/common/Sidebar.js
+++ b/client/src/common/Sidebar.js
@@ -1,7 +1,7 @@
-import React from 'react'
+import React from 'react';
 
 export default props => (
   <div className="flex flex-column h-100 overflow-x-hidden overflow-y-auto">
     {props.children}
   </div>
-)
+);

--- a/client/src/common/SidebarBody.js
+++ b/client/src/common/SidebarBody.js
@@ -1,7 +1,7 @@
-import React from 'react'
+import React from 'react';
 
 export default props => (
   <div className="flex-auto pa2 overflow-x-hidden overflow-y-auto">
     {props.children}
   </div>
-)
+);

--- a/client/src/common/SpinKitCube.js
+++ b/client/src/common/SpinKitCube.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import './SpinKitCube.css'
+import React from 'react';
+import './SpinKitCube.css';
 
 // http://tobiasahlin.com/spinkit/
 export default () => (
@@ -14,4 +14,4 @@ export default () => (
     <div className="sk-cube sk-cube8" />
     <div className="sk-cube sk-cube9" />
   </div>
-)
+);

--- a/client/src/common/SqlEditor.js
+++ b/client/src/common/SqlEditor.js
@@ -1,15 +1,15 @@
 // NOTE this import 'brace' must occur before the importing of brace extensions
-import 'brace'
-import 'brace/ext/searchbox'
-import 'brace/mode/sql'
-import 'brace/theme/sqlserver'
-import PropTypes from 'prop-types'
-import React from 'react'
-import Measure from 'react-measure'
-import AceEditor from 'react-ace'
-import AppContext from '../containers/AppContext'
+import 'brace';
+import 'brace/ext/searchbox';
+import 'brace/mode/sql';
+import 'brace/theme/sqlserver';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Measure from 'react-measure';
+import AceEditor from 'react-ace';
+import AppContext from '../containers/AppContext';
 
-const noop = () => {}
+const noop = () => {};
 
 class SqlEditor extends React.Component {
   state = {
@@ -17,14 +17,14 @@ class SqlEditor extends React.Component {
       width: -1,
       height: -1
     }
-  }
+  };
 
   componentDidMount() {
-    const { config, onChange } = this.props
-    const editor = this.editor
+    const { config, onChange } = this.props;
+    const editor = this.editor;
 
     if (editor && onChange) {
-      editor.focus()
+      editor.focus();
 
       // augment the built-in behavior of liveAutocomplete
       // built-in behavior only starts autocomplete when at least 1 character has been typed
@@ -33,42 +33,42 @@ class SqlEditor extends React.Component {
       editor.commands.on('afterExec', e => {
         if (e.command.name === 'insertstring' && /^[\w.]$/.test(e.args)) {
           if (e.args === '.') {
-            editor.execCommand('startAutocomplete')
+            editor.execCommand('startAutocomplete');
           }
         }
-      })
+      });
       if (config.editorWordWrap) {
-        editor.session.setUseWrapMode(true)
+        editor.session.setUseWrapMode(true);
       }
     }
   }
 
   handleSelection = selection => {
-    const { onSelectionChange } = this.props
-    const { editor } = this
+    const { onSelectionChange } = this.props;
+    const { editor } = this;
     if (editor && editor.session) {
-      const selectedText = editor.session.getTextRange(selection.getRange())
-      onSelectionChange(selectedText)
+      const selectedText = editor.session.getTextRange(selection.getRange());
+      onSelectionChange(selectedText);
     }
-  }
+  };
 
   handleRef = ref => {
-    this.editor = ref ? ref.editor : null
-  }
+    this.editor = ref ? ref.editor : null;
+  };
 
   render() {
-    const { config, onChange, readOnly, value } = this.props
-    const { width, height } = this.state.dimensions
+    const { config, onChange, readOnly, value } = this.props;
+    const { width, height } = this.state.dimensions;
 
     if (this.editor && config.editorWordWrap) {
-      this.editor.session.setUseWrapMode(true)
+      this.editor.session.setUseWrapMode(true);
     }
 
     return (
       <Measure
         bounds
         onResize={contentRect => {
-          this.setState({ dimensions: contentRect.bounds })
+          this.setState({ dimensions: contentRect.bounds });
         }}
       >
         {({ measureRef }) => (
@@ -94,7 +94,7 @@ class SqlEditor extends React.Component {
           </div>
         )}
       </Measure>
-    )
+    );
   }
 }
 
@@ -104,24 +104,24 @@ SqlEditor.propTypes = {
   onSelectionChange: PropTypes.func,
   readOnly: PropTypes.bool,
   value: PropTypes.string
-}
+};
 
 SqlEditor.defaultProps = {
   onSelectionChange: () => {},
   readOnly: false,
   value: ''
-}
+};
 
 class SqlEditorContainer extends React.Component {
   render() {
     return (
       <AppContext.Consumer>
         {appContext => {
-          return <SqlEditor {...this.props} config={appContext.config} />
+          return <SqlEditor {...this.props} config={appContext.config} />;
         }}
       </AppContext.Consumer>
-    )
+    );
   }
 }
 
-export default SqlEditorContainer
+export default SqlEditorContainer;

--- a/client/src/common/SqlpadTauChart.js
+++ b/client/src/common/SqlpadTauChart.js
@@ -1,82 +1,82 @@
-import message from 'antd/lib/message'
-import 'd3'
-import PropTypes from 'prop-types'
-import React from 'react'
-import { Chart } from 'taucharts'
-import exportTo from 'taucharts/build/development/plugins/tauCharts.export'
-import legend from 'taucharts/build/development/plugins/tauCharts.legend'
-import quickFilter from 'taucharts/build/development/plugins/tauCharts.quick-filter'
-import tooltip from 'taucharts/build/development/plugins/tauCharts.tooltip'
-import tcTrendline from 'taucharts/build/development/plugins/tauCharts.trendline'
-import chartDefinitions from '../utilities/chartDefinitions.js'
-import SpinKitCube from './SpinKitCube.js'
+import message from 'antd/lib/message';
+import 'd3';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Chart } from 'taucharts';
+import exportTo from 'taucharts/build/development/plugins/tauCharts.export';
+import legend from 'taucharts/build/development/plugins/tauCharts.legend';
+import quickFilter from 'taucharts/build/development/plugins/tauCharts.quick-filter';
+import tooltip from 'taucharts/build/development/plugins/tauCharts.tooltip';
+import tcTrendline from 'taucharts/build/development/plugins/tauCharts.trendline';
+import chartDefinitions from '../utilities/chartDefinitions.js';
+import SpinKitCube from './SpinKitCube.js';
 
 class SqlpadTauChart extends React.Component {
-  displayName = 'SqlpadTauChart'
+  displayName = 'SqlpadTauChart';
 
   componentDidUpdate(prevProps) {
-    const { isRunning, queryError, renderChart } = this.props
+    const { isRunning, queryError, renderChart } = this.props;
     if (isRunning || queryError) {
-      this.destroyChart()
+      this.destroyChart();
     } else if (renderChart && !this.chart) {
-      this.renderChart()
+      this.renderChart();
     }
   }
 
-  chart = undefined
+  chart = undefined;
 
   destroyChart = () => {
     if (this.chart) {
-      this.chart.destroy()
-      this.chart = null
+      this.chart.destroy();
+      this.chart = null;
     }
-  }
+  };
 
   getUnmetFields = (chartType, selectedFieldMap) => {
     const chartDefinition = chartDefinitions.find(
       def => def.chartType === chartType
-    )
+    );
     if (!chartDefinition) {
-      throw new Error(`Unknown chartType ${chartType}`)
+      throw new Error(`Unknown chartType ${chartType}`);
     }
-    const unmetRequiredFields = []
+    const unmetRequiredFields = [];
 
     chartDefinition.fields.forEach(field => {
       if (field.required && !selectedFieldMap[field.fieldId]) {
-        unmetRequiredFields.push(field)
+        unmetRequiredFields.push(field);
       }
-    })
+    });
 
-    return unmetRequiredFields
-  }
+    return unmetRequiredFields;
+  };
 
   renderChart = rerender => {
-    const { queryResult, query } = this.props
+    const { queryResult, query } = this.props;
     // This is invoked during following:
     //  - Vis tab enter
     //  - Visualize button press (forces rerender)
     //  - new data arrival
-    const meta = queryResult ? queryResult.meta : {}
-    let dataRows = queryResult ? queryResult.rows : []
-    const chartType = query.chartConfiguration.chartType
-    const selectedFields = query.chartConfiguration.fields
+    const meta = queryResult ? queryResult.meta : {};
+    let dataRows = queryResult ? queryResult.rows : [];
+    const chartType = query.chartConfiguration.chartType;
+    const selectedFields = query.chartConfiguration.fields;
 
     const chartDefinition = chartDefinitions.find(
       def => def.chartType === chartType
-    )
+    );
 
     if (rerender || !dataRows.length || !chartDefinition) {
-      this.destroyChart()
+      this.destroyChart();
     }
 
     // If there's no data just exit the chart render
     if (!dataRows.length) {
-      return
+      return;
     }
 
     // if there's no chart definition exit the render
     if (!chartDefinition) {
-      return
+      return;
     }
 
     const chartConfig = {
@@ -100,21 +100,21 @@ class SqlpadTauChart extends React.Component {
         handleRenderingErrors: true,
         utcTime: true
       }
-    }
+    };
 
     // loop through data rows and convert types as needed
     dataRows = dataRows.map(row => {
-      const newRow = {}
+      const newRow = {};
       Object.keys(row).forEach(col => {
-        const datatype = queryResult.meta[col].datatype
+        const datatype = queryResult.meta[col].datatype;
         if (datatype === 'date') {
-          newRow[col] = new Date(row[col])
+          newRow[col] = new Date(row[col]);
         } else if (datatype === 'number') {
-          newRow[col] = Number(row[col])
+          newRow[col] = Number(row[col]);
         } else {
-          newRow[col] = row[col]
+          newRow[col] = row[col];
         }
-      })
+      });
 
       // HACK -
       // Facets need to be a dimension, not a measure.
@@ -123,16 +123,16 @@ class SqlpadTauChart extends React.Component {
       // to trick tauCharts into thinking its a dimension
       const forceDimensionFields = chartDefinition.fields.filter(
         field => field.forceDimension === true
-      )
+      );
       forceDimensionFields.forEach(fieldDefinition => {
-        const col = selectedFields[fieldDefinition.fieldId]
-        const colDatatype = meta[col] ? meta[col].datatype : null
+        const col = selectedFields[fieldDefinition.fieldId];
+        const colDatatype = meta[col] ? meta[col].datatype : null;
         if (col && colDatatype === 'number' && newRow[col]) {
-          newRow[col] = newRow[col].toString()
+          newRow[col] = newRow[col].toString();
         }
-      })
-      return newRow
-    })
+      });
+      return newRow;
+    });
 
     // Some chartConfiguration.fields may reference columns that no longer exist
     // Remove them from a copy of chartConfigurationFields
@@ -142,23 +142,23 @@ class SqlpadTauChart extends React.Component {
     ).reduce((fieldsMap, field) => {
       const fieldDefinition = chartDefinition.fields.find(
         f => f.fieldId === field
-      )
-      const value = query.chartConfiguration.fields[field]
+      );
+      const value = query.chartConfiguration.fields[field];
 
       if (fieldDefinition && fieldDefinition.inputType !== 'field-dropdown') {
-        fieldsMap[field] = value
+        fieldsMap[field] = value;
       } else if (meta[value]) {
-        fieldsMap[field] = value
+        fieldsMap[field] = value;
       }
-      return fieldsMap
-    }, {})
+      return fieldsMap;
+    }, {});
 
     // Now that non-existing columns are removed from the configuration fields
     // Validate that the chart required fields are provided
     const unmetFields = this.getUnmetFields(
       chartType,
       cleanedChartConfigurationFields
-    )
+    );
 
     if (unmetFields.length) {
       // if rerender is true, a render was explicitly requested by user clicking the vis button
@@ -166,9 +166,9 @@ class SqlpadTauChart extends React.Component {
       if (rerender) {
         message.error(
           'Unmet required fields: ' + unmetFields.map(f => f.label).join(', ')
-        )
+        );
       }
-      return
+      return;
     }
 
     const {
@@ -187,141 +187,141 @@ class SqlpadTauChart extends React.Component {
       barlabel,
       labelFacet,
       color
-    } = cleanedChartConfigurationFields
+    } = cleanedChartConfigurationFields;
 
     switch (chartType) {
       case 'line':
-        chartConfig.x = [x]
+        chartConfig.x = [x];
         if (xFacet) {
-          chartConfig.x.unshift(xFacet)
+          chartConfig.x.unshift(xFacet);
         }
-        chartConfig.y = [y]
+        chartConfig.y = [y];
         if (yFacet) {
-          chartConfig.y.unshift(yFacet)
+          chartConfig.y.unshift(yFacet);
         }
         if (filter) {
-          chartConfig.plugins.push(quickFilter())
+          chartConfig.plugins.push(quickFilter());
         }
         if (trendline) {
-          chartConfig.plugins.push(tcTrendline())
+          chartConfig.plugins.push(tcTrendline());
         }
         if (split) {
-          chartConfig.color = split
+          chartConfig.color = split;
         }
         if (size) {
-          chartConfig.size = size
+          chartConfig.size = size;
         }
         if (yMin || yMax) {
           chartConfig.guide = {
             y: { autoScale: false }
-          }
+          };
           if (yMin) {
-            chartConfig.guide.y.min = Number(yMin)
+            chartConfig.guide.y.min = Number(yMin);
           }
           if (yMax) {
-            chartConfig.guide.y.max = Number(yMax)
+            chartConfig.guide.y.max = Number(yMax);
           }
         }
-        break
+        break;
 
       case 'bar':
-        chartConfig.x = [barvalue]
+        chartConfig.x = [barvalue];
         if (valueFacet) {
-          chartConfig.x.unshift(valueFacet)
+          chartConfig.x.unshift(valueFacet);
         }
-        chartConfig.y = [barlabel]
+        chartConfig.y = [barlabel];
         if (labelFacet) {
-          chartConfig.y.unshift(labelFacet)
+          chartConfig.y.unshift(labelFacet);
         }
-        break
+        break;
 
       case 'verticalbar':
-        chartConfig.y = [barvalue]
+        chartConfig.y = [barvalue];
         if (valueFacet) {
-          chartConfig.y.unshift(valueFacet)
+          chartConfig.y.unshift(valueFacet);
         }
-        chartConfig.x = [barlabel]
+        chartConfig.x = [barlabel];
         if (labelFacet) {
-          chartConfig.x.unshift(labelFacet)
+          chartConfig.x.unshift(labelFacet);
         }
-        break
+        break;
 
       case 'stacked-bar-horizontal':
-        chartConfig.x = [barvalue]
+        chartConfig.x = [barvalue];
         if (valueFacet) {
-          chartConfig.x.unshift(valueFacet)
+          chartConfig.x.unshift(valueFacet);
         }
-        chartConfig.y = [barlabel]
+        chartConfig.y = [barlabel];
         if (labelFacet) {
-          chartConfig.y.unshift(labelFacet)
+          chartConfig.y.unshift(labelFacet);
         }
         if (color) {
-          chartConfig.color = color
+          chartConfig.color = color;
         }
-        break
+        break;
 
       case 'stacked-bar-vertical':
-        chartConfig.y = [barvalue]
+        chartConfig.y = [barvalue];
         if (valueFacet) {
-          chartConfig.y.unshift(valueFacet)
+          chartConfig.y.unshift(valueFacet);
         }
-        chartConfig.x = [barlabel]
+        chartConfig.x = [barlabel];
         if (labelFacet) {
-          chartConfig.x.unshift(labelFacet)
+          chartConfig.x.unshift(labelFacet);
         }
         if (color) {
-          chartConfig.color = color
+          chartConfig.color = color;
         }
-        break
+        break;
 
       case 'bubble':
-        chartConfig.x = [x]
+        chartConfig.x = [x];
         if (xFacet) {
-          chartConfig.x.unshift(xFacet)
+          chartConfig.x.unshift(xFacet);
         }
-        chartConfig.y = [y]
+        chartConfig.y = [y];
         if (yFacet) {
-          chartConfig.y.unshift(yFacet)
+          chartConfig.y.unshift(yFacet);
         }
         if (filter) {
-          chartConfig.plugins.push(quickFilter())
+          chartConfig.plugins.push(quickFilter());
         }
         if (trendline) {
-          chartConfig.plugins.push(tcTrendline())
+          chartConfig.plugins.push(tcTrendline());
         }
         if (size) {
-          chartConfig.size = size
+          chartConfig.size = size;
         }
         if (color) {
-          chartConfig.color = color
+          chartConfig.color = color;
         }
-        break
+        break;
 
       default:
-        console.error('unknown chart type')
+        console.error('unknown chart type');
     }
 
     // Add data to chart chartConfig
-    chartConfig.data = dataRows
+    chartConfig.data = dataRows;
 
     if (!this.chart) {
-      this.chart = new Chart(chartConfig)
-      this.chart.renderTo('#chart')
+      this.chart = new Chart(chartConfig);
+      this.chart.renderTo('#chart');
     } else {
-      this.chart.setData(dataRows)
+      this.chart.setData(dataRows);
     }
-  }
+  };
 
   setData = chartData => {
-    this.chart.setData(chartData)
-  }
+    this.chart.setData(chartData);
+  };
 
   componentWillUnmount() {
-    this.destroyChart()
+    this.destroyChart();
   }
 
   render() {
-    const { isRunning, queryError } = this.props
+    const { isRunning, queryError } = this.props;
     if (isRunning) {
       return (
         <div
@@ -330,7 +330,7 @@ class SqlpadTauChart extends React.Component {
         >
           <SpinKitCube />
         </div>
-      )
+      );
     }
     if (queryError) {
       return (
@@ -340,9 +340,9 @@ class SqlpadTauChart extends React.Component {
         >
           {queryError}
         </div>
-      )
+      );
     }
-    return <div id="chart" className="flex h-100 w-100 pa3" />
+    return <div id="chart" className="flex h-100 w-100 pa3" />;
   }
 }
 
@@ -352,6 +352,6 @@ SqlpadTauChart.propTypes = {
   queryError: PropTypes.string,
   queryResult: PropTypes.object,
   renderChart: PropTypes.bool
-}
+};
 
-export default SqlpadTauChart
+export default SqlpadTauChart;

--- a/client/src/configuration/CheckListItem.js
+++ b/client/src/configuration/CheckListItem.js
@@ -1,26 +1,26 @@
-import React from 'react'
-import Icon from 'antd/lib/icon'
+import React from 'react';
+import Icon from 'antd/lib/icon';
 
 const CheckListItem = props => {
   if (!props.configKey || !props.configItems || !props.configItems.length) {
-    return null
+    return null;
   }
   const configItem = props.configItems.find(item => {
-    return item.key === props.configKey
-  })
+    return item.key === props.configKey;
+  });
   if (!configItem) {
     return (
       <li style={{ listStyle: 'none' }}>
         <strong>{props.configKey} is not in configItems.</strong>
       </li>
-    )
+    );
   }
   return (
     <li style={{ listStyle: 'none' }}>
       <Icon type={configItem.effectiveValue ? 'check' : 'close'} />{' '}
       {configItem.label || configItem.envVar}
     </li>
-  )
-}
+  );
+};
 
-export default CheckListItem
+export default CheckListItem;

--- a/client/src/configuration/ConfigEnvDocumentation.js
+++ b/client/src/configuration/ConfigEnvDocumentation.js
@@ -1,35 +1,35 @@
-import Table from 'antd/lib/table'
-import React from 'react'
+import Table from 'antd/lib/table';
+import React from 'react';
 
-const { Column } = Table
+const { Column } = Table;
 
 class ConfigEnvDocumentation extends React.Component {
   renderValue = (text, record) => {
-    return record.value === '' ? '<empty>' : record.effectiveValue.toString()
-  }
+    return record.value === '' ? '<empty>' : record.effectiveValue.toString();
+  };
 
   renderInfo = (text, record) => {
     return (
       <div style={{ width: '300px' }}>
         <p>{record.description}</p>
       </div>
-    )
-  }
+    );
+  };
 
   renderCli = (text, record) => {
     const cliFlag =
       record.cliFlag && record.cliFlag.pop
         ? record.cliFlag.pop()
-        : record.cliFlag
+        : record.cliFlag;
     if (cliFlag) {
-      return '--' + cliFlag
+      return '--' + cliFlag;
     }
-  }
+  };
 
   render() {
     const filteredConfigItems = this.props.configItems.filter(
       config => config.interface === 'env'
-    )
+    );
 
     return (
       <Table
@@ -44,8 +44,8 @@ class ConfigEnvDocumentation extends React.Component {
         <Column title="Set by" key="setby" dataIndex="effectiveValueSource" />
         <Column title="Info" key="info" render={this.renderInfo} />
       </Table>
-    )
+    );
   }
 }
 
-export default ConfigEnvDocumentation
+export default ConfigEnvDocumentation;

--- a/client/src/configuration/ConfigItemInput.js
+++ b/client/src/configuration/ConfigItemInput.js
@@ -1,34 +1,34 @@
-import Input from 'antd/lib/input'
-import Select from 'antd/lib/select'
-import React from 'react'
+import Input from 'antd/lib/input';
+import Select from 'antd/lib/select';
+import React from 'react';
 
-const { Option } = Select
+const { Option } = Select;
 
 class ConfigItemInput extends React.Component {
   state = {
     value: this.props.config.effectiveValue
-  }
+  };
 
   handleChange = e => {
     this.setState({
       value: e.target.value
-    })
-    this.props.saveConfigValue(this.props.config.key, e.target.value)
-  }
+    });
+    this.props.saveConfigValue(this.props.config.key, e.target.value);
+  };
 
   handleSelectChange = value => {
     this.setState({
       value
-    })
-    this.props.saveConfigValue(this.props.config.key, value)
-  }
+    });
+    this.props.saveConfigValue(this.props.config.key, value);
+  };
 
   render() {
-    const { config } = this.props
+    const { config } = this.props;
     const disabled =
       config.effectiveValueSource === 'cli' ||
       config.effectiveValueSource === 'saved cli' ||
-      config.effectiveValueSource === 'env'
+      config.effectiveValueSource === 'env';
 
     if (config.options) {
       const optionNodes = config.options.map(option => {
@@ -36,8 +36,8 @@ class ConfigItemInput extends React.Component {
           <Option key={option} value={option}>
             {option.toString()}
           </Option>
-        )
-      })
+        );
+      });
       return (
         <Select
           className="w-100"
@@ -47,7 +47,7 @@ class ConfigItemInput extends React.Component {
         >
           {optionNodes}
         </Select>
-      )
+      );
     } else {
       return (
         <Input
@@ -57,9 +57,9 @@ class ConfigItemInput extends React.Component {
           placeholder={config.label}
           value={this.state.value}
         />
-      )
+      );
     }
   }
 }
 
-export default ConfigItemInput
+export default ConfigItemInput;

--- a/client/src/configuration/ConfigurationView.js
+++ b/client/src/configuration/ConfigurationView.js
@@ -1,47 +1,47 @@
-import Col from 'antd/lib/col'
-import Layout from 'antd/lib/layout'
-import message from 'antd/lib/message'
-import Row from 'antd/lib/row'
-import debounce from 'lodash.debounce'
-import React from 'react'
-import AppNav from '../AppNav'
-import Header from '../common/Header'
-import fetchJson from '../utilities/fetch-json.js'
-import CheckListItem from './CheckListItem'
-import ConfigEnvDocumentation from './ConfigEnvDocumentation'
-import ConfigItemInput from './ConfigItemInput'
+import Col from 'antd/lib/col';
+import Layout from 'antd/lib/layout';
+import message from 'antd/lib/message';
+import Row from 'antd/lib/row';
+import debounce from 'lodash.debounce';
+import React from 'react';
+import AppNav from '../AppNav';
+import Header from '../common/Header';
+import fetchJson from '../utilities/fetch-json.js';
+import CheckListItem from './CheckListItem';
+import ConfigEnvDocumentation from './ConfigEnvDocumentation';
+import ConfigItemInput from './ConfigItemInput';
 
-const { Content } = Layout
+const { Content } = Layout;
 
 class ConfigurationView extends React.Component {
   state = {
     configItems: []
-  }
+  };
 
   loadConfigValuesFromServer = () => {
     fetchJson('GET', '/api/config-items').then(json => {
-      if (json.error) message.error(json.error)
-      this.setState({ configItems: json.configItems })
-    })
-  }
+      if (json.error) message.error(json.error);
+      this.setState({ configItems: json.configItems });
+    });
+  };
 
   saveConfigValue = (key, value) => {
     fetchJson('POST', '/api/config-values/' + key, {
       value: value
     }).then(json => {
       if (json.error) {
-        message.error('Save failed')
+        message.error('Save failed');
       } else {
-        message.success('Value saved')
-        this.loadConfigValuesFromServer()
+        message.success('Value saved');
+        this.loadConfigValuesFromServer();
       }
-    })
-  }
+    });
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Configuration'
-    this.loadConfigValuesFromServer()
-    this.saveConfigValue = debounce(this.saveConfigValue, 500)
+    document.title = 'SQLPad - Configuration';
+    this.loadConfigValuesFromServer();
+    this.saveConfigValue = debounce(this.saveConfigValue, 500);
   }
 
   renderValueInput = (text, record) => {
@@ -54,33 +54,34 @@ class ConfigurationView extends React.Component {
           saveConfigValue={this.saveConfigValue}
         />
       </div>
-    )
-  }
+    );
+  };
 
   renderInfo = config => {
     const disabled =
       config.effectiveValueSource === 'cli' ||
       config.effectiveValueSource === 'saved cli' ||
-      config.effectiveValueSource === 'env'
+      config.effectiveValueSource === 'env';
 
     const effectiveValueSourceLabels = {
       cli: 'Command Line',
       'saved cli': 'Saved Command Line',
       env: 'Environment Varialbe'
-    }
-    const overriddenBy = effectiveValueSourceLabels[config.effectiveValueSource]
+    };
+    const overriddenBy =
+      effectiveValueSourceLabels[config.effectiveValueSource];
 
     const defaultValue =
       config.default === '' ? (
         <em>empty</em>
       ) : (
         <span>{config.default.toString()}</span>
-      )
+      );
 
     const cliFlag =
       config.cliFlag && config.cliFlag.pop
         ? config.cliFlag.pop()
-        : config.cliFlag
+        : config.cliFlag;
 
     return (
       <div className="mt4">
@@ -110,14 +111,14 @@ class ConfigurationView extends React.Component {
           </div>
         )}
       </div>
-    )
-  }
+    );
+  };
 
   renderConfigInputs() {
-    const { configItems } = this.state
+    const { configItems } = this.state;
     const uiConfigItems = configItems.filter(
       config => config.interface === 'ui'
-    )
+    );
     return (
       <div className="bg-white w-100 pa4">
         {uiConfigItems.map(config => {
@@ -136,10 +137,10 @@ class ConfigurationView extends React.Component {
                 <div>{this.renderInfo(config)}</div>
               </Col>
             </Row>
-          )
+          );
         })}
       </div>
-    )
+    );
   }
 
   render() {
@@ -223,8 +224,8 @@ class ConfigurationView extends React.Component {
           </Content>
         </Layout>
       </AppNav>
-    )
+    );
   }
 }
 
-export default ConfigurationView
+export default ConfigurationView;

--- a/client/src/connections/ConnectionEditDrawer.js
+++ b/client/src/connections/ConnectionEditDrawer.js
@@ -1,6 +1,6 @@
-import Drawer from 'antd/lib/drawer'
-import React from 'react'
-import ConnectionForm from './ConnectionForm'
+import Drawer from 'antd/lib/drawer';
+import React from 'react';
+import ConnectionForm from './ConnectionForm';
 
 function ConnectionEditDrawer({
   connectionId,
@@ -9,7 +9,7 @@ function ConnectionEditDrawer({
   onConnectionSaved,
   placement
 }) {
-  const title = connectionId ? 'Edit connection' : 'New connection'
+  const title = connectionId ? 'Edit connection' : 'New connection';
   return (
     <Drawer
       title={title}
@@ -28,7 +28,7 @@ function ConnectionEditDrawer({
         onConnectionSaved={onConnectionSaved}
       />
     </Drawer>
-  )
+  );
 }
 
-export default ConnectionEditDrawer
+export default ConnectionEditDrawer;

--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -1,18 +1,18 @@
-import Button from 'antd/lib/button'
-import Checkbox from 'antd/lib/checkbox'
-import Form from 'antd/lib/form'
-import Icon from 'antd/lib/icon'
-import Input from 'antd/lib/input'
-import Select from 'antd/lib/select'
-import React from 'react'
-import fetchJson from '../utilities/fetch-json.js'
+import Button from 'antd/lib/button';
+import Checkbox from 'antd/lib/checkbox';
+import Form from 'antd/lib/form';
+import Icon from 'antd/lib/icon';
+import Input from 'antd/lib/input';
+import Select from 'antd/lib/select';
+import React from 'react';
+import fetchJson from '../utilities/fetch-json.js';
 
-const FormItem = Form.Item
-const { Option } = Select
+const FormItem = Form.Item;
+const { Option } = Select;
 
-const TEXT = 'TEXT'
-const PASSWORD = 'PASSWORD'
-const CHECKBOX = 'CHECKBOX'
+const TEXT = 'TEXT';
+const PASSWORD = 'PASSWORD';
+const CHECKBOX = 'CHECKBOX';
 
 const formItemLayout = {
   labelCol: {
@@ -23,7 +23,7 @@ const formItemLayout = {
     xs: { span: 24 },
     sm: { span: 16 }
   }
-}
+};
 
 const tailFormItemLayout = {
   wrapperCol: {
@@ -36,7 +36,7 @@ const tailFormItemLayout = {
       offset: 8
     }
   }
-}
+};
 
 class ConnectionForm extends React.Component {
   state = {
@@ -49,96 +49,96 @@ class ConnectionForm extends React.Component {
     testSuccess: false,
     title: '',
     visible: false
-  }
+  };
 
   componentDidMount() {
-    this.loadDriversFromServer()
-    this.loadConnectionFromServer()
+    this.loadDriversFromServer();
+    this.loadConnectionFromServer();
   }
 
   // TODO move this to app load - no reason this will change
   loadDriversFromServer = () => {
     fetchJson('GET', '/api/drivers').then(json => {
-      this.setState({ drivers: json.drivers })
-    })
-  }
+      this.setState({ drivers: json.drivers });
+    });
+  };
 
   loadConnectionFromServer = async () => {
-    const { connectionId } = this.props
+    const { connectionId } = this.props;
     if (connectionId) {
-      const json = await fetchJson('GET', `/api/connections/${connectionId}`)
+      const json = await fetchJson('GET', `/api/connections/${connectionId}`);
       if (json.error) {
-        return console.error(json.error)
+        return console.error(json.error);
       }
-      return this.setState({ connectionEdits: json.connection })
+      return this.setState({ connectionEdits: json.connection });
     }
-  }
+  };
 
   setConnectionValue = (key, value) => {
-    const { connectionEdits } = this.state
-    connectionEdits[key] = value
-    return this.setState({ connectionEdits })
-  }
+    const { connectionEdits } = this.state;
+    connectionEdits[key] = value;
+    return this.setState({ connectionEdits });
+  };
 
   testConnection = async () => {
-    const { connectionEdits } = this.state
-    this.setState({ testing: true })
+    const { connectionEdits } = this.state;
+    this.setState({ testing: true });
     const json = await fetchJson(
       'POST',
       '/api/test-connection',
       connectionEdits
-    )
+    );
     return this.setState({
       testing: false,
       testFailed: json.error ? true : false,
       testSuccess: json.error ? false : true
-    })
-  }
+    });
+  };
 
   saveConnection = async () => {
-    const { saving, connectionEdits } = this.state
-    const { onConnectionSaved } = this.props
+    const { saving, connectionEdits } = this.state;
+    const { onConnectionSaved } = this.props;
     if (saving) {
-      return
+      return;
     }
 
-    this.setState({ saving: true })
+    this.setState({ saving: true });
 
-    let json
+    let json;
     if (connectionEdits._id) {
       json = await fetchJson(
         'PUT',
         '/api/connections/' + connectionEdits._id,
         connectionEdits
-      )
+      );
     } else {
-      json = await fetchJson('POST', '/api/connections', connectionEdits)
+      json = await fetchJson('POST', '/api/connections', connectionEdits);
     }
 
     if (json.error) {
-      return this.setState({ saving: false, savingError: json.error })
+      return this.setState({ saving: false, savingError: json.error });
     }
-    return onConnectionSaved(json.connection)
-  }
+    return onConnectionSaved(json.connection);
+  };
 
   renderDriverFields() {
-    const { drivers, connectionEdits } = this.state
+    const { drivers, connectionEdits } = this.state;
 
     if (connectionEdits.driver && drivers.length) {
       // NOTE connection.driver is driverId
       const driver = drivers.find(
         driver => driver.id === connectionEdits.driver
-      )
+      );
 
       if (!driver) {
-        console.error(`Driver ${connectionEdits.driver} not found`)
-        return null
+        console.error(`Driver ${connectionEdits.driver} not found`);
+        return null;
       }
 
-      const { fields } = driver
+      const { fields } = driver;
       return fields.map(field => {
         if (field.formType === TEXT) {
-          const value = connectionEdits[field.key] || ''
+          const value = connectionEdits[field.key] || '';
           return (
             <FormItem {...formItemLayout} key={field.key} label={field.label}>
               {/* <label className="near-black">{field.label}</label> */}
@@ -150,9 +150,9 @@ class ConnectionForm extends React.Component {
                 }
               />
             </FormItem>
-          )
+          );
         } else if (field.formType === PASSWORD) {
-          const value = connectionEdits[field.key] || ''
+          const value = connectionEdits[field.key] || '';
           // autoComplete='new-password' used to prevent browsers from autofilling username and password
           // Because we dont return a password, Chrome goes ahead and autofills
           return (
@@ -168,9 +168,9 @@ class ConnectionForm extends React.Component {
                 }
               />
             </FormItem>
-          )
+          );
         } else if (field.formType === CHECKBOX) {
-          const checked = connectionEdits[field.key] || false
+          const checked = connectionEdits[field.key] || false;
           return (
             <FormItem {...tailFormItemLayout} key={field.key}>
               <Checkbox
@@ -183,10 +183,10 @@ class ConnectionForm extends React.Component {
                 {field.label}
               </Checkbox>
             </FormItem>
-          )
+          );
         }
-        return null
-      })
+        return null;
+      });
     }
   }
 
@@ -198,18 +198,18 @@ class ConnectionForm extends React.Component {
       testing,
       testSuccess,
       testFailed
-    } = this.state
+    } = this.state;
 
-    const { name = '', driver = '' } = connectionEdits
+    const { name = '', driver = '' } = connectionEdits;
 
-    const driverSelectOptions = [<Option key="none" value="" />]
+    const driverSelectOptions = [<Option key="none" value="" />];
 
     if (!drivers.length) {
       driverSelectOptions.push(
         <Option key="loading" value="">
           Loading...
         </Option>
-      )
+      );
     } else {
       drivers
         .sort((a, b) => a.name > b.name)
@@ -219,7 +219,7 @@ class ConnectionForm extends React.Component {
               {driver.name}
             </Option>
           )
-        )
+        );
     }
 
     return (
@@ -302,8 +302,8 @@ class ConnectionForm extends React.Component {
           </div>
         </Form>
       </div>
-    )
+    );
   }
 }
 
-export default ConnectionForm
+export default ConnectionForm;

--- a/client/src/connections/ConnectionListDrawer.js
+++ b/client/src/connections/ConnectionListDrawer.js
@@ -1,88 +1,88 @@
-import Button from 'antd/lib/button'
-import Drawer from 'antd/lib/drawer'
-import Icon from 'antd/lib/icon'
-import List from 'antd/lib/list'
-import Popconfirm from 'antd/lib/popconfirm'
-import React from 'react'
-import { withAppContext } from '../containers/withAppContext'
-import ConnectionEditDrawer from './ConnectionEditDrawer'
-import { withConnectionsContext } from './ConnectionsStore'
+import Button from 'antd/lib/button';
+import Drawer from 'antd/lib/drawer';
+import Icon from 'antd/lib/icon';
+import List from 'antd/lib/list';
+import Popconfirm from 'antd/lib/popconfirm';
+import React from 'react';
+import { withAppContext } from '../containers/withAppContext';
+import ConnectionEditDrawer from './ConnectionEditDrawer';
+import { withConnectionsContext } from './ConnectionsStore';
 
 class ConnectionListDrawer extends React.Component {
   state = {
     connectionId: null,
     showEdit: false
-  }
+  };
 
   componentDidMount() {
-    this.props.connectionsContext.loadConnections()
+    this.props.connectionsContext.loadConnections();
   }
 
   editConnection = connection => {
-    this.setState({ connectionId: connection._id, showEdit: true })
-  }
+    this.setState({ connectionId: connection._id, showEdit: true });
+  };
 
   newConnection = () => {
-    this.setState({ showEdit: true, connectionId: null })
-  }
+    this.setState({ showEdit: true, connectionId: null });
+  };
 
   handleEditDrawerClose = () => {
-    this.setState({ showEdit: false, connectionId: null })
-  }
+    this.setState({ showEdit: false, connectionId: null });
+  };
 
   handleConnectionSaved = connection => {
-    const { connectionId } = this.state
-    const { onClose, connectionsContext } = this.props
-    const { addUpdateConnection, selectConnection } = connectionsContext
-    addUpdateConnection(connection)
+    const { connectionId } = this.state;
+    const { onClose, connectionsContext } = this.props;
+    const { addUpdateConnection, selectConnection } = connectionsContext;
+    addUpdateConnection(connection);
 
     // If there was not a connectionId previously passed to edit drawer
     // this is a new connection
     // New connections can be selected and then all the drawer closed
     if (!connectionId) {
-      this.setState({ showEdit: false, connectionId: null }, onClose)
-      selectConnection(connection._id)
+      this.setState({ showEdit: false, connectionId: null }, onClose);
+      selectConnection(connection._id);
     } else {
-      this.setState({ showEdit: false, connectionId: null })
+      this.setState({ showEdit: false, connectionId: null });
     }
-  }
+  };
 
   render() {
-    const { appContext, connectionsContext, visible, onClose } = this.props
-    const { connectionId, showEdit } = this.state
-    const { currentUser } = appContext
+    const { appContext, connectionsContext, visible, onClose } = this.props;
+    const { connectionId, showEdit } = this.state;
+    const { currentUser } = appContext;
     const {
       selectConnection,
       selectedConnectionId,
       connections,
       deleteConnection
-    } = connectionsContext
+    } = connectionsContext;
 
     // TODO - server driver implementations should implement functions
     // that get decorated normalized display values
     const decoratedConnections = connections.map(connection => {
-      connection.key = connection._id
-      connection.displayDatabase = connection.database
-      connection.displaySchema = ''
-      let displayPort = connection.port ? ':' + connection.port : ''
+      connection.key = connection._id;
+      connection.displayDatabase = connection.database;
+      connection.displaySchema = '';
+      let displayPort = connection.port ? ':' + connection.port : '';
 
       if (connection.driver === 'hdb') {
-        connection.displayDatabase = connection.hanadatabase
-        connection.displaySchema = connection.hanaSchema
-        displayPort = connection.hanaport ? ':' + connection.hanaport : ''
+        connection.displayDatabase = connection.hanadatabase;
+        connection.displaySchema = connection.hanaSchema;
+        displayPort = connection.hanaport ? ':' + connection.hanaport : '';
       } else if (connection.driver === 'presto') {
-        connection.displayDatabase = connection.prestoCatalog
-        connection.displaySchema = connection.prestoSchema
+        connection.displayDatabase = connection.prestoCatalog;
+        connection.displaySchema = connection.prestoSchema;
       }
 
-      connection.displayHost = (connection.host || '') + displayPort
-      return connection
-    })
+      connection.displayHost = (connection.host || '') + displayPort;
+      return connection;
+    });
 
     // The last "connection" list item will be an input to add a connection
     // This is just something simple to branch off of in List.renderItem prop
     if (currentUser.role === 'admin') {
-      decoratedConnections.push('ADD_BUTTON')
+      decoratedConnections.push('ADD_BUTTON');
     }
 
     return (
@@ -113,12 +113,12 @@ class ConnectionListDrawer extends React.Component {
                     <Icon type="plus" /> Add connection
                   </Button>
                 </List.Item>
-              )
+              );
             }
 
-            let description = ''
+            let description = '';
             if (item.user) {
-              description = item.user + '@'
+              description = item.user + '@';
             }
             description += [
               item.displayHost,
@@ -126,34 +126,34 @@ class ConnectionListDrawer extends React.Component {
               item.displaySchema
             ]
               .filter(part => part && part.trim())
-              .join(' / ')
+              .join(' / ');
 
-            const actions = []
+            const actions = [];
 
             if (selectedConnectionId === item._id) {
               actions.push(
                 <Button className="w4" disabled>
                   selected
                 </Button>
-              )
+              );
             } else {
               actions.push(
                 <Button
                   className="w4"
                   onClick={() => {
-                    selectConnection(item._id)
-                    onClose()
+                    selectConnection(item._id);
+                    onClose();
                   }}
                 >
                   select
                 </Button>
-              )
+              );
             }
 
             if (currentUser.role === 'admin') {
               actions.push(
                 <Button onClick={() => this.editConnection(item)}>edit</Button>
-              )
+              );
               actions.push(
                 <Popconfirm
                   title="Delete connection?"
@@ -164,7 +164,7 @@ class ConnectionListDrawer extends React.Component {
                 >
                   <Button icon="delete" type="danger" />
                 </Popconfirm>
-              )
+              );
             }
 
             return (
@@ -180,7 +180,7 @@ class ConnectionListDrawer extends React.Component {
                   }
                 />
               </List.Item>
-            )
+            );
           }}
         />
         <ConnectionEditDrawer
@@ -191,8 +191,8 @@ class ConnectionListDrawer extends React.Component {
           placement="left"
         />
       </Drawer>
-    )
+    );
   }
 }
 
-export default withAppContext(withConnectionsContext(ConnectionListDrawer))
+export default withAppContext(withConnectionsContext(ConnectionListDrawer));

--- a/client/src/connections/ConnectionsStore.js
+++ b/client/src/connections/ConnectionsStore.js
@@ -1,17 +1,17 @@
-import message from 'antd/lib/message'
-import sortBy from 'lodash.sortby'
-import React from 'react'
-import fetchJson from '../utilities/fetch-json.js'
+import message from 'antd/lib/message';
+import sortBy from 'lodash.sortby';
+import React from 'react';
+import fetchJson from '../utilities/fetch-json.js';
 
-const ONE_HOUR_MS = 1000 * 60 * 60
+const ONE_HOUR_MS = 1000 * 60 * 60;
 
-const sortFunctions = [connection => connection.name.toLowerCase()]
+const sortFunctions = [connection => connection.name.toLowerCase()];
 
-export const ConnectionsContext = React.createContext({})
+export const ConnectionsContext = React.createContext({});
 
 export class ConnectionsStore extends React.Component {
   constructor() {
-    super()
+    super();
     this.state = {
       selectedConnectionId: null,
       connections: [],
@@ -24,7 +24,7 @@ export class ConnectionsStore extends React.Component {
       setConnections: connections => {
         return this.setState({
           connections: sortBy(connections, sortFunctions)
-        })
+        });
       },
 
       // Calls delete API and updates store
@@ -32,40 +32,42 @@ export class ConnectionsStore extends React.Component {
         const json = await fetchJson(
           'DELETE',
           '/api/connections/' + connectionId
-        )
+        );
         // TODO should errors be messaged like this or should they be captured in state?
         if (json.error) {
-          return message.error('Delete failed')
+          return message.error('Delete failed');
         }
         const connections = this.state.connections.filter(
           c => c._id !== connectionId
-        )
-        return this.setState({ connections })
+        );
+        return this.setState({ connections });
       },
 
       // Updates store (is not resonponsible for API call)
       addUpdateConnection: async connection => {
-        const found = this.state.connections.find(c => c._id === connection._id)
+        const found = this.state.connections.find(
+          c => c._id === connection._id
+        );
         if (found) {
           const connections = this.state.connections.map(c => {
             if (c._id === connection._id) {
-              return connection
+              return connection;
             }
-            return c
-          })
-          return this.state.setConnections(connections)
+            return c;
+          });
+          return this.state.setConnections(connections);
         }
 
         return this.state.setConnections(
           [connection].concat(this.state.connections)
-        )
+        );
       },
 
       loadConnections: async force => {
-        const { lastUpdated, loading, connections } = this.state
+        const { lastUpdated, loading, connections } = this.state;
 
         if (loading) {
-          return
+          return;
         }
 
         if (
@@ -73,18 +75,18 @@ export class ConnectionsStore extends React.Component {
           !connections.length ||
           (lastUpdated && new Date() - lastUpdated > ONE_HOUR_MS)
         ) {
-          this.setState({ loading: true })
+          this.setState({ loading: true });
           const { error, connections } = await fetchJson(
             'GET',
             '/api/connections/'
-          )
+          );
           if (error) {
-            message.error(error)
+            message.error(error);
           }
 
-          let { selectedConnectionId } = this.state
+          let { selectedConnectionId } = this.state;
           if (connections && connections.length === 1) {
-            selectedConnectionId = connections[0]._id
+            selectedConnectionId = connections[0]._id;
           }
 
           return this.setState({
@@ -93,10 +95,10 @@ export class ConnectionsStore extends React.Component {
             connections,
             loading: false,
             lastUpdated: new Date()
-          })
+          });
         }
       }
-    }
+    };
   }
 
   render() {
@@ -104,7 +106,7 @@ export class ConnectionsStore extends React.Component {
       <ConnectionsContext.Provider value={this.state}>
         {this.props.children}
       </ConnectionsContext.Provider>
-    )
+    );
   }
 }
 
@@ -116,8 +118,8 @@ export function withConnectionsContext(Component) {
           <Component {...props} connectionsContext={connectionsContext} />
         )}
       </ConnectionsContext.Consumer>
-    )
-  }
+    );
+  };
 }
 
-export default ConnectionsStore
+export default ConnectionsStore;

--- a/client/src/containers/AppContext.js
+++ b/client/src/containers/AppContext.js
@@ -1,5 +1,5 @@
-import React from 'react'
+import React from 'react';
 
-const AppContext = React.createContext({ refreshAppContext: () => {} })
+const AppContext = React.createContext({ refreshAppContext: () => {} });
 
-export default AppContext
+export default AppContext;

--- a/client/src/containers/AppContextProvider.js
+++ b/client/src/containers/AppContextProvider.js
@@ -1,20 +1,20 @@
-import React from 'react'
-import fetchJson from '../utilities/fetch-json.js'
-import AppContext from './AppContext'
+import React from 'react';
+import fetchJson from '../utilities/fetch-json.js';
+import AppContext from './AppContext';
 
 export class AppContextProvider extends React.Component {
   constructor() {
-    super()
+    super();
     this.state = {
       refreshAppContext: async () => {
-        const json = await fetchJson('GET', 'api/app')
+        const json = await fetchJson('GET', 'api/app');
         // Assign config.baseUrl to global
         // It doesn't change and is needed for fetch requests
         // This allows us to simplify the fetch() call
         if (!json.config) {
-          return
+          return;
         }
-        window.BASE_URL = json.config.baseUrl
+        window.BASE_URL = json.config.baseUrl;
         return this.setState({
           config: json.config,
           smtpConfigured: json.smtpConfigured,
@@ -23,25 +23,25 @@ export class AppContextProvider extends React.Component {
           passport: json.passport,
           adminRegistrationOpen: json.adminRegistrationOpen,
           version: json.version
-        })
+        });
       }
-    }
+    };
   }
 
   componentDidMount() {
-    this.state.refreshAppContext()
+    this.state.refreshAppContext();
   }
 
   render() {
-    const { config } = this.state
+    const { config } = this.state;
 
     // Don't render children until config is sorted out
     return (
       <AppContext.Provider value={this.state}>
         {config ? this.props.children : null}
       </AppContext.Provider>
-    )
+    );
   }
 }
 
-export default AppContextProvider
+export default AppContextProvider;

--- a/client/src/containers/withAppContext.js
+++ b/client/src/containers/withAppContext.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import AppContext from './AppContext'
+import React from 'react';
+import AppContext from './AppContext';
 
 export function withAppContext(Component) {
   return function ConnectedComponent(props) {
@@ -7,8 +7,8 @@ export function withAppContext(Component) {
       <AppContext.Consumer>
         {appContext => <Component {...props} appContext={appContext} />}
       </AppContext.Consumer>
-    )
-  }
+    );
+  };
 }
 
-export default withAppContext
+export default withAppContext;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,16 +1,16 @@
-import 'antd/dist/antd.css'
-import React from 'react'
-import ReactDOM from 'react-dom'
-import 'tachyons/css/tachyons.min.css'
-import App from './App.js'
-import AppContextProvider from './containers/AppContextProvider'
-import './css/index.css'
-import './css/react-split-pane.css'
-import './css/vendorOverrides.css'
+import 'antd/dist/antd.css';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import 'tachyons/css/tachyons.min.css';
+import App from './App.js';
+import AppContextProvider from './containers/AppContextProvider';
+import './css/index.css';
+import './css/react-split-pane.css';
+import './css/vendorOverrides.css';
 
 ReactDOM.render(
   <AppContextProvider>
     <App />
   </AppContextProvider>,
   document.getElementById('root')
-)
+);

--- a/client/src/queries/QueriesView.js
+++ b/client/src/queries/QueriesView.js
@@ -1,30 +1,30 @@
-import { Col, Row } from 'antd'
-import Button from 'antd/lib/button'
-import Divider from 'antd/lib/divider'
-import Icon from 'antd/lib/icon'
-import Input from 'antd/lib/input'
-import Layout from 'antd/lib/layout'
-import message from 'antd/lib/message'
-import Popconfirm from 'antd/lib/popconfirm'
-import Popover from 'antd/lib/popover'
-import Select from 'antd/lib/select'
-import Table from 'antd/lib/table'
-import Tag from 'antd/lib/tag'
-import uniq from 'lodash.uniq'
-import moment from 'moment'
-import React from 'react'
-import { Link } from 'react-router-dom'
-import AppNav from '../AppNav'
-import Header from '../common/Header'
-import SqlEditor from '../common/SqlEditor'
-import AppContext from '../containers/AppContext'
-import fetchJson from '../utilities/fetch-json.js'
+import { Col, Row } from 'antd';
+import Button from 'antd/lib/button';
+import Divider from 'antd/lib/divider';
+import Icon from 'antd/lib/icon';
+import Input from 'antd/lib/input';
+import Layout from 'antd/lib/layout';
+import message from 'antd/lib/message';
+import Popconfirm from 'antd/lib/popconfirm';
+import Popover from 'antd/lib/popover';
+import Select from 'antd/lib/select';
+import Table from 'antd/lib/table';
+import Tag from 'antd/lib/tag';
+import uniq from 'lodash.uniq';
+import moment from 'moment';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import AppNav from '../AppNav';
+import Header from '../common/Header';
+import SqlEditor from '../common/SqlEditor';
+import AppContext from '../containers/AppContext';
+import fetchJson from '../utilities/fetch-json.js';
 
-const { Content } = Layout
+const { Content } = Layout;
 
-const { Option } = Select
-const { Column } = Table
-const { Search } = Input
+const { Option } = Select;
+const { Column } = Table;
+const { Search } = Input;
 
 class QueriesView extends React.Component {
   state = {
@@ -39,62 +39,62 @@ class QueriesView extends React.Component {
     selectedCreatedBy: this.props.currentUser
       ? this.props.currentUser.email
       : ''
-  }
+  };
 
   handleQueryDelete = queryId => {
-    let { queries } = this.state
+    let { queries } = this.state;
     queries = queries.filter(q => {
-      return q._id !== queryId
-    })
+      return q._id !== queryId;
+    });
     this.setState({
       queries
-    })
+    });
     fetchJson('DELETE', '/api/queries/' + queryId).then(json => {
-      if (json.error) message.error(json.error)
-    })
-  }
+      if (json.error) message.error(json.error);
+    });
+  };
 
   loadConfigValuesFromServer = () => {
     fetchJson('GET', '/api/queries').then(json => {
-      const queries = json.queries || []
-      const createdBys = uniq(queries.map(q => q.createdBy))
+      const queries = json.queries || [];
+      const createdBys = uniq(queries.map(q => q.createdBy));
       const tags = uniq(
         queries
           .map(q => q.tags)
           .reduce((a, b) => a.concat(b), [])
           .filter(tag => tag)
-      )
-      let selectedCreatedBy = this.state.selectedCreatedBy
-      const email = this.props.currentUser && this.props.currentUser.email
+      );
+      let selectedCreatedBy = this.state.selectedCreatedBy;
+      const email = this.props.currentUser && this.props.currentUser.email;
       if (createdBys.indexOf(email) === -1) {
-        selectedCreatedBy = ''
+        selectedCreatedBy = '';
       }
       this.setState({
         queries: json.queries,
         createdBys: createdBys,
         selectedCreatedBy: selectedCreatedBy,
         tags: tags
-      })
-    })
+      });
+    });
     fetchJson('GET', '/api/connections').then(json => {
-      this.setState({ connections: json.connections })
-    })
-  }
+      this.setState({ connections: json.connections });
+    });
+  };
 
   onSearchChange = e => {
     this.setState({
       searchInput: e.target.value
-    })
-  }
+    });
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Queries'
-    this.loadConfigValuesFromServer()
+    document.title = 'SQLPad - Queries';
+    this.loadConfigValuesFromServer();
   }
 
   nameRender = (text, record) => {
-    return <Link to={'/queries/' + record._id}>{record.name}</Link>
-  }
+    return <Link to={'/queries/' + record._id}>{record.name}</Link>;
+  };
 
   previewRender = (text, record) => {
     return (
@@ -110,30 +110,30 @@ class QueriesView extends React.Component {
       >
         <Icon type="code-o" />
       </Popover>
-    )
-  }
+    );
+  };
 
-  nameSorter = (a, b) => a.name.localeCompare(b.name)
+  nameSorter = (a, b) => a.name.localeCompare(b.name);
 
   modifiedSorter = (a, b) => {
-    return moment(a.modifiedDate).toDate() - moment(b.modifiedDate).toDate()
-  }
+    return moment(a.modifiedDate).toDate() - moment(b.modifiedDate).toDate();
+  };
 
-  modifiedRender = (text, record) => moment(record.modifiedDate).calendar()
+  modifiedRender = (text, record) => moment(record.modifiedDate).calendar();
 
   tagsRender = (text, record) => {
     if (record.tags && record.tags.length) {
-      return record.tags.map(tag => <Tag key={tag}>{tag}</Tag>)
+      return record.tags.map(tag => <Tag key={tag}>{tag}</Tag>);
     }
-  }
+  };
 
   actionsRender = (text, record) => {
     return (
       <AppContext.Consumer>
         {appContext => {
-          const { config } = appContext
-          const tableUrl = `${config.baseUrl}/query-table/${record._id}`
-          const chartUrl = `${config.baseUrl}/query-chart/${record._id}`
+          const { config } = appContext;
+          const tableUrl = `${config.baseUrl}/query-table/${record._id}`;
+          const chartUrl = `${config.baseUrl}/query-chart/${record._id}`;
           return (
             <span>
               <a href={tableUrl} target="_blank" rel="noopener noreferrer">
@@ -154,30 +154,30 @@ class QueriesView extends React.Component {
                 <Button icon="delete" type="danger" />
               </Popconfirm>
             </span>
-          )
+          );
         }}
       </AppContext.Consumer>
-    )
-  }
+    );
+  };
 
   getDecoratedQueries() {
-    const { queries, connections } = this.state
+    const { queries, connections } = this.state;
 
     // Create index of lookups
     // TODO this should come from API
     const connectionsById = connections.reduce((connMap, connection) => {
-      connMap[connection._id] = connection
-      return connMap
-    }, {})
+      connMap[connection._id] = connection;
+      return connMap;
+    }, {});
 
     return queries.map(query => {
-      query.key = query._id
+      query.key = query._id;
 
-      const connection = connectionsById[query.connectionId]
-      query.connectionName = connection ? connection.name : ''
+      const connection = connectionsById[query.connectionId];
+      query.connectionName = connection ? connection.name : '';
 
-      return query
-    })
+      return query;
+    });
   }
 
   renderTable() {
@@ -186,50 +186,50 @@ class QueriesView extends React.Component {
       selectedConnection,
       selectedCreatedBy,
       selectedTags
-    } = this.state
+    } = this.state;
 
-    let filteredQueries = this.getDecoratedQueries()
+    let filteredQueries = this.getDecoratedQueries();
 
     if (selectedTags.length) {
       filteredQueries = filteredQueries.filter(q => {
         if (!q.tags || !q.tags.length) {
-          return false
+          return false;
         }
         const matchedTags = selectedTags.filter(
           selectedTag => q.tags.indexOf(selectedTag) > -1
-        )
-        return selectedTags.length === matchedTags.length
-      })
+        );
+        return selectedTags.length === matchedTags.length;
+      });
     }
 
     if (searchInput) {
-      const terms = searchInput.split(' ')
-      const termCount = terms.length
+      const terms = searchInput.split(' ');
+      const termCount = terms.length;
       filteredQueries = filteredQueries.filter(q => {
-        let matchedCount = 0
+        let matchedCount = 0;
         terms.forEach(term => {
-          term = term.toLowerCase()
+          term = term.toLowerCase();
           if (
             (q.name && q.name.toLowerCase().search(term) !== -1) ||
             (q.queryText && q.queryText.toLowerCase().search(term) !== -1)
           ) {
-            matchedCount++
+            matchedCount++;
           }
-        })
-        return matchedCount === termCount
-      })
+        });
+        return matchedCount === termCount;
+      });
     }
 
     if (selectedConnection) {
       filteredQueries = filteredQueries.filter(
         q => q.connectionId === selectedConnection
-      )
+      );
     }
 
     if (selectedCreatedBy) {
       filteredQueries = filteredQueries.filter(
         q => q.createdBy === selectedCreatedBy
-      )
+      );
     }
 
     return (
@@ -262,7 +262,7 @@ class QueriesView extends React.Component {
         />
         <Column key="action" render={this.actionsRender} />
       </Table>
-    )
+    );
   }
 
   renderFilters() {
@@ -274,7 +274,7 @@ class QueriesView extends React.Component {
       selectedCreatedBy,
       selectedTags,
       tags
-    } = this.state
+    } = this.state;
     return (
       <Row gutter={16}>
         <Col className="pb3" span={6}>
@@ -331,7 +331,7 @@ class QueriesView extends React.Component {
           </Select>
         </Col>
       </Row>
-    )
+    );
   }
 
   render() {
@@ -352,8 +352,8 @@ class QueriesView extends React.Component {
           </Content>
         </Layout>
       </AppNav>
-    )
+    );
   }
 }
 
-export default QueriesView
+export default QueriesView;

--- a/client/src/queryEditor/ChartInputs.js
+++ b/client/src/queryEditor/ChartInputs.js
@@ -1,44 +1,44 @@
-import Checkbox from 'antd/lib/checkbox'
-import Input from 'antd/lib/input'
-import Select from 'antd/lib/select'
-import PropTypes from 'prop-types'
-import React from 'react'
-import chartDefinitions from '../utilities/chartDefinitions.js'
+import Checkbox from 'antd/lib/checkbox';
+import Input from 'antd/lib/input';
+import Select from 'antd/lib/select';
+import PropTypes from 'prop-types';
+import React from 'react';
+import chartDefinitions from '../utilities/chartDefinitions.js';
 
-const { Option } = Select
+const { Option } = Select;
 
 function cleanBoolean(value) {
   if (typeof value === 'string') {
     if (value.toLowerCase() === 'true') {
-      value = true
+      value = true;
     } else if (value.toLowerCase() === 'false') {
-      value = false
+      value = false;
     }
   }
-  return value
+  return value;
 }
 
-const inputClassName = 'mt3 mb3'
+const inputClassName = 'mt3 mb3';
 
 class ChartInputs extends React.Component {
   state = {
     showAdvanced: false
-  }
+  };
 
   handleAdvancedClick = e => {
-    e.preventDefault()
+    e.preventDefault();
     this.setState({
       showAdvanced: !this.state.showAdvanced
-    })
-  }
+    });
+  };
 
   changeChartConfigurationField = (chartFieldId, queryResultField) => {
-    this.props.onChartConfigurationFieldsChange(chartFieldId, queryResultField)
-  }
+    this.props.onChartConfigurationFieldsChange(chartFieldId, queryResultField);
+  };
 
   renderFormGroup(inputDefinitionFields) {
-    const { queryChartConfigurationFields, queryResult } = this.props
-    const queryResultFields = queryResult.fields || []
+    const { queryChartConfigurationFields, queryResult } = this.props;
+    const queryResultFields = queryResult.fields || [];
 
     return inputDefinitionFields.map(field => {
       if (field.inputType === 'field-dropdown') {
@@ -47,10 +47,10 @@ class ChartInputs extends React.Component {
             <Option key={qrfield} value={qrfield}>
               {qrfield}
             </Option>
-          )
-        })
+          );
+        });
         const selectedQueryResultField =
-          queryChartConfigurationFields[field.fieldId]
+          queryChartConfigurationFields[field.fieldId];
         if (
           selectedQueryResultField &&
           queryResultFields.indexOf(selectedQueryResultField) === -1
@@ -62,7 +62,7 @@ class ChartInputs extends React.Component {
             >
               {selectedQueryResultField}
             </Option>
-          )
+          );
         }
         return (
           <div className={inputClassName} key={field.fieldId}>
@@ -75,7 +75,7 @@ class ChartInputs extends React.Component {
               value={selectedQueryResultField}
               notFoundContent="No fields available"
               onChange={value => {
-                this.changeChartConfigurationField(field.fieldId, value)
+                this.changeChartConfigurationField(field.fieldId, value);
               }}
               filterOption={(input, option) =>
                 option.props.value &&
@@ -87,10 +87,10 @@ class ChartInputs extends React.Component {
               {optionNodes}
             </Select>
           </div>
-        )
+        );
       } else if (field.inputType === 'checkbox') {
         const checked =
-          cleanBoolean(queryChartConfigurationFields[field.fieldId]) || false
+          cleanBoolean(queryChartConfigurationFields[field.fieldId]) || false;
         return (
           <div className={inputClassName} key={field.fieldId}>
             <Checkbox
@@ -100,15 +100,15 @@ class ChartInputs extends React.Component {
                 this.changeChartConfigurationField(
                   field.fieldId,
                   e.target.checked
-                )
+                );
               }}
             >
               {field.label}
             </Checkbox>
           </div>
-        )
+        );
       } else if (field.inputType === 'textbox') {
-        const value = queryChartConfigurationFields[field.fieldId] || ''
+        const value = queryChartConfigurationFields[field.fieldId] || '';
         return (
           <div className={inputClassName} key={field.fieldId}>
             <label>{field.label}</label>
@@ -118,43 +118,43 @@ class ChartInputs extends React.Component {
                 this.changeChartConfigurationField(
                   field.fieldId,
                   e.target.value
-                )
+                );
               }}
               className="w-100"
             />
           </div>
-        )
+        );
       } else {
-        throw Error(`field.inputType ${field.inputType} not supported`)
+        throw Error(`field.inputType ${field.inputType} not supported`);
       }
-    })
+    });
   }
 
   render() {
-    const { chartType } = this.props
-    const { showAdvanced } = this.state
+    const { chartType } = this.props;
+    const { showAdvanced } = this.state;
 
     const chartDefinition = chartDefinitions.find(
       def => def.chartType === chartType
-    )
+    );
 
     if (!chartDefinition || !chartDefinition.fields) {
-      return null
+      return null;
     }
 
     const regularFields = chartDefinition.fields.filter(
       field => field.advanced == null || field.advanced === false
-    )
+    );
 
     const advancedFields = chartDefinition.fields.filter(
       field => field.advanced === true
-    )
+    );
 
     const advancedLink = advancedFields.length ? (
       <a href="#settings" onClick={this.handleAdvancedClick}>
         {showAdvanced ? 'hide advanced settings' : 'show advanced settings'}
       </a>
-    ) : null
+    ) : null;
 
     return (
       <div>
@@ -162,7 +162,7 @@ class ChartInputs extends React.Component {
         {advancedLink}
         {showAdvanced && this.renderFormGroup(advancedFields)}
       </div>
-    )
+    );
   }
 }
 
@@ -171,11 +171,11 @@ ChartInputs.propTypes = {
   onChartConfigurationFieldsChange: PropTypes.func.isRequired,
   queryChartConfigurationFields: PropTypes.object,
   queryResult: PropTypes.object
-}
+};
 
 ChartInputs.defaultProps = {
   queryChartConfigurationFields: {},
   queryResult: {}
-}
+};
 
-export default ChartInputs
+export default ChartInputs;

--- a/client/src/queryEditor/ConnectionDropdown.js
+++ b/client/src/queryEditor/ConnectionDropdown.js
@@ -1,8 +1,8 @@
-import Select from 'antd/lib/select'
-import React from 'react'
-import { ConnectionsContext } from '../connections/ConnectionsStore'
+import Select from 'antd/lib/select';
+import React from 'react';
+import { ConnectionsContext } from '../connections/ConnectionsStore';
 
-const { Option } = Select
+const { Option } = Select;
 
 function ConnectionDropdown() {
   return (
@@ -29,12 +29,12 @@ function ConnectionDropdown() {
               <Option key={conn._id} value={conn._id}>
                 {conn.name}
               </Option>
-            )
+            );
           })}
         </Select>
       )}
     </ConnectionsContext.Consumer>
-  )
+  );
 }
 
-export default ConnectionDropdown
+export default ConnectionDropdown;

--- a/client/src/queryEditor/EditorNavBar.js
+++ b/client/src/queryEditor/EditorNavBar.js
@@ -1,18 +1,18 @@
-import Button from 'antd/lib/button'
-import Form from 'antd/lib/form'
-import Icon from 'antd/lib/icon'
-import Input from 'antd/lib/input'
-import Radio from 'antd/lib/radio'
-import PropTypes from 'prop-types'
-import React from 'react'
-import ConnectionDropDown from './ConnectionDropdown'
+import Button from 'antd/lib/button';
+import Form from 'antd/lib/form';
+import Icon from 'antd/lib/icon';
+import Input from 'antd/lib/input';
+import Radio from 'antd/lib/radio';
+import PropTypes from 'prop-types';
+import React from 'react';
+import ConnectionDropDown from './ConnectionDropdown';
 
-const FormItem = Form.Item
+const FormItem = Form.Item;
 
 class EditorNavBar extends React.Component {
   onQueryNameChange = e => {
-    this.props.onQueryNameChange(e.target.value)
-  }
+    this.props.onQueryNameChange(e.target.value);
+  };
 
   render() {
     const {
@@ -28,12 +28,12 @@ class EditorNavBar extends React.Component {
       query,
       showValidation,
       unsavedChanges
-    } = this.props
+    } = this.props;
 
     const validationState =
-      showValidation && !query.name.length ? 'error' : null
-    const saveText = unsavedChanges ? 'Save*' : 'Save'
-    const cloneDisabled = !query._id
+      showValidation && !query.name.length ? 'error' : null;
+    const saveText = unsavedChanges ? 'Save*' : 'Save';
+    const cloneDisabled = !query._id;
 
     return (
       <div className="w-100 bg-near-white ph2 pv1 bb b--light-gray">
@@ -82,7 +82,7 @@ class EditorNavBar extends React.Component {
           </FormItem>
         </Form>
       </div>
-    )
+    );
   }
 }
 
@@ -99,6 +99,6 @@ EditorNavBar.propTypes = {
   query: PropTypes.object.isRequired,
   showValidation: PropTypes.bool.isRequired,
   unsavedChanges: PropTypes.bool.isRequired
-}
+};
 
-export default EditorNavBar
+export default EditorNavBar;

--- a/client/src/queryEditor/FlexTabPane.js
+++ b/client/src/queryEditor/FlexTabPane.js
@@ -1,21 +1,21 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class FlexTabPane extends React.Component {
   render() {
-    const { activeTabKey, tabKey } = this.props
-    const display = activeTabKey === tabKey ? 'flex' : 'none'
-    return <div style={{ display, width: '100%' }}>{this.props.children}</div>
+    const { activeTabKey, tabKey } = this.props;
+    const display = activeTabKey === tabKey ? 'flex' : 'none';
+    return <div style={{ display, width: '100%' }}>{this.props.children}</div>;
   }
 }
 
 FlexTabPane.propTypes = {
   activeTabKey: PropTypes.string,
   tabKey: PropTypes.string.isRequired
-}
+};
 
 FlexTabPane.defaultProps = {
   activeTabKey: ''
-}
+};
 
-export default FlexTabPane
+export default FlexTabPane;

--- a/client/src/queryEditor/QueryDetailsModal.js
+++ b/client/src/queryEditor/QueryDetailsModal.js
@@ -1,18 +1,18 @@
-import Icon from 'antd/lib/icon'
-import Modal from 'antd/lib/modal'
-import Tooltip from 'antd/lib/tooltip'
-import PropTypes from 'prop-types'
-import React from 'react'
-import EditableTagGroup from '../common/EditableTagGroup'
+import Icon from 'antd/lib/icon';
+import Modal from 'antd/lib/modal';
+import Tooltip from 'antd/lib/tooltip';
+import PropTypes from 'prop-types';
+import React from 'react';
+import EditableTagGroup from '../common/EditableTagGroup';
 
 class QueryDetailsModal extends React.Component {
   onQueryNameChange = e => {
-    this.props.onQueryNameChange(e.target.value)
-  }
+    this.props.onQueryNameChange(e.target.value);
+  };
 
   renderNavLink = (href, text) => {
-    const { query } = this.props
-    const saved = !!query._id
+    const { query } = this.props;
+    const saved = !!query._id;
     if (saved) {
       return (
         <li role="presentation">
@@ -20,7 +20,7 @@ class QueryDetailsModal extends React.Component {
             {text} <Icon type="export" />
           </a>
         </li>
-      )
+      );
     } else {
       return (
         <Tooltip title="Save query to enable table/chart view links">
@@ -35,9 +35,9 @@ class QueryDetailsModal extends React.Component {
             </a>
           </li>
         </Tooltip>
-      )
+      );
     }
-  }
+  };
 
   render() {
     const {
@@ -47,10 +47,10 @@ class QueryDetailsModal extends React.Component {
       query,
       showModal,
       tagOptions
-    } = this.props
+    } = this.props;
 
-    const tableUrl = `${config.baseUrl}/query-table/${query._id}`
-    const chartUrl = `${config.baseUrl}/query-chart/${query._id}`
+    const tableUrl = `${config.baseUrl}/query-table/${query._id}`;
+    const chartUrl = `${config.baseUrl}/query-chart/${query._id}`;
 
     return (
       <Modal
@@ -92,7 +92,7 @@ class QueryDetailsModal extends React.Component {
           {this.renderNavLink(chartUrl, 'Link to Chart')}
         </ul>
       </Modal>
-    )
+    );
   }
 }
 
@@ -103,10 +103,10 @@ QueryDetailsModal.propTypes = {
   query: PropTypes.object.isRequired,
   showModal: PropTypes.bool.isRequired,
   tagOptions: PropTypes.array
-}
+};
 
 QueryDetailsModal.defaultProps = {
   tagOptions: []
-}
+};
 
-export default QueryDetailsModal
+export default QueryDetailsModal;

--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -1,21 +1,21 @@
-import message from 'antd/lib/message'
-import keymaster from 'keymaster'
-import PropTypes from 'prop-types'
-import React from 'react'
-import { Prompt } from 'react-router-dom'
-import SplitPane from 'react-split-pane'
-import sqlFormatter from 'sql-formatter'
-import uuid from 'uuid'
-import QueryResultDataTable from '../common/QueryResultDataTable.js'
-import SqlEditor from '../common/SqlEditor'
-import SqlpadTauChart from '../common/SqlpadTauChart.js'
-import fetchJson from '../utilities/fetch-json.js'
-import EditorNavBar from './EditorNavBar'
-import FlexTabPane from './FlexTabPane'
-import QueryDetailsModal from './QueryDetailsModal'
-import QueryResultHeader from './QueryResultHeader.js'
-import SchemaSidebar from './SchemaSidebar.js'
-import VisSidebar from './VisSidebar'
+import message from 'antd/lib/message';
+import keymaster from 'keymaster';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Prompt } from 'react-router-dom';
+import SplitPane from 'react-split-pane';
+import sqlFormatter from 'sql-formatter';
+import uuid from 'uuid';
+import QueryResultDataTable from '../common/QueryResultDataTable.js';
+import SqlEditor from '../common/SqlEditor';
+import SqlpadTauChart from '../common/SqlpadTauChart.js';
+import fetchJson from '../utilities/fetch-json.js';
+import EditorNavBar from './EditorNavBar';
+import FlexTabPane from './FlexTabPane';
+import QueryDetailsModal from './QueryDetailsModal';
+import QueryResultHeader from './QueryResultHeader.js';
+import SchemaSidebar from './SchemaSidebar.js';
+import VisSidebar from './VisSidebar';
 
 const NEW_QUERY = {
   _id: '',
@@ -27,7 +27,7 @@ const NEW_QUERY = {
     chartType: '',
     fields: {} // key value for chart
   }
-}
+};
 
 class QueryEditor extends React.Component {
   state = {
@@ -43,25 +43,25 @@ class QueryEditor extends React.Component {
     showModal: false,
     showValidation: false,
     selectedText: ''
-  }
+  };
 
-  sqlpadTauChart = undefined
+  sqlpadTauChart = undefined;
 
   getTagOptions() {
-    const { availableTags, query } = this.state
-    const tagOptions = availableTags.slice()
+    const { availableTags, query } = this.state;
+    const tagOptions = availableTags.slice();
     if (query && query.tags) {
       query.tags.forEach(t => {
         if (tagOptions.indexOf(t) === -1) {
-          tagOptions.push(t)
+          tagOptions.push(t);
         }
-      })
+      });
     }
-    return tagOptions
+    return tagOptions;
   }
 
   componentDidUpdate(prevProps) {
-    const { queryId } = this.props
+    const { queryId } = this.props;
 
     if (queryId !== prevProps.queryId) {
       if (queryId === 'new') {
@@ -70,186 +70,190 @@ class QueryEditor extends React.Component {
           queryResult: undefined,
           query: Object.assign({}, NEW_QUERY),
           unsavedChanges: false
-        })
+        });
       }
-      return this.loadQueryFromServer(queryId)
+      return this.loadQueryFromServer(queryId);
     }
   }
 
   loadQueryFromServer = queryId => {
-    const { selectConnection } = this.props
+    const { selectConnection } = this.props;
     fetchJson('GET', `/api/queries/${queryId}`).then(json => {
-      const { error, query } = json
+      const { error, query } = json;
       if (error) {
-        message.error(error)
+        message.error(error);
       }
-      this.setState({ query })
-      selectConnection(query.connectionId)
-    })
-  }
+      this.setState({ query });
+      selectConnection(query.connectionId);
+    });
+  };
 
   loadTagsFromServer = () => {
     fetchJson('GET', '/api/tags').then(json => {
-      const { error, tags } = json
+      const { error, tags } = json;
       if (error) {
-        message.error(error)
+        message.error(error);
       }
-      this.setState({ availableTags: tags })
-    })
-  }
+      this.setState({ availableTags: tags });
+    });
+  };
 
   runQuery = () => {
-    const { cacheKey, query, selectedText } = this.state
-    const { selectedConnectionId } = this.props
+    const { cacheKey, query, selectedText } = this.state;
+    const { selectedConnectionId } = this.props;
 
     this.setState({
       isRunning: true,
       runQueryStartTime: new Date()
-    })
+    });
     const postData = {
       connectionId: selectedConnectionId,
       cacheKey,
       queryName: query.name,
       queryText: selectedText || query.queryText
-    }
+    };
     fetchJson('POST', '/api/query-result', postData).then(json => {
-      if (json.error) message.error(json.error)
+      if (json.error) message.error(json.error);
       this.setState({
         isRunning: false,
         queryError: json.error,
         queryResult: json.queryResult
-      })
-    })
-  }
+      });
+    });
+  };
 
   handleCloneClick = () => {
-    const { config } = this.props
-    const { query } = this.state
-    delete query._id
-    query.name = 'Copy of ' + query.name
-    window.history.replaceState({}, query.name, `${config.baseUrl}/queries/new`)
-    this.setState({ query, unsavedChanges: true })
-  }
+    const { config } = this.props;
+    const { query } = this.state;
+    delete query._id;
+    query.name = 'Copy of ' + query.name;
+    window.history.replaceState(
+      {},
+      query.name,
+      `${config.baseUrl}/queries/new`
+    );
+    this.setState({ query, unsavedChanges: true });
+  };
 
   formatQuery = () => {
-    const { query } = this.state
-    query.queryText = sqlFormatter.format(query.queryText)
+    const { query } = this.state;
+    query.queryText = sqlFormatter.format(query.queryText);
     this.setState({
       query,
       unsavedChanges: true
-    })
-  }
+    });
+  };
 
   saveQuery = () => {
-    const { query } = this.state
-    const { config, selectedConnectionId } = this.props
+    const { query } = this.state;
+    const { config, selectedConnectionId } = this.props;
     if (!query.name) {
-      message.error('Query name required')
-      this.setState({ showValidation: true })
-      return
+      message.error('Query name required');
+      this.setState({ showValidation: true });
+      return;
     }
-    this.setState({ isSaving: true })
+    this.setState({ isSaving: true });
     const queryData = Object.assign({}, query, {
       connectionId: selectedConnectionId
-    })
+    });
     if (query._id) {
       fetchJson('PUT', `/api/queries/${query._id}`, queryData).then(json => {
-        const { error, query } = json
+        const { error, query } = json;
         if (error) {
-          message.error(error)
-          this.setState({ isSaving: false })
-          return
+          message.error(error);
+          this.setState({ isSaving: false });
+          return;
         }
-        message.success('Query Saved')
-        this.setState({ isSaving: false, unsavedChanges: false, query })
-      })
+        message.success('Query Saved');
+        this.setState({ isSaving: false, unsavedChanges: false, query });
+      });
     } else {
       fetchJson('POST', `/api/queries`, queryData).then(json => {
-        const { error, query } = json
+        const { error, query } = json;
         if (error) {
-          message.error(error)
-          this.setState({ isSaving: false })
-          return
+          message.error(error);
+          this.setState({ isSaving: false });
+          return;
         }
         window.history.replaceState(
           {},
           query.name,
           `${config.baseUrl}/queries/${query._id}`
-        )
-        message.success('Query Saved')
-        this.setState({ isSaving: false, unsavedChanges: false, query })
-      })
+        );
+        message.success('Query Saved');
+        this.setState({ isSaving: false, unsavedChanges: false, query });
+      });
     }
-  }
+  };
 
   setQueryState = (field, value) => {
-    const { query } = this.state
-    query[field] = value
-    this.setState({ query, unsavedChanges: true })
-  }
+    const { query } = this.state;
+    query[field] = value;
+    this.setState({ query, unsavedChanges: true });
+  };
 
   handleChartConfigurationFieldsChange = (chartFieldId, queryResultField) => {
-    const { query } = this.state
-    query.chartConfiguration.fields[chartFieldId] = queryResultField
-    this.setState({ query, unsavedChanges: true })
-  }
+    const { query } = this.state;
+    query.chartConfiguration.fields[chartFieldId] = queryResultField;
+    this.setState({ query, unsavedChanges: true });
+  };
 
   handleChartTypeChange = value => {
-    const { query } = this.state
-    query.chartConfiguration.chartType = value
-    this.setState({ query, unsavedChanges: true })
-  }
+    const { query } = this.state;
+    query.chartConfiguration.chartType = value;
+    this.setState({ query, unsavedChanges: true });
+  };
 
   handleConnectionChange = connectionId =>
-    this.props.selectConnection(connectionId)
+    this.props.selectConnection(connectionId);
 
   handleModalHide = () => {
-    this.setState({ showModal: false })
-  }
+    this.setState({ showModal: false });
+  };
 
-  handleQueryNameChange = name => this.setQueryState('name', name)
+  handleQueryNameChange = name => this.setQueryState('name', name);
 
-  handleMoreClick = () => this.setState({ showModal: true })
+  handleMoreClick = () => this.setState({ showModal: true });
 
-  handleQueryTagsChange = values => this.setQueryState('tags', values)
+  handleQueryTagsChange = values => this.setQueryState('tags', values);
 
   handleQueryTextChange = queryText =>
-    this.setQueryState('queryText', queryText)
+    this.setQueryState('queryText', queryText);
 
   handleQuerySelectionChange = selectedText => {
-    this.setState({ selectedText })
-  }
+    this.setState({ selectedText });
+  };
 
   handleSaveImageClick = e => {
     if (this.sqlpadTauChart && this.sqlpadTauChart.chart) {
-      this.sqlpadTauChart.chart.fire('exportTo', 'png')
+      this.sqlpadTauChart.chart.fire('exportTo', 'png');
     }
-  }
+  };
 
   handleTabSelect = e => {
-    this.setState({ activeTabKey: e.target.value })
-  }
+    this.setState({ activeTabKey: e.target.value });
+  };
 
-  handleVisualizeClick = () => this.sqlpadTauChart.renderChart(true)
+  handleVisualizeClick = () => this.sqlpadTauChart.renderChart(true);
 
   hasRows = () => {
-    const queryResult = this.state.queryResult
-    return !!(queryResult && queryResult.rows && queryResult.rows.length)
-  }
+    const queryResult = this.state.queryResult;
+    return !!(queryResult && queryResult.rows && queryResult.rows.length);
+  };
 
   isChartable = () => {
-    const { isRunning, queryError, activeTabKey } = this.state
-    const pending = isRunning || queryError
-    return !pending && activeTabKey === 'vis' && this.hasRows()
-  }
+    const { isRunning, queryError, activeTabKey } = this.state;
+    const pending = isRunning || queryError;
+    return !pending && activeTabKey === 'vis' && this.hasRows();
+  };
 
   async componentDidMount() {
-    const { queryId, loadConnections } = this.props
+    const { queryId, loadConnections } = this.props;
 
-    await loadConnections()
-    this.loadTagsFromServer()
+    await loadConnections();
+    this.loadTagsFromServer();
     if (queryId !== 'new') {
-      this.loadQueryFromServer(queryId)
+      this.loadQueryFromServer(queryId);
     }
 
     /*  Shortcuts
@@ -257,62 +261,62 @@ class QueryEditor extends React.Component {
     // keymaster doesn't fire on input/textarea events by default
     // since we are only using command/ctrl shortcuts,
     // we want the event to fire all the time for any element
-    keymaster.filter = () => true
-    keymaster.unbind('ctrl+s, command+s')
+    keymaster.filter = () => true;
+    keymaster.unbind('ctrl+s, command+s');
     keymaster('ctrl+s, command+s', e => {
-      this.saveQuery()
-      e.preventDefault()
-      return false
-    })
+      this.saveQuery();
+      e.preventDefault();
+      return false;
+    });
     // there should only ever be 1 QueryEditor on the page,
     // but just in case there isn't unbind anything previously bound
     // rather something previously not run than something run more than once
-    keymaster.unbind('ctrl+r, command+r, ctrl+e, command+e')
+    keymaster.unbind('ctrl+r, command+r, ctrl+e, command+e');
     keymaster('ctrl+r, command+r, ctrl+e, command+e', e => {
-      message.info('Shortcut changed to ctrl+return / command+return')
-      e.preventDefault()
-      return false
-    })
-    keymaster.unbind('ctrl+return, command+return')
+      message.info('Shortcut changed to ctrl+return / command+return');
+      e.preventDefault();
+      return false;
+    });
+    keymaster.unbind('ctrl+return, command+return');
     keymaster('ctrl+return, command+return', e => {
-      this.runQuery()
-      e.preventDefault()
-      return false
-    })
-    keymaster.unbind('alt+r')
+      this.runQuery();
+      e.preventDefault();
+      return false;
+    });
+    keymaster.unbind('alt+r');
     keymaster('alt+r', e => {
-      message.info('Shortcut changed to shift+return')
-      e.preventDefault()
-      return false
-    })
-    keymaster.unbind('shift+return')
+      message.info('Shortcut changed to shift+return');
+      e.preventDefault();
+      return false;
+    });
+    keymaster.unbind('shift+return');
     keymaster('shift+return', e => {
-      this.formatQuery()
-      e.preventDefault()
-      return false
-    })
+      this.formatQuery();
+      e.preventDefault();
+      return false;
+    });
   }
 
   componentWillUnmount() {
-    keymaster.unbind('ctrl+return, command+return')
-    keymaster.unbind('ctrl+s, command+s')
-    keymaster.unbind('ctrl+r, command+r, ctrl+e, command+e')
-    keymaster.unbind('alt+r')
-    keymaster.unbind('shift+return')
+    keymaster.unbind('ctrl+return, command+return');
+    keymaster.unbind('ctrl+s, command+s');
+    keymaster.unbind('ctrl+r, command+r, ctrl+e, command+e');
+    keymaster.unbind('alt+r');
+    keymaster.unbind('shift+return');
   }
 
   handleFormatClick = () => {
-    this.formatQuery()
-  }
+    this.formatQuery();
+  };
 
   handleVisPaneResize = () => {
     if (this.sqlpadTauChart && this.sqlpadTauChart.chart) {
-      this.sqlpadTauChart.chart.resize()
+      this.sqlpadTauChart.chart.resize();
     }
-  }
+  };
 
   render() {
-    const { config } = this.props
+    const { config } = this.props;
     const {
       activeTabKey,
       cacheKey,
@@ -326,9 +330,9 @@ class QueryEditor extends React.Component {
       showModal,
       showValidation,
       unsavedChanges
-    } = this.state
+    } = this.state;
 
-    document.title = query.name || 'New Query'
+    document.title = query.name || 'New Query';
 
     return (
       <div className="flex w-100" style={{ flexDirection: 'column' }}>
@@ -425,7 +429,7 @@ class QueryEditor extends React.Component {
                   queryResult={queryResult}
                   renderChart={this.isChartable()}
                   ref={ref => {
-                    this.sqlpadTauChart = ref
+                    this.sqlpadTauChart = ref;
                   }}
                 />
               </div>
@@ -445,7 +449,7 @@ class QueryEditor extends React.Component {
           message={location => `Leave without saving?`}
         />
       </div>
-    )
+    );
   }
 }
 
@@ -454,6 +458,6 @@ QueryEditor.propTypes = {
   selectedConnectionId: PropTypes.string,
   selectConnection: PropTypes.func,
   loadConnections: PropTypes.func
-}
+};
 
-export default QueryEditor
+export default QueryEditor;

--- a/client/src/queryEditor/QueryEditorContainer.js
+++ b/client/src/queryEditor/QueryEditorContainer.js
@@ -1,16 +1,16 @@
-import Icon from 'antd/lib/icon'
-import Menu from 'antd/lib/menu'
-import React from 'react'
-import AppNav from '../AppNav'
-import ConnectionListDrawer from '../connections/ConnectionListDrawer'
-import { ConnectionsContext } from '../connections/ConnectionsStore'
-import AppContext from '../containers/AppContext'
-import QueryEditor from './QueryEditor'
+import Icon from 'antd/lib/icon';
+import Menu from 'antd/lib/menu';
+import React from 'react';
+import AppNav from '../AppNav';
+import ConnectionListDrawer from '../connections/ConnectionListDrawer';
+import { ConnectionsContext } from '../connections/ConnectionsStore';
+import AppContext from '../containers/AppContext';
+import QueryEditor from './QueryEditor';
 
 class QueryEditorContainer extends React.Component {
   state = {
     visible: false
-  }
+  };
   render() {
     return (
       <AppNav
@@ -45,8 +45,8 @@ class QueryEditorContainer extends React.Component {
           onClose={() => this.setState({ visible: false })}
         />
       </AppNav>
-    )
+    );
   }
 }
 
-export default QueryEditorContainer
+export default QueryEditorContainer;

--- a/client/src/queryEditor/QueryResultHeader.js
+++ b/client/src/queryEditor/QueryResultHeader.js
@@ -1,15 +1,17 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import IncompleteDataNotification from '../common/IncompleteDataNotification'
-import SecondsTimer from '../common/SecondsTimer.js'
+import React from 'react';
+import PropTypes from 'prop-types';
+import IncompleteDataNotification from '../common/IncompleteDataNotification';
+import SecondsTimer from '../common/SecondsTimer.js';
 
 class QueryResultHeader extends React.Component {
   renderDownloadLinks() {
-    const { cacheKey, config } = this.props
-    const csvDownloadLink = `${config.baseUrl}/download-results/${cacheKey}.csv`
+    const { cacheKey, config } = this.props;
+    const csvDownloadLink = `${
+      config.baseUrl
+    }/download-results/${cacheKey}.csv`;
     const xlsxDownloadLink = `${
       config.baseUrl
-    }/download-results/${cacheKey}.xlsx`
+    }/download-results/${cacheKey}.xlsx`;
     if (config.allowCsvDownload) {
       return (
         <span>
@@ -31,12 +33,12 @@ class QueryResultHeader extends React.Component {
             .xlsx
           </a>
         </span>
-      )
+      );
     }
   }
 
   render() {
-    const { isRunning, queryResult, runQueryStartTime } = this.props
+    const { isRunning, queryResult, runQueryStartTime } = this.props;
     if (isRunning || !queryResult) {
       return (
         <div
@@ -52,16 +54,16 @@ class QueryResultHeader extends React.Component {
             </span>
           ) : null}
         </div>
-      )
+      );
     }
 
     const serverSec = queryResult
       ? queryResult.queryRunTime / 1000 + ' sec.'
-      : ''
+      : '';
     const rowCount =
-      queryResult && queryResult.rows ? queryResult.rows.length : ''
+      queryResult && queryResult.rows ? queryResult.rows.length : '';
 
-    const incomplete = queryResult ? queryResult.incomplete : false
+    const incomplete = queryResult ? queryResult.incomplete : false;
 
     return (
       <div
@@ -81,7 +83,7 @@ class QueryResultHeader extends React.Component {
           <IncompleteDataNotification incomplete={incomplete} />
         </span>
       </div>
-    )
+    );
   }
 }
 
@@ -91,12 +93,12 @@ QueryResultHeader.propTypes = {
   isRunning: PropTypes.bool,
   queryResult: PropTypes.object,
   runQueryStartTime: PropTypes.instanceOf(Date)
-}
+};
 
 QueryResultHeader.defaultProps = {
   cacheKey: '',
   config: {},
   isRunning: false
-}
+};
 
-export default QueryResultHeader
+export default QueryResultHeader;

--- a/client/src/queryEditor/SchemaSidebar.js
+++ b/client/src/queryEditor/SchemaSidebar.js
@@ -1,12 +1,12 @@
-import Icon from 'antd/lib/icon'
-import Tooltip from 'antd/lib/tooltip'
-import React from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
-import Sidebar from '../common/Sidebar'
-import SidebarBody from '../common/SidebarBody'
-import { ConnectionsContext } from '../connections/ConnectionsStore'
-import fetchJson from '../utilities/fetch-json.js'
-import updateCompletions from '../utilities/updateCompletions.js'
+import Icon from 'antd/lib/icon';
+import Tooltip from 'antd/lib/tooltip';
+import React from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import Sidebar from '../common/Sidebar';
+import SidebarBody from '../common/SidebarBody';
+import { ConnectionsContext } from '../connections/ConnectionsStore';
+import fetchJson from '../utilities/fetch-json.js';
+import updateCompletions from '../utilities/updateCompletions.js';
 
 const SchemaSidebarContainer = props => {
   return (
@@ -15,25 +15,25 @@ const SchemaSidebarContainer = props => {
         <SchemaSidebar {...props} connectionId={context.selectedConnectionId} />
       )}
     </ConnectionsContext.Consumer>
-  )
-}
+  );
+};
 
 class SchemaSidebar extends React.PureComponent {
   state = {
     schemaInfo: {},
     loading: false
-  }
+  };
 
   componentDidMount() {
-    const { connectionId } = this.props
+    const { connectionId } = this.props;
     if (connectionId) {
-      this.getSchemaInfo(connectionId)
+      this.getSchemaInfo(connectionId);
     }
   }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.connectionId !== nextProps.connectionId) {
-      this.getSchemaInfo(nextProps.connectionId)
+      this.getSchemaInfo(nextProps.connectionId);
     }
   }
 
@@ -42,40 +42,40 @@ class SchemaSidebar extends React.PureComponent {
       this.setState({
         schemaInfo: {},
         loading: true
-      })
-      const qs = reload ? '?reload=true' : ''
+      });
+      const qs = reload ? '?reload=true' : '';
       fetchJson('GET', `/api/schema-info/${connectionId}${qs}`).then(json => {
-        const { error, schemaInfo } = json
+        const { error, schemaInfo } = json;
         if (error) {
-          console.error(error)
+          console.error(error);
         }
-        updateCompletions(schemaInfo)
+        updateCompletions(schemaInfo);
         this.setState({
           schemaInfo: schemaInfo
-        })
+        });
         // sometimes refreshes happen so fast and people don't get to enjoy the animation
         setTimeout(() => {
-          this.setState({ loading: false })
-        }, 1000)
-      })
+          this.setState({ loading: false });
+        }, 1000);
+      });
     } else {
       this.setState({
         schemaInfo: {}
-      })
+      });
     }
-  }
+  };
 
   handleRefreshClick = e => {
-    e.preventDefault()
-    this.getSchemaInfo(this.props.connectionId, true)
-  }
+    e.preventDefault();
+    this.getSchemaInfo(this.props.connectionId, true);
+  };
 
   render() {
-    const { loading, schemaInfo } = this.state
-    const refreshClass = loading ? 'spinning' : ''
+    const { loading, schemaInfo } = this.state;
+    const refreshClass = loading ? 'spinning' : '';
 
-    const schemaCount = schemaInfo ? Object.keys(schemaInfo).length : 0
-    const initShowTables = schemaCount <= 2
+    const schemaCount = schemaInfo ? Object.keys(schemaInfo).length : 0;
+    const initShowTables = schemaCount <= 2;
     const schemaItemNodes = schemaInfo
       ? Object.keys(schemaInfo).map(schema => {
           return (
@@ -86,9 +86,9 @@ class SchemaSidebar extends React.PureComponent {
               schema={schema}
               tables={schemaInfo[schema]}
             />
-          )
+          );
         })
-      : null
+      : null;
 
     return (
       <Sidebar>
@@ -109,27 +109,27 @@ class SchemaSidebar extends React.PureComponent {
           </div>
         </SidebarBody>
       </Sidebar>
-    )
+    );
   }
 }
 
 class SchemaInfoSchemaItem extends React.Component {
   state = {
     showTables: this.props.initShowTables
-  }
+  };
 
   handleClick = e => {
-    e.stopPropagation()
-    e.preventDefault()
+    e.stopPropagation();
+    e.preventDefault();
     this.setState({
       showTables: !this.state.showTables
-    })
-  }
+    });
+  };
 
   render() {
-    const { showTables } = this.state
-    const { schema, tables } = this.props
-    let tableJsx
+    const { showTables } = this.state;
+    const { schema, tables } = this.props;
+    let tableJsx;
     if (showTables) {
       tableJsx = Object.keys(tables).map(table => {
         return (
@@ -140,8 +140,8 @@ class SchemaInfoSchemaItem extends React.Component {
             table={table}
             columns={tables[table]}
           />
-        )
-      })
+        );
+      });
     }
     return (
       <li className="list" key={schema}>
@@ -155,7 +155,7 @@ class SchemaInfoSchemaItem extends React.Component {
         </a>
         <ul className="pl3">{tableJsx}</ul>
       </li>
-    )
+    );
   }
 }
 
@@ -164,44 +164,44 @@ class SchemaInfoTableItem extends React.Component {
     showColumns: false,
     showCopyButton: false,
     copyButtonText: 'copy'
-  }
+  };
 
   handleClick = e => {
-    e.stopPropagation()
-    e.preventDefault()
+    e.stopPropagation();
+    e.preventDefault();
     this.setState({
       showColumns: !this.state.showColumns
-    })
-  }
+    });
+  };
 
   handleMouseOver = e => {
     this.setState({
       showCopyButton: true
-    })
-  }
+    });
+  };
 
   handleMouseOut = e => {
     this.setState({
       showCopyButton: false
-    })
-  }
+    });
+  };
 
   handleCopyClick = e => {
-    e.stopPropagation()
-    e.preventDefault()
-  }
+    e.stopPropagation();
+    e.preventDefault();
+  };
 
   handleCopy = e => {
-    this.setState({ copyButtonText: 'copied' })
+    this.setState({ copyButtonText: 'copied' });
     setTimeout(() => {
-      this.setState({ copyButtonText: 'copy' })
-    }, 2000)
-  }
+      this.setState({ copyButtonText: 'copy' });
+    }, 2000);
+  };
 
   render() {
-    const { columns, config, schema, table } = this.props
-    const { showColumns, showCopyButton, copyButtonText } = this.state
-    let columnJsx
+    const { columns, config, schema, table } = this.props;
+    const { showColumns, showCopyButton, copyButtonText } = this.state;
+    let columnJsx;
     if (showColumns) {
       columnJsx = columns.map(column => {
         if (column.column_name) {
@@ -215,7 +215,7 @@ class SchemaInfoTableItem extends React.Component {
               schema={schema}
               table={table}
             />
-          )
+          );
         } else {
           return (
             <SchemaInfoColumnItem
@@ -226,14 +226,14 @@ class SchemaInfoTableItem extends React.Component {
               schema={schema}
               table={table}
             />
-          )
+          );
         }
-      })
+      });
     }
 
     const copyButtonClassName = showCopyButton
       ? 'right-2 pointer absolute bg-black hover-bg-hot-pink label'
-      : 'right-2 pointer absolute bg-black hover-bg-hot-pink label dn'
+      : 'right-2 pointer absolute bg-black hover-bg-hot-pink label dn';
     const getCopyToClipboard = () => {
       if (config && config.showSchemaCopyButton) {
         return (
@@ -246,9 +246,9 @@ class SchemaInfoTableItem extends React.Component {
               {copyButtonText}
             </span>
           </CopyToClipboard>
-        )
+        );
       }
-    }
+    };
     return (
       <li className="list" key={table}>
         <a
@@ -264,7 +264,7 @@ class SchemaInfoTableItem extends React.Component {
         </a>
         <ul className="pl3">{columnJsx}</ul>
       </li>
-    )
+    );
   }
 }
 
@@ -272,34 +272,34 @@ class SchemaInfoColumnItem extends React.Component {
   state = {
     showCopyButton: false,
     copyButtonText: 'copy'
-  }
+  };
 
   handleMouseOver = e => {
     this.setState({
       showCopyButton: true
-    })
-  }
+    });
+  };
 
   handleMouseOut = e => {
     this.setState({
       showCopyButton: false
-    })
-  }
+    });
+  };
 
   handleCopyClick = e => {
-    e.stopPropagation()
-    e.preventDefault()
-  }
+    e.stopPropagation();
+    e.preventDefault();
+  };
 
   handleCopy = () => {
-    this.setState({ copyButtonText: 'copied' })
+    this.setState({ copyButtonText: 'copied' });
     setTimeout(() => {
-      this.setState({ copyButtonText: 'copy' })
-    }, 2000)
-  }
+      this.setState({ copyButtonText: 'copy' });
+    }, 2000);
+  };
 
   render() {
-    const { copyButtonText, showCopyButton } = this.state
+    const { copyButtonText, showCopyButton } = this.state;
     const {
       config,
       column_name,
@@ -307,10 +307,10 @@ class SchemaInfoColumnItem extends React.Component {
       column_description,
       schema,
       table
-    } = this.props
+    } = this.props;
     const copyButtonClassName = showCopyButton
       ? 'right-2 pointer absolute bg-black hover-bg-hot-pink label label-info'
-      : 'right-2 pointer absolute bg-black hover-bg-hot-pink label label-info dn'
+      : 'right-2 pointer absolute bg-black hover-bg-hot-pink label label-info dn';
     const getCopyToClipboard = () => {
       if (config && config.showSchemaCopyButton) {
         return (
@@ -326,11 +326,11 @@ class SchemaInfoColumnItem extends React.Component {
               {copyButtonText}
             </span>
           </CopyToClipboard>
-        )
+        );
       }
-    }
+    };
 
-    const description = column_description && ` - ${column_description}`
+    const description = column_description && ` - ${column_description}`;
     return (
       <li className="list">
         <span
@@ -345,8 +345,8 @@ class SchemaInfoColumnItem extends React.Component {
           {getCopyToClipboard()}
         </span>
       </li>
-    )
+    );
   }
 }
 
-export default SchemaSidebarContainer
+export default SchemaSidebarContainer;

--- a/client/src/queryEditor/VisSidebar.js
+++ b/client/src/queryEditor/VisSidebar.js
@@ -1,14 +1,14 @@
-import Button from 'antd/lib/button'
-import Icon from 'antd/lib/icon'
-import Select from 'antd/lib/select'
-import PropTypes from 'prop-types'
-import React from 'react'
-import Sidebar from '../common/Sidebar'
-import SidebarBody from '../common/SidebarBody'
-import chartDefinitions from '../utilities/chartDefinitions.js'
-import ChartInputs from './ChartInputs.js'
+import Button from 'antd/lib/button';
+import Icon from 'antd/lib/icon';
+import Select from 'antd/lib/select';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Sidebar from '../common/Sidebar';
+import SidebarBody from '../common/SidebarBody';
+import chartDefinitions from '../utilities/chartDefinitions.js';
+import ChartInputs from './ChartInputs.js';
 
-const { Option } = Select
+const { Option } = Select;
 
 class VisSidebar extends React.Component {
   render() {
@@ -20,15 +20,15 @@ class VisSidebar extends React.Component {
       onVisualizeClick,
       query,
       queryResult
-    } = this.props
+    } = this.props;
 
     const chartOptions = chartDefinitions.map(d => {
       return (
         <Option key={d.chartType} value={d.chartType}>
           {d.chartLabel}
         </Option>
-      )
-    })
+      );
+    });
 
     return (
       <Sidebar>
@@ -70,7 +70,7 @@ class VisSidebar extends React.Component {
           </Button>
         </div>
       </Sidebar>
-    )
+    );
   }
 }
 
@@ -82,6 +82,6 @@ VisSidebar.propTypes = {
   onVisualizeClick: PropTypes.func,
   query: PropTypes.object,
   queryResult: PropTypes.object
-}
+};
 
-export default VisSidebar
+export default VisSidebar;

--- a/client/src/users/InviteUserForm.js
+++ b/client/src/users/InviteUserForm.js
@@ -1,57 +1,57 @@
-import Button from 'antd/lib/button'
-import Form from 'antd/lib/form'
-import Input from 'antd/lib/input'
-import message from 'antd/lib/message'
-import Select from 'antd/lib/select'
-import React from 'react'
-import AppContext from '../containers/AppContext'
-import fetchJson from '../utilities/fetch-json.js'
+import Button from 'antd/lib/button';
+import Form from 'antd/lib/form';
+import Input from 'antd/lib/input';
+import message from 'antd/lib/message';
+import Select from 'antd/lib/select';
+import React from 'react';
+import AppContext from '../containers/AppContext';
+import fetchJson from '../utilities/fetch-json.js';
 
-const FormItem = Form.Item
-const { Option } = Select
+const FormItem = Form.Item;
+const { Option } = Select;
 
 class InviteUserForm extends React.Component {
   state = {
     email: null,
     role: null,
     isInviting: null
-  }
+  };
 
   onEmailChange = e => {
-    this.setState({ email: e.target.value })
-  }
+    this.setState({ email: e.target.value });
+  };
 
   onRoleChange = role => {
-    this.setState({ role })
-  }
+    this.setState({ role });
+  };
 
   onInviteClick = e => {
-    const { onInvited } = this.props
+    const { onInvited } = this.props;
     const user = {
       email: this.state.email,
       role: this.state.role
-    }
+    };
     this.setState({
       isInviting: true
-    })
+    });
     fetchJson('POST', '/api/users', user).then(json => {
       this.setState({
         isInviting: false
-      })
+      });
       if (json.error) {
-        return message.error('Whitelist failed: ' + json.error.toString())
+        return message.error('Whitelist failed: ' + json.error.toString());
       }
-      message.success('User Whitelisted')
+      message.success('User Whitelisted');
       this.setState({
         email: null,
         role: null
-      })
-      onInvited()
-    })
-  }
+      });
+      onInvited();
+    });
+  };
 
   render() {
-    const { email, role, isInviting } = this.state
+    const { email, role, isInviting } = this.state;
 
     return (
       <AppContext.Consumer>
@@ -107,8 +107,8 @@ class InviteUserForm extends React.Component {
           </div>
         )}
       </AppContext.Consumer>
-    )
+    );
   }
 }
 
-export default InviteUserForm
+export default InviteUserForm;

--- a/client/src/users/UsersView.js
+++ b/client/src/users/UsersView.js
@@ -1,122 +1,122 @@
-import Button from 'antd/lib/button'
-import Layout from 'antd/lib/layout'
-import message from 'antd/lib/message'
-import Modal from 'antd/lib/modal'
-import Popconfirm from 'antd/lib/popconfirm'
-import Select from 'antd/lib/select'
-import Table from 'antd/lib/table'
-import moment from 'moment'
-import React from 'react'
-import { Link } from 'react-router-dom'
-import uuid from 'uuid'
-import AppNav from '../AppNav'
-import Header from '../common/Header'
-import AppContext from '../containers/AppContext'
-import fetchJson from '../utilities/fetch-json.js'
-import InviteUserForm from './InviteUserForm'
+import Button from 'antd/lib/button';
+import Layout from 'antd/lib/layout';
+import message from 'antd/lib/message';
+import Modal from 'antd/lib/modal';
+import Popconfirm from 'antd/lib/popconfirm';
+import Select from 'antd/lib/select';
+import Table from 'antd/lib/table';
+import moment from 'moment';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import uuid from 'uuid';
+import AppNav from '../AppNav';
+import Header from '../common/Header';
+import AppContext from '../containers/AppContext';
+import fetchJson from '../utilities/fetch-json.js';
+import InviteUserForm from './InviteUserForm';
 
-const { Content } = Layout
-const { Column } = Table
-const { Option } = Select
+const { Content } = Layout;
+const { Column } = Table;
+const { Option } = Select;
 
 class UsersView extends React.Component {
   state = {
     users: [],
     isSaving: false,
     showAddUser: false
-  }
+  };
 
   componentDidMount() {
-    document.title = 'SQLPad - Users'
-    this.loadUsersFromServer()
+    document.title = 'SQLPad - Users';
+    this.loadUsersFromServer();
   }
 
   handleDelete = user => {
     fetchJson('DELETE', '/api/users/' + user._id).then(json => {
       if (json.error) {
-        return message.error('Delete Failed: ' + json.error.toString())
+        return message.error('Delete Failed: ' + json.error.toString());
       }
-      message.success('User Deleted')
-      this.loadUsersFromServer()
-    })
-  }
+      message.success('User Deleted');
+      this.loadUsersFromServer();
+    });
+  };
 
   loadUsersFromServer = () => {
     fetchJson('GET', '/api/users').then(json => {
       if (json.error) {
-        message.error(json.error)
+        message.error(json.error);
       }
       if (json.users) {
         const users = json.users.map(user => {
-          user.key = user._id
-          return user
-        })
-        this.setState({ users })
+          user.key = user._id;
+          return user;
+        });
+        this.setState({ users });
       }
-    })
-  }
+    });
+  };
 
   updateUserRole = user => {
-    this.setState({ isSaving: true })
+    this.setState({ isSaving: true });
     fetchJson('PUT', '/api/users/' + user._id, {
       role: user.role
     }).then(json => {
-      this.loadUsersFromServer()
-      this.setState({ isSaving: false })
+      this.loadUsersFromServer();
+      this.setState({ isSaving: false });
       if (json.error) {
-        return message.error('Update failed: ' + json.error.toString())
+        return message.error('Update failed: ' + json.error.toString());
       }
-      message.success('User Updated')
-    })
-  }
+      message.success('User Updated');
+    });
+  };
 
   generatePasswordResetLink = user => {
-    this.setState({ isSaving: true })
-    const passwordResetId = uuid.v4()
+    this.setState({ isSaving: true });
+    const passwordResetId = uuid.v4();
     fetchJson('PUT', '/api/users/' + user._id, {
       passwordResetId
     }).then(json => {
-      this.loadUsersFromServer()
-      this.setState({ isSaving: false })
+      this.loadUsersFromServer();
+      this.setState({ isSaving: false });
       if (json.error) {
-        return message.error('Update failed: ' + json.error.toString())
+        return message.error('Update failed: ' + json.error.toString());
       }
-      message.success('Password link generated')
-    })
-  }
+      message.success('Password link generated');
+    });
+  };
 
   removePasswordResetLink = user => {
-    this.setState({ isSaving: true })
+    this.setState({ isSaving: true });
     fetchJson('PUT', '/api/users/' + user._id, {
       passwordResetId: ''
     }).then(json => {
-      this.loadUsersFromServer()
-      this.setState({ isSaving: false })
+      this.loadUsersFromServer();
+      this.setState({ isSaving: false });
       if (json.error) {
-        return message.error('Update failed: ' + json.error.toString())
+        return message.error('Update failed: ' + json.error.toString());
       }
-      message.success('Password reset link removed')
-    })
-  }
+      message.success('Password reset link removed');
+    });
+  };
 
   handleOnInvited = () => {
-    this.loadUsersFromServer()
-    this.setState({ showAddUser: false })
-  }
+    this.loadUsersFromServer();
+    this.setState({ showAddUser: false });
+  };
 
   createdRender = (text, record) => {
     return !record.signupDate ? (
       <em>not signed up yet</em>
     ) : (
       moment(record.signupDate).calendar()
-    )
-  }
+    );
+  };
 
   roleRender = (text, record) => {
     return (
       <AppContext.Consumer>
         {appContext => {
-          const { currentUser } = appContext
+          const { currentUser } = appContext;
 
           return (
             <Select
@@ -125,18 +125,18 @@ class UsersView extends React.Component {
               disabled={currentUser && currentUser._id === record._id}
               value={record.role || ''}
               onChange={value => {
-                record.role = value
-                return this.updateUserRole(record)
+                record.role = value;
+                return this.updateUserRole(record);
               }}
             >
               <Option value="editor">Editor</Option>
               <Option value="admin">Admin</Option>
             </Select>
-          )
+          );
         }}
       </AppContext.Consumer>
-    )
-  }
+    );
+  };
 
   resetButtonRender = (text, record) => {
     if (record.passwordResetId) {
@@ -152,7 +152,7 @@ class UsersView extends React.Component {
             Reset Link
           </Link>
         </span>
-      )
+      );
     }
     return (
       <Button
@@ -161,11 +161,11 @@ class UsersView extends React.Component {
       >
         Generate Link
       </Button>
-    )
-  }
+    );
+  };
 
   renderTable() {
-    const { users } = this.state
+    const { users } = this.state;
     return (
       <Table
         locale={{ emptyText: 'No users found' }}
@@ -195,15 +195,15 @@ class UsersView extends React.Component {
               >
                 <Button icon="delete" type="danger" />
               </Popconfirm>
-            )
+            );
           }}
         />
       </Table>
-    )
+    );
   }
 
   renderModal() {
-    const { showAddUser } = this.state
+    const { showAddUser } = this.state;
     return (
       <Modal
         title="New user"
@@ -215,7 +215,7 @@ class UsersView extends React.Component {
       >
         <InviteUserForm onInvited={this.handleOnInvited} />
       </Modal>
-    )
+    );
   }
 
   render() {
@@ -239,8 +239,8 @@ class UsersView extends React.Component {
           </Content>
         </Layout>
       </AppNav>
-    )
+    );
   }
 }
 
-export default UsersView
+export default UsersView;

--- a/client/src/utilities/chartDefinitions.js
+++ b/client/src/utilities/chartDefinitions.js
@@ -276,6 +276,6 @@ const chartDefinitions = [
       }
     ]
   }
-]
+];
 
-export default chartDefinitions
+export default chartDefinitions;

--- a/client/src/utilities/fetch-json.js
+++ b/client/src/utilities/fetch-json.js
@@ -1,8 +1,8 @@
-import 'whatwg-fetch'
-import message from 'antd/lib/message'
+import 'whatwg-fetch';
+import message from 'antd/lib/message';
 
 export default function fetchJson(method, url, body) {
-  const BASE_URL = window.BASE_URL || ''
+  const BASE_URL = window.BASE_URL || '';
   const opts = {
     method: method.toUpperCase(),
     credentials: 'same-origin',
@@ -13,14 +13,14 @@ export default function fetchJson(method, url, body) {
       Expires: '-1',
       Pragma: 'no-cache'
     }
-  }
+  };
   if (body) {
-    opts.body = JSON.stringify(body)
+    opts.body = JSON.stringify(body);
   }
 
-  let fetchUrl = BASE_URL + url
+  let fetchUrl = BASE_URL + url;
   if (BASE_URL && url.substring(0, 1) !== '/') {
-    fetchUrl = BASE_URL + '/' + url
+    fetchUrl = BASE_URL + '/' + url;
   }
 
   return fetch(fetchUrl, opts)
@@ -28,18 +28,18 @@ export default function fetchJson(method, url, body) {
       // API server will send 200 even if error occurs
       // Eventually this should change to proper status code usage
       if (response.redirected) {
-        return (window.location = response.url)
+        return (window.location = response.url);
       } else if (response.status === 200) {
-        return response.json()
+        return response.json();
       } else {
-        console.error(response)
-        throw new Error('Server responded not ok')
+        console.error(response);
+        throw new Error('Server responded not ok');
       }
     })
     .catch(error => {
-      message.error(error.toString())
+      message.error(error.toString());
       return {
         error: 'Server responded not ok'
-      }
-    })
+      };
+    });
 }

--- a/client/src/utilities/updateCompletions.js
+++ b/client/src/utilities/updateCompletions.js
@@ -1,19 +1,19 @@
 // import various ace editor things
-import * as ace from 'brace'
-import 'brace/mode/sql'
-import 'brace/theme/sqlserver'
-import 'brace/ext/searchbox'
-import 'brace/ext/language_tools'
+import * as ace from 'brace';
+import 'brace/mode/sql';
+import 'brace/theme/sqlserver';
+import 'brace/ext/searchbox';
+import 'brace/ext/language_tools';
 
-export default updateCompletions
+export default updateCompletions;
 
 // There's stuff below that logs to console a lot
 // documentation on this autocompletion is light
 // and you may find it helpful to print some vars out during dev
-const DEBUG_ON = false
+const DEBUG_ON = false;
 
 function debug() {
-  if (DEBUG_ON) console.log.apply(null, arguments)
+  if (DEBUG_ON) console.log.apply(null, arguments);
 }
 
 /**
@@ -26,11 +26,11 @@ function debug() {
  * @param {schemaInfoObject} schemaInfo
  */
 function updateCompletions(schemaInfo) {
-  debug('updating completions')
-  debug(schemaInfo)
+  debug('updating completions');
+  debug(schemaInfo);
 
   if (schemaInfo === null || schemaInfo === undefined) {
-    return
+    return;
   }
 
   // TODO make this more efficient and less confusing
@@ -45,8 +45,8 @@ function updateCompletions(schemaInfo) {
   // for now we pre-assemble entire buckets of all schemas/tables/columns
   // these handle autocompletes with no dot
   // NOTE sqlpad is also firing autocomplete on every keypress instead of using live autocomplete
-  const schemaCompletions = []
-  const tableCompletions = []
+  const schemaCompletions = [];
+  const tableCompletions = [];
 
   // we also should create an index of dotted autocompletes.
   // given a precedingtoken as "sometable." or "someschema.table." we should be able to look up relevant completions
@@ -58,7 +58,7 @@ function updateCompletions(schemaInfo) {
     schema: {}, // will contain tables
     table: {},
     schemaTable: {}
-  }
+  };
 
   Object.keys(schemaInfo).forEach(schema => {
     schemaCompletions.push({
@@ -66,16 +66,16 @@ function updateCompletions(schemaInfo) {
       value: schema,
       score: 0,
       meta: 'schema'
-    })
-    const SCHEMA = schema.toUpperCase()
-    if (!matchMaps.schema[SCHEMA]) matchMaps.schema[SCHEMA] = []
+    });
+    const SCHEMA = schema.toUpperCase();
+    if (!matchMaps.schema[SCHEMA]) matchMaps.schema[SCHEMA] = [];
 
     Object.keys(schemaInfo[schema]).forEach(table => {
-      const SCHEMA_TABLE = SCHEMA + '.' + table.toUpperCase()
-      const TABLE = table.toUpperCase()
-      if (!matchMaps.table[TABLE]) matchMaps.table[TABLE] = []
+      const SCHEMA_TABLE = SCHEMA + '.' + table.toUpperCase();
+      const TABLE = table.toUpperCase();
+      if (!matchMaps.table[TABLE]) matchMaps.table[TABLE] = [];
       if (!matchMaps.schemaTable[SCHEMA_TABLE]) {
-        matchMaps.schemaTable[SCHEMA_TABLE] = []
+        matchMaps.schemaTable[SCHEMA_TABLE] = [];
       }
       const tableCompletion = {
         name: table,
@@ -83,11 +83,11 @@ function updateCompletions(schemaInfo) {
         score: 0,
         meta: 'table',
         schema
-      }
-      tableCompletions.push(tableCompletion)
-      matchMaps.schema[SCHEMA].push(tableCompletion)
+      };
+      tableCompletions.push(tableCompletion);
+      matchMaps.schema[SCHEMA].push(tableCompletion);
 
-      const columns = schemaInfo[schema][table]
+      const columns = schemaInfo[schema][table];
       columns.forEach(column => {
         const columnCompletion = {
           name: schema + table + column.column_name,
@@ -96,14 +96,14 @@ function updateCompletions(schemaInfo) {
           meta: 'column',
           schema,
           table
-        }
-        matchMaps.table[TABLE].push(columnCompletion)
-        matchMaps.schemaTable[SCHEMA_TABLE].push(columnCompletion)
-      })
-    })
-  })
+        };
+        matchMaps.table[TABLE].push(columnCompletion);
+        matchMaps.schemaTable[SCHEMA_TABLE].push(columnCompletion);
+      });
+    });
+  });
 
-  const tableWantedCompletions = schemaCompletions.concat(tableCompletions)
+  const tableWantedCompletions = schemaCompletions.concat(tableCompletions);
 
   const myCompleter = {
     getCompletions: function(editor, session, pos, prefix, callback) {
@@ -111,149 +111,149 @@ function updateCompletions(schemaInfo) {
       const allTokens = session
         .getValue()
         .split(/\s+/)
-        .map(t => t.toUpperCase())
-      const relevantDottedMatches = {}
+        .map(t => t.toUpperCase());
+      const relevantDottedMatches = {};
       Object.keys(matchMaps.schemaTable).forEach(schemaTable => {
         if (allTokens.indexOf(schemaTable) >= 0) {
           relevantDottedMatches[schemaTable] =
-            matchMaps.schemaTable[schemaTable]
+            matchMaps.schemaTable[schemaTable];
           // HACK - also add relevant matches for table only
-          const firstMatch = matchMaps.schemaTable[schemaTable][0]
-          const table = firstMatch.table.toUpperCase()
-          relevantDottedMatches[table] = matchMaps.table[table]
+          const firstMatch = matchMaps.schemaTable[schemaTable][0];
+          const table = firstMatch.table.toUpperCase();
+          relevantDottedMatches[table] = matchMaps.table[table];
         }
-      })
+      });
       Object.keys(matchMaps.table).forEach(table => {
         if (allTokens.indexOf(table) >= 0) {
-          relevantDottedMatches[table] = matchMaps.table[table]
+          relevantDottedMatches[table] = matchMaps.table[table];
           // HACK add schemaTable match for this table
           // we store schema at column match item, so look at first one and use that
-          const firstMatch = matchMaps.table[table][0]
+          const firstMatch = matchMaps.table[table][0];
           const schemaTable =
             firstMatch.schema.toUpperCase() +
             '.' +
-            firstMatch.table.toUpperCase()
-          relevantDottedMatches[schemaTable] = matchMaps.table[table]
+            firstMatch.table.toUpperCase();
+          relevantDottedMatches[schemaTable] = matchMaps.table[table];
         }
-      })
-      debug('matched found: ', Object.keys(relevantDottedMatches))
+      });
+      debug('matched found: ', Object.keys(relevantDottedMatches));
 
       // complete for schema and tables already referenced, plus their columns
-      let matches = []
+      let matches = [];
       Object.keys(relevantDottedMatches).forEach(key => {
-        matches = matches.concat(relevantDottedMatches[key])
-      })
-      const schemas = {}
-      const tables = {}
-      const wantedColumnCompletions = []
+        matches = matches.concat(relevantDottedMatches[key]);
+      });
+      const schemas = {};
+      const tables = {};
+      const wantedColumnCompletions = [];
       matches.forEach(match => {
-        if (match.schema) schemas[match.schema] = match.schema
-        if (match.table) tables[match.table] = match.schema
-      })
+        if (match.schema) schemas[match.schema] = match.schema;
+        if (match.table) tables[match.table] = match.schema;
+      });
       Object.keys(schemas).forEach(schema => {
         wantedColumnCompletions.push({
           name: schema,
           value: schema,
           score: 0,
           meta: 'schema'
-        })
-      })
+        });
+      });
       Object.keys(tables).forEach(table => {
         const tableCompletion = {
           name: table,
           value: table,
           score: 0,
           meta: 'table'
-        }
-        wantedColumnCompletions.push(tableCompletion)
-        const SCHEMA = tables[table].toUpperCase()
-        if (!relevantDottedMatches[SCHEMA]) relevantDottedMatches[SCHEMA] = []
-        relevantDottedMatches[SCHEMA].push(tableCompletion)
-      })
+        };
+        wantedColumnCompletions.push(tableCompletion);
+        const SCHEMA = tables[table].toUpperCase();
+        if (!relevantDottedMatches[SCHEMA]) relevantDottedMatches[SCHEMA] = [];
+        relevantDottedMatches[SCHEMA].push(tableCompletion);
+      });
 
       // get tokens leading up to the cursor to figure out context
       // depending on where we are we either want tables or we want columns
-      const tableWantedKeywords = ['FROM', 'JOIN']
-      const columnWantedKeywords = ['SELECT', 'WHERE', 'GROUP', 'HAVING', 'ON']
+      const tableWantedKeywords = ['FROM', 'JOIN'];
+      const columnWantedKeywords = ['SELECT', 'WHERE', 'GROUP', 'HAVING', 'ON'];
 
       // find out what is wanted
       // first look at the current line before cursor, then rest of lines beforehand
-      let wanted = ''
-      const currentRow = pos.row
+      let wanted = '';
+      const currentRow = pos.row;
       for (let r = currentRow; r >= 0; r--) {
-        let line = session.getDocument().getLine(r)
-        let lineTokens
+        let line = session.getDocument().getLine(r);
+        let lineTokens;
         // if dealing with current row only use stuff before cursor
         if (r === currentRow) {
-          line = line.slice(0, pos.column)
+          line = line.slice(0, pos.column);
         }
-        lineTokens = line.split(/\s+/).map(t => t.toUpperCase())
+        lineTokens = line.split(/\s+/).map(t => t.toUpperCase());
 
         for (let i = lineTokens.length - 1; i >= 0; i--) {
-          const token = lineTokens[i]
+          const token = lineTokens[i];
           if (columnWantedKeywords.indexOf(token) >= 0) {
-            debug('WANT COLUMN BECAUSE FOUND: ', token)
-            wanted = 'COLUMN'
-            r = 0
-            break
+            debug('WANT COLUMN BECAUSE FOUND: ', token);
+            wanted = 'COLUMN';
+            r = 0;
+            break;
           }
           if (tableWantedKeywords.indexOf(token) >= 0) {
-            debug('WANT TABLE BECAUSE FOUND: ', token)
-            wanted = 'TABLE'
-            r = 0
-            break
+            debug('WANT TABLE BECAUSE FOUND: ', token);
+            wanted = 'TABLE';
+            r = 0;
+            break;
           }
         }
       }
-      debug('WANTED: ', wanted)
+      debug('WANTED: ', wanted);
 
-      const currentLine = session.getDocument().getLine(pos.row)
+      const currentLine = session.getDocument().getLine(pos.row);
       const currentTokens = currentLine
         .slice(0, pos.column)
         .split(/\s+/)
-        .map(t => t.toUpperCase())
-      const precedingCharacter = currentLine.slice(pos.column - 1, pos.column)
-      const precedingToken = currentTokens[currentTokens.length - 1]
+        .map(t => t.toUpperCase());
+      const precedingCharacter = currentLine.slice(pos.column - 1, pos.column);
+      const precedingToken = currentTokens[currentTokens.length - 1];
 
       // if preceding token has a . try to provide completions based on that object
-      debug('PREFIX: "%s"', prefix)
-      debug('PRECEDING CHAR: "%s"', precedingCharacter)
-      debug('PRECEDING TOKEN: "%s"', precedingToken)
+      debug('PREFIX: "%s"', prefix);
+      debug('PRECEDING CHAR: "%s"', precedingCharacter);
+      debug('PRECEDING TOKEN: "%s"', precedingToken);
       if (precedingToken.indexOf('.') >= 0) {
-        let dotTokens = precedingToken.split('.')
-        dotTokens.pop()
-        const DOT_MATCH = dotTokens.join('.').toUpperCase()
+        let dotTokens = precedingToken.split('.');
+        dotTokens.pop();
+        const DOT_MATCH = dotTokens.join('.').toUpperCase();
         debug(
           'Completing for "%s" even though we got "%s"',
           DOT_MATCH,
           precedingToken
-        )
+        );
         if (wanted === 'TABLE') {
           // if we're in a table place, a completion should only be for tables, not columns
-          return callback(null, matchMaps.schema[DOT_MATCH])
+          return callback(null, matchMaps.schema[DOT_MATCH]);
         }
         if (wanted === 'COLUMN') {
           // here we should see show matches for only the tables mentioned in query
-          return callback(null, relevantDottedMatches[DOT_MATCH])
+          return callback(null, relevantDottedMatches[DOT_MATCH]);
         }
       }
 
       // if we are not dealing with a . match show all relevant objects
       if (wanted === 'TABLE') {
-        return callback(null, tableWantedCompletions)
+        return callback(null, tableWantedCompletions);
       }
       if (wanted === 'COLUMN') {
         // TODO also include alias?
-        return callback(null, matches.concat(wantedColumnCompletions))
+        return callback(null, matches.concat(wantedColumnCompletions));
       }
       // No keywords found? User probably wants some keywords
-      callback(null, null)
+      callback(null, null);
     }
-  }
+  };
 
   ace.acequire(['ace/ext/language_tools'], langTools => {
-    langTools.setCompleters([myCompleter])
+    langTools.setCompleters([myCompleter]);
     // Note - later on might be able to set a completer for specific editor like:
     // editor.completers = [staticWordCompleter]
-  })
+  });
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "prettier": "^1.16.4"
   },
   "prettier": {
-    "semi": false,
     "singleQuote": true
   },
   "husky": {

--- a/server/app.js
+++ b/server/app.js
@@ -1,13 +1,13 @@
-const fs = require('fs')
-const path = require('path')
-const crypto = require('crypto')
-const express = require('express')
-const helmet = require('helmet')
-const session = require('express-session')
-const FileStore = require('session-file-store')(session)
-const configUtil = require('./lib/config')
-const version = require('./lib/version')
-const db = require('./lib/db')
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const express = require('express');
+const helmet = require('helmet');
+const session = require('express-session');
+const FileStore = require('session-file-store')(session);
+const configUtil = require('./lib/config');
+const version = require('./lib/version');
+const db = require('./lib/db');
 const {
   baseUrl,
   googleClientId,
@@ -15,53 +15,53 @@ const {
   publicUrl,
   dbPath,
   debug
-} = configUtil.getPreDbConfig()
+} = configUtil.getPreDbConfig();
 
 // Cookie secrets are generated randomly at server start
 // SQLPad (currently) is designed for running as a single instance
 // so this should be okay unless SQLPad is frequently restarting
 const cookieSecrets = debug
   ? 'devmode'
-  : [1, 2, 3, 4].map(n => crypto.randomBytes(64).toString('hex'))
+  : [1, 2, 3, 4].map(n => crypto.randomBytes(64).toString('hex'));
 
-const ONE_HOUR_MS = 1000 * 60 * 60
+const ONE_HOUR_MS = 1000 * 60 * 60;
 
 if (!debug) {
   // Note actual checks will only happen if not disabled via config
-  version.scheduleUpdateChecks()
+  version.scheduleUpdateChecks();
 }
 
 /*  Express setup
 ============================================================================= */
-const bodyParser = require('body-parser')
-const favicon = require('serve-favicon')
-const morgan = require('morgan')
-const passport = require('passport')
-const errorhandler = require('errorhandler')
+const bodyParser = require('body-parser');
+const favicon = require('serve-favicon');
+const morgan = require('morgan');
+const passport = require('passport');
+const errorhandler = require('errorhandler');
 
-const app = express()
+const app = express();
 
 // Default helmet protections, minus frameguard (becaue of sqlpad iframe embed), adding referrerPolicy
-app.use(helmet.dnsPrefetchControl())
-app.use(helmet.hidePoweredBy())
-app.use(helmet.hsts({}))
-app.use(helmet.ieNoOpen())
-app.use(helmet.noSniff())
-app.use(helmet.xssFilter())
-app.use(helmet.referrerPolicy({ policy: 'same-origin' }))
+app.use(helmet.dnsPrefetchControl());
+app.use(helmet.hidePoweredBy());
+app.use(helmet.hsts({}));
+app.use(helmet.ieNoOpen());
+app.use(helmet.noSniff());
+app.use(helmet.xssFilter());
+app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
 
-app.set('env', debug ? 'development' : 'production')
+app.set('env', debug ? 'development' : 'production');
 
 if (debug) {
-  app.use(errorhandler())
+  app.use(errorhandler());
 }
-app.use(favicon(path.join(__dirname, '/public/favicon.ico')))
-app.use(bodyParser.json())
+app.use(favicon(path.join(__dirname, '/public/favicon.ico')));
+app.use(bodyParser.json());
 app.use(
   bodyParser.urlencoded({
     extended: true
   })
-)
+);
 
 app.use(
   session({
@@ -74,13 +74,13 @@ app.use(
     cookie: { maxAge: ONE_HOUR_MS },
     secret: cookieSecrets
   })
-)
+);
 
-app.use(passport.initialize())
-app.use(passport.session())
-app.use(baseUrl, express.static(path.join(__dirname, 'public')))
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(baseUrl, express.static(path.join(__dirname, 'public')));
 if (debug) {
-  app.use(morgan('dev'))
+  app.use(morgan('dev'));
 }
 
 // Add config helper to req
@@ -88,18 +88,18 @@ app.use(function(req, res, next) {
   configUtil
     .getHelper(db)
     .then(config => {
-      req.config = config
-      next()
+      req.config = config;
+      next();
     })
     .catch(error => {
-      console.error('Error getting config helper', error)
-      next(error)
-    })
-})
+      console.error('Error getting config helper', error);
+      next(error);
+    });
+});
 
 /*  Passport setup
 ============================================================================= */
-require('./middleware/passport.js')
+require('./middleware/passport.js');
 
 /*  Routes
 ============================================================================= */
@@ -119,53 +119,53 @@ const routers = [
   require('./routes/config-values.js'),
   require('./routes/tags.js'),
   require('./routes/signup-signin-signout.js')
-]
+];
 
 if (googleClientId && googleClientSecret && publicUrl) {
   if (debug) {
-    console.log('Enabling Google authentication Strategy.')
+    console.log('Enabling Google authentication Strategy.');
   }
-  routers.push(require('./routes/oauth.js'))
+  routers.push(require('./routes/oauth.js'));
 }
 
 // Add all core routes to the baseUrl except for the */api/app route
 routers.forEach(function(router) {
-  app.use(baseUrl, router)
-})
+  app.use(baseUrl, router);
+});
 
 // Add '*/api/app' route last and without baseUrl
-app.use(require('./routes/app.js'))
+app.use(require('./routes/app.js'));
 
 // For any missing api route, return a 404
 // NOTE - this cannot be a general catch-all because it might be a valid non-api route from a front-end perspective
 app.use(baseUrl + '/api/', function(req, res) {
-  console.log('reached catch all api route')
-  res.sendStatus(404)
-})
+  console.log('reached catch all api route');
+  res.sendStatus(404);
+});
 
 // Anything else should render the client-side app
 // Client-side routing will take care of things from here
 // Because index.html will be served via static plugin,
 // we need to rename it to something else and switch out the URLs to consider the baseUrl
-const indexPath = path.join(__dirname, 'public/index.html')
-const indexTemplatePath = path.join(__dirname, 'public/index-template.html')
+const indexPath = path.join(__dirname, 'public/index.html');
+const indexTemplatePath = path.join(__dirname, 'public/index-template.html');
 
 if (fs.existsSync(indexPath)) {
-  fs.renameSync(indexPath, indexTemplatePath)
+  fs.renameSync(indexPath, indexTemplatePath);
 }
 
 if (fs.existsSync(indexTemplatePath)) {
-  const html = fs.readFileSync(indexTemplatePath, 'utf8')
+  const html = fs.readFileSync(indexTemplatePath, 'utf8');
   const baseUrlHtml = html
     .replace(/="\/stylesheets/g, `="${baseUrl}/stylesheets`)
     .replace(/="\/javascripts/g, `="${baseUrl}/javascripts`)
     .replace(/="\/images/g, `="${baseUrl}/images`)
     .replace(/="\/fonts/g, `="${baseUrl}/fonts`)
-    .replace(/="\/static/g, `="${baseUrl}/static`)
-  app.use((req, res) => res.send(baseUrlHtml))
+    .replace(/="\/static/g, `="${baseUrl}/static`);
+  app.use((req, res) => res.send(baseUrlHtml));
 } else {
-  console.error('\nNO FRONT END TEMPLATE DETECTED')
-  console.error('If not running in dev mode please report this issue.\n')
+  console.error('\nNO FRONT END TEMPLATE DETECTED');
+  console.error('If not running in dev mode please report this issue.\n');
 }
 
-module.exports = app
+module.exports = app;

--- a/server/drivers/cassandra/index.js
+++ b/server/drivers/cassandra/index.js
@@ -1,8 +1,8 @@
-const cassandra = require('cassandra-driver')
-const { formatSchemaQueryResults } = require('../utils')
+const cassandra = require('cassandra-driver');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'cassandra'
-const name = 'Cassandra'
+const id = 'cassandra';
+const name = 'Cassandra';
 
 const fields = [
   {
@@ -15,7 +15,7 @@ const fields = [
     formType: 'TEXT',
     label: 'Keyspace'
   }
-]
+];
 
 const SCHEMA_SQL = `
   SELECT 
@@ -25,7 +25,7 @@ const SCHEMA_SQL = `
     type AS data_type
   FROM 
     system_schema.columns;
-`
+`;
 
 /**
  * Cassandra client needs to be shut down for either success or failure
@@ -36,7 +36,7 @@ function shutdownClient(client) {
     .shutdown()
     .catch(error =>
       console.error('Error shutting down cassandra connection', error)
-    )
+    );
 }
 
 /**
@@ -46,24 +46,24 @@ function shutdownClient(client) {
  * @param {object} connection
  */
 function runQuery(query, connection) {
-  const { contactPoints, keyspace, maxRows } = connection
+  const { contactPoints, keyspace, maxRows } = connection;
 
   const client = new cassandra.Client({
     contactPoints: contactPoints.split(',').map(cp => cp.trim()),
     keyspace
-  })
+  });
 
   return client
     .execute(query, [], { fetchSize: maxRows })
     .then(result => {
-      shutdownClient(client)
-      const incomplete = result.rows && result.rows.length === maxRows
-      return { rows: result.rows, incomplete }
+      shutdownClient(client);
+      const incomplete = result.rows && result.rows.length === maxRows;
+      return { rows: result.rows, incomplete };
     })
     .catch(error => {
-      shutdownClient(client)
-      throw error
-    })
+      shutdownClient(client);
+      throw error;
+    });
 }
 
 /**
@@ -71,8 +71,8 @@ function runQuery(query, connection) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = 'select * from system.local;'
-  return runQuery(query, connection)
+  const query = 'select * from system.local;';
+  return runQuery(query, connection);
 }
 
 /**
@@ -81,10 +81,10 @@ function testConnection(connection) {
  * @param {*} connection
  */
 function getSchema(connection) {
-  connection.maxRows = 1000000
+  connection.maxRows = 1000000;
   return runQuery(SCHEMA_SQL, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 module.exports = {
@@ -94,4 +94,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/cassandra/test.js
+++ b/server/drivers/cassandra/test.js
@@ -1,11 +1,11 @@
-const assert = require('assert')
-const cassandra = require('./index.js')
+const assert = require('assert');
+const cassandra = require('./index.js');
 
 const connection = {
   name: 'test cassandra',
   driver: 'cassandra',
   contactPoints: 'localhost'
-}
+};
 
 const initSqls = [
   `DROP KEYSPACE IF EXISTS test;`,
@@ -14,66 +14,66 @@ const initSqls = [
   `INSERT INTO test.test (id, name) VALUES (1, 'one');`,
   `INSERT INTO test.test (id, name) VALUES (2, 'two');`,
   `INSERT INTO test.test (id, name) VALUES (3, 'three');`
-]
+];
 
 describe('drivers/cassandra', function() {
   before(function() {
-    this.timeout(10000)
-    let seq = Promise.resolve()
+    this.timeout(10000);
+    let seq = Promise.resolve();
     initSqls.forEach(sql => {
-      seq = seq.then(() => cassandra.runQuery(sql, connection))
-    })
-    return seq
-  })
+      seq = seq.then(() => cassandra.runQuery(sql, connection));
+    });
+    return seq;
+  });
 
   it('tests connection', function() {
-    return cassandra.testConnection(connection)
-  })
+    return cassandra.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return cassandra.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo)
-      assert(schemaInfo.test, 'test')
-      assert(schemaInfo.test.test, 'test.test')
-      const columns = schemaInfo.test.test
-      assert.equal(columns.length, 2, 'columns.length')
-      assert.equal(columns[0].table_schema, 'test', 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
-      assert.equal(columns[0].column_name, 'id', 'column_name')
-      assert(columns[0].hasOwnProperty('data_type'), 'data_type')
-    })
-  })
+      assert(schemaInfo);
+      assert(schemaInfo.test, 'test');
+      assert(schemaInfo.test.test, 'test.test');
+      const columns = schemaInfo.test.test;
+      assert.equal(columns.length, 2, 'columns.length');
+      assert.equal(columns[0].table_schema, 'test', 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
+      assert.equal(columns[0].column_name, 'id', 'column_name');
+      assert(columns[0].hasOwnProperty('data_type'), 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return cassandra
       .runQuery('SELECT id FROM test.test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'rows length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
 
   it('runQuery over limit', function() {
-    const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
+    const limitedConnection = Object.assign({}, connection, { maxRows: 2 });
     return cassandra
       .runQuery('SELECT * FROM test.test;', limitedConnection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
 
   it('returns descriptive error message', function() {
-    let error
+    let error;
 
     return cassandra
       .runQuery('SELECT * FROM test.missing_table;', connection)
       .catch(e => {
-        error = e
+        error = e;
       })
       .then(() => {
-        assert(error)
-        assert(error.toString().indexOf('missing_table') > -1)
-      })
-  })
-})
+        assert(error);
+        assert(error.toString().indexOf('missing_table') > -1);
+      });
+  });
+});

--- a/server/drivers/crate/index.js
+++ b/server/drivers/crate/index.js
@@ -1,12 +1,12 @@
-const crate = require('node-crate')
-const { formatSchemaQueryResults } = require('../utils')
+const crate = require('node-crate');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'crate'
-const name = 'Crate'
+const id = 'crate';
+const name = 'Crate';
 
 // NOTE per crate docs: If a client using the HTTP or Transport protocol is used a default limit of 10000 is implicitly added.
 // node-crate uses the REST API, so it is assumed this is a limit
-const CRATE_LIMIT = 10000
+const CRATE_LIMIT = 10000;
 
 // old crate called table_schema schema_name
 const SCHEMA_SQL_V0 = `
@@ -21,7 +21,7 @@ const SCHEMA_SQL_V0 = `
     tables.schema_name not in ('information_schema') 
     and columns.schema_name = tables.schema_name 
     and columns.table_name = tables.table_name
-`
+`;
 
 const SCHEMA_SQL_V1 = `
   select 
@@ -35,7 +35,7 @@ const SCHEMA_SQL_V1 = `
     tables.table_schema not in ('information_schema') 
     and columns.table_schema = tables.table_schema 
     and columns.table_name = tables.table_name
-`
+`;
 
 /**
  * Run query for connection
@@ -44,13 +44,13 @@ const SCHEMA_SQL_V1 = `
  * @param {object} connection
  */
 function runQuery(query, connection) {
-  const { maxRows } = connection
-  const limit = maxRows < CRATE_LIMIT ? maxRows : CRATE_LIMIT
+  const { maxRows } = connection;
+  const limit = maxRows < CRATE_LIMIT ? maxRows : CRATE_LIMIT;
 
   if (connection.port) {
-    crate.connect(connection.host, connection.port)
+    crate.connect(connection.host, connection.port);
   } else {
-    crate.connect(connection.host)
+    crate.connect(connection.host);
   }
 
   return crate
@@ -59,18 +59,18 @@ function runQuery(query, connection) {
       const results = {
         rows: res.json,
         incomplete: false
-      }
+      };
 
       if (results.rows.length >= limit) {
-        results.incomplete = true
-        results.rows = results.rows.slice(0, limit)
+        results.incomplete = true;
+        results.rows = results.rows.slice(0, limit);
       }
 
-      return results
+      return results;
     })
     .catch(err => {
-      throw new Error(err.message)
-    })
+      throw new Error(err.message);
+    });
 }
 
 /**
@@ -78,8 +78,8 @@ function runQuery(query, connection) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = 'SELECT name from sys.cluster'
-  return runQuery(query, connection)
+  const query = 'SELECT name from sys.cluster';
+  return runQuery(query, connection);
 }
 
 /**
@@ -96,7 +96,7 @@ function getSchema(connection) {
       runQuery(SCHEMA_SQL_V0, connection).then(queryResult =>
         formatSchemaQueryResults(queryResult)
       )
-    )
+    );
 }
 
 const fields = [
@@ -110,7 +110,7 @@ const fields = [
     formType: 'TEXT',
     label: 'Port (optional)'
   }
-]
+];
 
 module.exports = {
   id,
@@ -119,4 +119,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/crate/test.js
+++ b/server/drivers/crate/test.js
@@ -1,20 +1,20 @@
-const assert = require('assert')
-const crate = require('./index.js')
+const assert = require('assert');
+const crate = require('./index.js');
 
 const connection = {
   name: 'test crate',
   driver: 'crate',
   host: 'localhost',
   port: '4200'
-}
+};
 
-const dropTable = 'DROP TABLE IF EXISTS test;'
-const createTable = 'CREATE TABLE test (id int);'
-const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);'
+const dropTable = 'DROP TABLE IF EXISTS test;';
+const createTable = 'CREATE TABLE test (id int);';
+const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);';
 
 describe('drivers/crate', function() {
   before(function() {
-    this.timeout(10000)
+    this.timeout(10000);
     return (
       crate
         .runQuery(dropTable, connection)
@@ -22,55 +22,55 @@ describe('drivers/crate', function() {
         .then(() => crate.runQuery(inserts, connection))
         // Crate has to wait before data is available?
         .then(() => new Promise(resolve => setTimeout(resolve, 5000)))
-    )
-  })
+    );
+  });
 
   it('tests connection', function() {
-    return crate.testConnection(connection)
-  })
+    return crate.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return crate.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo.doc, 'doc')
-      assert(schemaInfo.doc.test, 'doc.test')
-      const columns = schemaInfo.doc.test
-      assert.equal(columns.length, 1, 'columns.length')
-      assert.equal(columns[0].table_schema, 'doc', 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
-      assert.equal(columns[0].column_name, 'id', 'column_name')
-      assert(columns[0].hasOwnProperty('data_type'), 'data_type')
-    })
-  })
+      assert(schemaInfo.doc, 'doc');
+      assert(schemaInfo.doc.test, 'doc.test');
+      const columns = schemaInfo.doc.test;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, 'doc', 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
+      assert.equal(columns[0].column_name, 'id', 'column_name');
+      assert(columns[0].hasOwnProperty('data_type'), 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return crate
       .runQuery('SELECT id FROM test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'rows length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
 
   it('runQuery over limit', function() {
-    const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
+    const limitedConnection = Object.assign({}, connection, { maxRows: 2 });
     return crate
       .runQuery('SELECT * FROM test;', limitedConnection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
 
   it('returns descriptive error message', function() {
-    let error
+    let error;
     return crate
       .runQuery('SELECT * FROM missing_table;', connection)
       .catch(e => {
-        error = e
+        error = e;
       })
       .then(() => {
-        assert(error)
-        assert(error.toString().indexOf('missing_table') > -1)
-      })
-  })
-})
+        assert(error);
+        assert(error.toString().indexOf('missing_table') > -1);
+      });
+  });
+});

--- a/server/drivers/drill/drill.js
+++ b/server/drivers/drill/drill.js
@@ -1,21 +1,21 @@
-const fetch = require('node-fetch')
-var request = require('request')
-var url = require('url')
+const fetch = require('node-fetch');
+var request = require('request');
+var url = require('url');
 
-exports.version = '1.0'
+exports.version = '1.0';
 
 var Client = (exports.Client = function(args) {
-  if (!args) args = {}
+  if (!args) args = {};
 
-  this.host = args.host || 'localhost'
-  this.port = args.port || 8047
-  this.user = args.user || process.env.USER
-  this.ssl = args.ssl || false
-  this.protocol = 'http'
+  this.host = args.host || 'localhost';
+  this.port = args.port || 8047;
+  this.user = args.user || process.env.USER;
+  this.ssl = args.ssl || false;
+  this.protocol = 'http';
   if (this.ssl) {
-    this.protocol = 'https'
+    this.protocol = 'https';
   }
-})
+});
 
 Client.prototype.execute = function(queryString, callback) {
   const href = url.format({
@@ -23,57 +23,57 @@ Client.prototype.execute = function(queryString, callback) {
     hostname: 'localhost',
     pathname: '/query.json',
     port: 8047
-  })
+  });
   let headers = {
     'Content-Type': 'application/json; charset=UTF-8',
     'User-Name': this.user,
     Accept: 'application/json'
-  }
+  };
   let queryOptions = {
     uri: href,
     method: 'POST',
     headers: headers,
     json: { queryType: 'SQL', query: queryString }
-  }
+  };
   request(queryOptions, function(error, response, body) {
     if (!error && response.statusCode === 200) {
-      callback(null, body)
+      callback(null, body);
     } //TODO Add error handling
-  })
-}
+  });
+};
 
 Client.prototype.getSchemata = function() {
-  return this.query('SHOW DATABASES')
-}
+  return this.query('SHOW DATABASES');
+};
 
 Client.prototype.query = function(config, query) {
   const headers = {
     'Content-Type': 'application/json; charset=UTF-8',
     Accept: 'application/json'
-  }
+  };
   const restURL =
-    this.protocol + '://' + this.host + ':' + this.port + '/query.json'
+    this.protocol + '://' + this.host + ':' + this.port + '/query.json';
   const queryInfo = {
     queryType: 'SQL',
     query: query
-  }
-  const body = JSON.stringify(queryInfo)
+  };
+  const body = JSON.stringify(queryInfo);
   return fetch(restURL, {
     method: 'POST',
     headers: headers,
     body: body
   })
     .then(function(data) {
-      return data.json()
+      return data.json();
     })
     .then(function(jsonData) {
-      return jsonData
+      return jsonData;
     })
     .catch(function(e) {
       //TODO Send error message to JSON
-      console.log('There was a problem with the request' + e)
-      return e
-    })
-}
+      console.log('There was a problem with the request' + e);
+      return e;
+    });
+};
 
-module.exports = { Client }
+module.exports = { Client };

--- a/server/drivers/drill/index.js
+++ b/server/drivers/drill/index.js
@@ -1,11 +1,11 @@
-const drill = require('./drill.js')
-const { formatSchemaQueryResults } = require('../utils')
+const drill = require('./drill.js');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'drill'
-const name = 'Apache Drill'
+const id = 'drill';
+const name = 'Apache Drill';
 
 function getDrillSchemaSql(catalog, schema) {
-  const schemaSql = schema ? `AND table_schema = '${schema}'` : ''
+  const schemaSql = schema ? `AND table_schema = '${schema}'` : '';
   return `
     SELECT 
       c.table_schema, 
@@ -21,7 +21,7 @@ function getDrillSchemaSql(catalog, schema) {
       c.table_schema, 
       c.table_name, 
       c.ordinal_position
-  `
+  `;
 }
 
 /**
@@ -32,8 +32,8 @@ function getDrillSchemaSql(catalog, schema) {
  */
 
 function runQuery(query, connection) {
-  let incomplete = false
-  const rows = []
+  let incomplete = false;
+  const rows = [];
 
   const drillConfig = {
     host: connection.host,
@@ -42,30 +42,30 @@ function runQuery(query, connection) {
     password: connection.password,
     defaultSchema: connection.drillDefaultSchema,
     ssl: connection.ssl || false
-  }
-  const client = new drill.Client(drillConfig)
+  };
+  const client = new drill.Client(drillConfig);
 
   return client.query(drillConfig, query).then(result => {
     if (!result) {
-      throw new Error('No result returned')
+      throw new Error('No result returned');
     } else if (result.errorMessage && result.errorMessage.length > 0) {
-      console.log('Error with query: ' + query)
-      console.log(result.errorMessage)
-      throw new Error(result.errorMessage.split('\n')[0])
+      console.log('Error with query: ' + query);
+      console.log(result.errorMessage);
+      throw new Error(result.errorMessage.split('\n')[0]);
     }
     if (result.length > connection.maxRows) {
-      incomplete = true
-      result['rows'] = result['rows'].slice(0, connection.maxRows)
+      incomplete = true;
+      result['rows'] = result['rows'].slice(0, connection.maxRows);
     }
     for (let r = 0; r < result['rows'].length; r++) {
-      const row = {}
+      const row = {};
       for (let c = 0; c < result['columns'].length; c++) {
-        row[result['columns'][c]] = result['rows'][r][result['columns'][c]]
+        row[result['columns'][c]] = result['rows'][r][result['columns'][c]];
       }
-      rows.push(row)
+      rows.push(row);
     }
-    return { rows, incomplete }
-  })
+    return { rows, incomplete };
+  });
 }
 
 /**
@@ -73,8 +73,8 @@ function runQuery(query, connection) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = "SELECT 'success'  FROM (VALUES(1))"
-  return runQuery(query, connection)
+  const query = "SELECT 'success'  FROM (VALUES(1))";
+  return runQuery(query, connection);
 }
 
 /**
@@ -85,10 +85,10 @@ function getSchema(connection) {
   const schemaSql = getDrillSchemaSql(
     connection.drillCatalog
     //connection.drillSchema
-  )
+  );
   return runQuery(schemaSql, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 const fields = [
@@ -122,7 +122,7 @@ const fields = [
     formType: 'CHECKBOX',
     label: 'Use SSL to connect to Drill'
   }
-]
+];
 
 module.exports = {
   id,
@@ -131,4 +131,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/hdb/test.js
+++ b/server/drivers/hdb/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const hdb = require('./index.js')
+const assert = require('assert');
+const hdb = require('./index.js');
 
 const connection = {
   name: 'test hdb (SAP HANA)',
@@ -11,75 +11,75 @@ const connection = {
   password: 'SQLPad1!',
   hanaSchema: 'SYSTEM',
   maxRows: 50000
-}
+};
 
 const initSqls = [
   'CREATE TABLE test ( ID INTEGER );',
   'INSERT INTO test VALUES (1);',
   'INSERT INTO test VALUES (2);',
   'INSERT INTO test VALUES (3);'
-]
+];
 
 describe('drivers/hdb', function() {
   before(function() {
-    this.timeout(10000)
+    this.timeout(10000);
     let seq = hdb.runQuery('DROP TABLE test;', connection).catch(error => {
       // ignore error - table might not exist
-    })
+    });
     initSqls.forEach(sql => {
-      seq = seq.then(() => hdb.runQuery(sql, connection))
-    })
-    return seq
-  })
+      seq = seq.then(() => hdb.runQuery(sql, connection));
+    });
+    return seq;
+  });
 
   it('tests connection', function() {
-    return hdb.testConnection(connection)
-  })
+    return hdb.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return hdb.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo.SYSTEM, 'SYSTEM')
-      assert(schemaInfo.SYSTEM.TEST, 'SYSTEM.TEST')
-      const columns = schemaInfo.SYSTEM.TEST
-      assert.equal(columns.length, 1, 'columns.length')
-      assert.equal(columns[0].table_schema, 'SYSTEM', 'table_schema')
-      assert.equal(columns[0].table_name, 'TEST', 'table_name')
-      assert.equal(columns[0].column_name, 'ID', 'column_name')
-      assert(columns[0].hasOwnProperty('data_type'), 'data_type')
-    })
-  })
+      assert(schemaInfo.SYSTEM, 'SYSTEM');
+      assert(schemaInfo.SYSTEM.TEST, 'SYSTEM.TEST');
+      const columns = schemaInfo.SYSTEM.TEST;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, 'SYSTEM', 'table_schema');
+      assert.equal(columns[0].table_name, 'TEST', 'table_name');
+      assert.equal(columns[0].column_name, 'ID', 'column_name');
+      assert(columns[0].hasOwnProperty('data_type'), 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return hdb
       .runQuery('SELECT id FROM test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'rows length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
 
   it('runQuery over limit', function() {
-    const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
+    const limitedConnection = Object.assign({}, connection, { maxRows: 2 });
     return hdb
       .runQuery('SELECT * FROM test;', limitedConnection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
 
   it('returns descriptive error message', function() {
-    let error
+    let error;
 
     // NOTE: SAP HANA turns things into ALL CAPS
     return hdb
       .runQuery('SELECT * FROM MISSING_TABLE;', connection)
       .catch(e => {
-        error = e
+        error = e;
       })
       .then(() => {
-        assert(error)
-        assert(error.toString().indexOf('MISSING_TABLE') > -1)
-      })
-  })
-})
+        assert(error);
+        assert(error.toString().indexOf('MISSING_TABLE') > -1);
+      });
+  });
+});

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -1,9 +1,9 @@
-const uuid = require('uuid')
-const { debug } = require('../lib/config').getPreDbConfig()
-const utils = require('./utils')
-const getMeta = require('../lib/getMeta')
+const uuid = require('uuid');
+const { debug } = require('../lib/config').getPreDbConfig();
+const utils = require('./utils');
+const getMeta = require('../lib/getMeta');
 
-const drivers = {}
+const drivers = {};
 
 /**
  * Validate that the driver implementation has a function by name provided
@@ -13,8 +13,8 @@ const drivers = {}
  */
 function validateFunction(path, driver, functionName) {
   if (typeof driver[functionName] !== 'function') {
-    console.error(`${path} missing .${functionName}() implementation`)
-    process.exit(1)
+    console.error(`${path} missing .${functionName}() implementation`);
+    process.exit(1);
   }
 }
 
@@ -25,10 +25,10 @@ function validateFunction(path, driver, functionName) {
  * @param {string} arrayName
  */
 function validateArray(path, driver, arrayName) {
-  const arr = driver[arrayName]
+  const arr = driver[arrayName];
   if (!Array.isArray(arr)) {
-    console.error(`${path} missing ${arrayName} array`)
-    process.exit(1)
+    console.error(`${path} missing ${arrayName} array`);
+    process.exit(1);
   }
 }
 
@@ -38,65 +38,65 @@ function validateArray(path, driver, arrayName) {
  * @param {string} path
  */
 function requireValidate(path, optional = false) {
-  let driver
+  let driver;
 
   try {
-    driver = require(path)
+    driver = require(path);
   } catch (er) {
     if (optional) {
-      console.log('optional driver ' + path + ' not available')
-      return
+      console.log('optional driver ' + path + ' not available');
+      return;
     } else {
       // rethrow
-      throw er
+      throw er;
     }
   }
 
   if (!driver.id) {
-    console.error(`${path} must export a unique id`)
-    process.exit(1)
+    console.error(`${path} must export a unique id`);
+    process.exit(1);
   }
 
   if (!driver.name) {
-    console.error(`${path} must export a name`)
-    process.exit(1)
+    console.error(`${path} must export a name`);
+    process.exit(1);
   }
 
   if (drivers[driver.id]) {
-    console.error(`Driver with id ${driver.id} already loaded`)
-    console.error(`Ensure ${path} has a unique id exported`)
-    process.exit(1)
+    console.error(`Driver with id ${driver.id} already loaded`);
+    console.error(`Ensure ${path} has a unique id exported`);
+    process.exit(1);
   }
 
-  validateFunction(path, driver, 'getSchema')
-  validateFunction(path, driver, 'runQuery')
-  validateFunction(path, driver, 'testConnection')
-  validateArray(path, driver, 'fields')
+  validateFunction(path, driver, 'getSchema');
+  validateFunction(path, driver, 'runQuery');
+  validateFunction(path, driver, 'testConnection');
+  validateArray(path, driver, 'fields');
 
-  driver.fieldsByKey = {}
+  driver.fieldsByKey = {};
 
   driver.fields.forEach(field => {
-    driver.fieldsByKey[field.key] = field
-  })
+    driver.fieldsByKey[field.key] = field;
+  });
 
-  drivers[driver.id] = driver
+  drivers[driver.id] = driver;
 }
 
 // Loads and validates drivers
 // Will populate drivers {} map
-requireValidate('../drivers/crate')
-requireValidate('../drivers/drill')
-requireValidate('../drivers/hdb')
-requireValidate('../drivers/mysql')
-requireValidate('../drivers/postgres')
-requireValidate('../drivers/presto')
-requireValidate('../drivers/sqlserver')
-requireValidate('../drivers/unixodbc', true)
-requireValidate('../drivers/vertica')
-requireValidate('../drivers/cassandra')
+requireValidate('../drivers/crate');
+requireValidate('../drivers/drill');
+requireValidate('../drivers/hdb');
+requireValidate('../drivers/mysql');
+requireValidate('../drivers/postgres');
+requireValidate('../drivers/presto');
+requireValidate('../drivers/sqlserver');
+requireValidate('../drivers/unixodbc', true);
+requireValidate('../drivers/vertica');
+requireValidate('../drivers/cassandra');
 
 if (debug || process.env.SQLPAD_TEST === 'true') {
-  requireValidate('../drivers/mock')
+  requireValidate('../drivers/mock');
 }
 
 /**
@@ -107,7 +107,7 @@ if (debug || process.env.SQLPAD_TEST === 'true') {
  * @returns {Promise}
  */
 function runQuery(query, connection, user) {
-  const driver = drivers[connection.driver]
+  const driver = drivers[connection.driver];
 
   const queryResult = {
     id: uuid.v4(),
@@ -119,25 +119,25 @@ function runQuery(query, connection, user) {
     incomplete: false,
     meta: {},
     rows: []
-  }
+  };
 
   return driver.runQuery(query, connection).then(results => {
-    const { rows, incomplete } = results
+    const { rows, incomplete } = results;
     if (!Array.isArray(rows)) {
-      throw new Error(`${connection.driver}.runQuery() must return rows array`)
+      throw new Error(`${connection.driver}.runQuery() must return rows array`);
     }
 
-    queryResult.incomplete = incomplete || false
-    queryResult.rows = rows
-    queryResult.stopTime = new Date()
-    queryResult.queryRunTime = queryResult.stopTime - queryResult.startTime
-    queryResult.meta = getMeta(rows)
-    queryResult.fields = Object.keys(queryResult.meta)
+    queryResult.incomplete = incomplete || false;
+    queryResult.rows = rows;
+    queryResult.stopTime = new Date();
+    queryResult.queryRunTime = queryResult.stopTime - queryResult.startTime;
+    queryResult.meta = getMeta(rows);
+    queryResult.fields = Object.keys(queryResult.meta);
 
     if (debug) {
-      const connectionName = connection.name
-      const rowCount = rows.length
-      const { startTime, stopTime, queryRunTime } = queryResult
+      const connectionName = connection.name;
+      const rowCount = rows.length;
+      const { startTime, stopTime, queryRunTime } = queryResult;
 
       console.log(
         JSON.stringify({
@@ -150,11 +150,11 @@ function runQuery(query, connection, user) {
           rowCount,
           query
         })
-      )
+      );
     }
 
-    return queryResult
-  })
+    return queryResult;
+  });
 }
 
 /**
@@ -164,8 +164,8 @@ function runQuery(query, connection, user) {
  * @param {object} connection
  */
 function testConnection(connection) {
-  const driver = drivers[connection.driver]
-  return driver.testConnection(connection)
+  const driver = drivers[connection.driver];
+  return driver.testConnection(connection);
 }
 
 /**
@@ -175,9 +175,9 @@ function testConnection(connection) {
  * @returns {Promise}
  */
 function getSchema(connection) {
-  connection.maxRows = Number.MAX_SAFE_INTEGER
-  const driver = drivers[connection.driver]
-  return driver.getSchema(connection)
+  connection.maxRows = Number.MAX_SAFE_INTEGER;
+  const driver = drivers[connection.driver];
+  return driver.getSchema(connection);
 }
 
 /**
@@ -190,8 +190,8 @@ function getDrivers() {
       id,
       name: drivers[id].name,
       fields: drivers[id].fields
-    }
-  })
+    };
+  });
 }
 
 /**
@@ -200,40 +200,41 @@ function getDrivers() {
  * @param {object} connection
  */
 function validateConnection(connection) {
-  const coreFields = ['_id', 'name', 'driver', 'createdDate', 'modifiedDate']
+  const coreFields = ['_id', 'name', 'driver', 'createdDate', 'modifiedDate'];
   if (!connection.name) {
-    throw new Error('connection.name required')
+    throw new Error('connection.name required');
   }
   if (!connection.driver) {
-    throw new Error('connection.driver required')
+    throw new Error('connection.driver required');
   }
-  const driver = drivers[connection.driver]
+  const driver = drivers[connection.driver];
   if (!driver) {
-    throw new Error(`driver implementation ${connection.driver} not found`)
+    throw new Error(`driver implementation ${connection.driver} not found`);
   }
-  const validFields = driver.fields.map(field => field.key).concat(coreFields)
+  const validFields = driver.fields.map(field => field.key).concat(coreFields);
   const cleanedConnection = validFields.reduce(
     (cleanedConnection, fieldKey) => {
       if (connection.hasOwnProperty(fieldKey)) {
-        let value = connection[fieldKey]
-        const fieldDefinition = drivers[connection.driver].fieldsByKey[fieldKey]
+        let value = connection[fieldKey];
+        const fieldDefinition =
+          drivers[connection.driver].fieldsByKey[fieldKey];
 
         // field definition may not exist since
         // this could be a core field like _id, name
         if (fieldDefinition) {
           if (fieldDefinition.formType === 'CHECKBOX') {
-            value = utils.ensureBoolean(value)
+            value = utils.ensureBoolean(value);
           }
         }
 
-        cleanedConnection[fieldKey] = value
+        cleanedConnection[fieldKey] = value;
       }
-      return cleanedConnection
+      return cleanedConnection;
     },
     {}
-  )
+  );
 
-  return cleanedConnection
+  return cleanedConnection;
 }
 
 module.exports = {
@@ -242,4 +243,4 @@ module.exports = {
   runQuery,
   testConnection,
   validateConnection
-}
+};

--- a/server/drivers/mock/index.js
+++ b/server/drivers/mock/index.js
@@ -1,9 +1,9 @@
-const _ = require('lodash')
-const moment = require('moment')
-const { formatSchemaQueryResults } = require('../utils')
+const _ = require('lodash');
+const moment = require('moment');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'mock'
-const name = 'Mock driver'
+const id = 'mock';
+const name = 'Mock driver';
 
 const fieldValues = {
   color: [
@@ -58,24 +58,24 @@ const fieldValues = {
         .add(index, 'hour')
         .toDate()
     )
-}
+};
 
 function cartesianify(rows, field) {
-  const newRows = []
+  const newRows = [];
   if (!rows.length) {
     field.values.forEach(value => {
-      newRows.push({ [field.name]: value })
-    })
+      newRows.push({ [field.name]: value });
+    });
   } else {
     rows.forEach(row => {
       field.values.forEach(value => {
-        const newRow = Object.assign({}, row, { [field.name]: value })
-        newRows.push(newRow)
-      })
-    })
+        const newRow = Object.assign({}, row, { [field.name]: value });
+        newRows.push(newRow);
+      });
+    });
   }
 
-  return newRows
+  return newRows;
 }
 
 /**
@@ -88,7 +88,7 @@ async function runQuery(query, connection) {
   // Connection here doesn't actually matter.
   // Someday this mock could get fancy and change output based on some connection value
   // For now validate that it is getting passed
-  const { maxRows } = connection
+  const { maxRows } = connection;
 
   // To determine the content of this mock query, inspect values from comments
   // Example format
@@ -96,11 +96,11 @@ async function runQuery(query, connection) {
   // -- measures = cost, revenue, profit, <anythingyouwant>
   // -- orderby = department asc, product desc
   // -- limit = 100
-  const dimensions = []
-  const measures = []
-  const orderByFields = []
-  const orderByDirections = []
-  let limit
+  const dimensions = [];
+  const measures = [];
+  const orderByFields = [];
+  const orderByDirections = [];
+  let limit;
 
   query
     .split('\n')
@@ -110,10 +110,10 @@ async function runQuery(query, connection) {
     .forEach(line => {
       const [fieldType, fieldData] = line
         .split('=')
-        .map(p => p.trim().toLowerCase())
+        .map(p => p.trim().toLowerCase());
 
       if (!fieldData) {
-        return
+        return;
       }
 
       // fieldData is something like <fieldname> <direction>, <field2> <direction>
@@ -123,70 +123,70 @@ async function runQuery(query, connection) {
         .map(p => p.trim())
         .forEach(part => {
           if (fieldType === 'limit') {
-            limit = parseInt(part)
+            limit = parseInt(part);
           } else if (fieldType === 'dimensions') {
-            const [fieldName, numString] = part.split(' ').map(p => p.trim())
+            const [fieldName, numString] = part.split(' ').map(p => p.trim());
             if (!fieldValues[fieldName]) {
               throw new Error(
                 `Unknown ${fieldName}. must be one of: ${Object.keys(
                   fieldValues
                 ).join(', ')}`
-              )
+              );
             }
             dimensions.push({
               name: fieldName,
               values: fieldValues[fieldName].slice(0, parseInt(numString))
-            })
+            });
           } else if (fieldType === 'measures') {
-            measures.push(part)
+            measures.push(part);
           } else if (fieldType === 'orderby') {
-            const [fieldName, direction] = part.split(' ').map(p => p.trim())
+            const [fieldName, direction] = part.split(' ').map(p => p.trim());
             if (!direction) {
-              throw new Error('direction required. Must be asc or desc')
+              throw new Error('direction required. Must be asc or desc');
             }
-            orderByFields.push(fieldName)
-            orderByDirections.push(direction)
+            orderByFields.push(fieldName);
+            orderByDirections.push(direction);
           } else {
             throw new Error(
               `Unknown ${fieldType}. Must be dimensions, measures, orderby, or limit`
-            )
+            );
           }
-        })
-    })
+        });
+    });
 
   if (!dimensions.length) {
-    throw new Error('dimensions required')
+    throw new Error('dimensions required');
   }
 
   // Assemble dimensions and things
-  let rows = []
+  let rows = [];
   dimensions.forEach(dimension => {
-    rows = cartesianify(rows, dimension)
-  })
+    rows = cartesianify(rows, dimension);
+  });
 
   if (measures.length) {
     rows.forEach((row, rowIndex) => {
       measures.forEach((measure, measureIndex) => {
-        const date = row.orderdate || row.orderdatetime
+        const date = row.orderdate || row.orderdatetime;
         if (date) {
-          const doy = moment.utc(date).dayOfYear()
-          row[measure] = 10 + Math.round(doy * Math.random())
+          const doy = moment.utc(date).dayOfYear();
+          row[measure] = 10 + Math.round(doy * Math.random());
         } else {
-          row[measure] = Math.round(Math.random() * 1000)
+          row[measure] = Math.round(Math.random() * 1000);
         }
-      })
-    })
+      });
+    });
   }
 
   if (orderByFields.length) {
-    rows = _.orderBy(rows, orderByFields, orderByDirections)
+    rows = _.orderBy(rows, orderByFields, orderByDirections);
   }
 
   if (limit) {
-    rows = rows.slice(0, limit)
+    rows = rows.slice(0, limit);
   }
 
-  return { rows: rows.slice(0, maxRows), incomplete: rows.length > maxRows }
+  return { rows: rows.slice(0, maxRows), incomplete: rows.length > maxRows };
 }
 
 /**
@@ -197,11 +197,11 @@ function testConnection(connection) {
   const query = `
     -- dimensions = department 1
     -- measures = price
-  `
-  return runQuery(query, connection)
+  `;
+  return runQuery(query, connection);
 }
 
-const schemaRows = []
+const schemaRows = [];
 const columns = [
   { name: 'product', type: 'TEXT', description: 'item sold' },
   { name: 'color', type: 'TEXT', description: 'color of item' },
@@ -212,7 +212,7 @@ const columns = [
     type: 'TIMESTAMP',
     description: 'date and time of order'
   }
-]
+];
 Array(500)
   .fill(true)
   .forEach((value, tableIndex) => {
@@ -223,9 +223,9 @@ Array(500)
         column_name: column.name,
         data_type: column.type,
         column_description: column.description
-      })
-    })
-  })
+      });
+    });
+  });
 
 /**
  * Get schema for connection
@@ -235,10 +235,10 @@ function getSchema(connection) {
   const fakeSchemaQueryResult = {
     rows: schemaRows,
     incomplete: false
-  }
+  };
   return Promise.resolve().then(() =>
     formatSchemaQueryResults(fakeSchemaQueryResult)
-  )
+  );
 }
 
 const fields = [
@@ -312,7 +312,7 @@ const fields = [
     formType: 'TEXT',
     label: 'Password for socks proxy'
   }
-]
+];
 
 module.exports = {
   id,
@@ -321,4 +321,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/mock/test.js
+++ b/server/drivers/mock/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const mock = require('./index.js')
+const assert = require('assert');
+const mock = require('./index.js');
 
 const connection = {
   name: 'test postgres',
@@ -9,40 +9,40 @@ const connection = {
   username: 'sqlpad',
   password: 'sqlpad',
   maxRows: 100
-}
+};
 
 describe('drivers/mock', function() {
   it('tests connection', function() {
-    return mock.testConnection(connection)
-  })
+    return mock.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return mock.getSchema(connection).then(schemaInfo => {
       // Should probably create tables and validate them here
       // For now this is a smoke test of sorts
-      assert(schemaInfo)
-    })
-  })
+      assert(schemaInfo);
+    });
+  });
 
   it('runQuery under limit', function() {
-    const c = Object.assign({}, connection, { maxRows: 10000 })
+    const c = Object.assign({}, connection, { maxRows: 10000 });
     const query = `
       -- dimensions = product 5
-    `
+    `;
     return mock.runQuery(query, c).then(results => {
-      assert(!results.incomplete, 'not incomplete')
-      assert.equal(results.rows.length, 5, 'row length')
-    })
-  })
+      assert(!results.incomplete, 'not incomplete');
+      assert.equal(results.rows.length, 5, 'row length');
+    });
+  });
 
   it('runQuery over limit', function() {
-    const c = Object.assign({}, connection, { maxRows: 10 })
+    const c = Object.assign({}, connection, { maxRows: 10 });
     const query = `
       -- dimensions = product 10, color 10, orderdate 500
-    `
+    `;
     return mock.runQuery(query, c).then(results => {
-      assert(results.incomplete, 'incomplete')
-      assert.equal(results.rows.length, 10, 'row length')
-    })
-  })
-})
+      assert(results.incomplete, 'incomplete');
+      assert.equal(results.rows.length, 10, 'row length');
+    });
+  });
+});

--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -1,8 +1,8 @@
-const mysql = require('mysql')
-const { formatSchemaQueryResults } = require('../utils')
+const mysql = require('mysql');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'mysql'
-const name = 'MySQL'
+const id = 'mysql';
+const name = 'MySQL';
 
 function getSchemaSql(database) {
   const whereSql = database
@@ -11,7 +11,7 @@ function getSchemaSql(database) {
         'mysql', 
         'performance_schema', 
         'information_schema'
-      )`
+      )`;
   return `
     SELECT 
       t.table_schema, 
@@ -26,7 +26,7 @@ function getSchemaSql(database) {
       t.table_schema, 
       t.table_name, 
       c.ordinal_position
-  `
+  `;
 }
 
 /**
@@ -46,53 +46,53 @@ function runQuery(query, connection) {
     insecureAuth: connection.mysqlInsecureAuth,
     timezone: 'Z',
     supportBigNumbers: true
-  })
+  });
 
   return new Promise((resolve, reject) => {
-    let incomplete = false
-    const rows = []
+    let incomplete = false;
+    const rows = [];
 
     myConnection.connect(err => {
       if (err) {
-        return reject(err)
+        return reject(err);
       }
-      let queryError
-      let resultsSent = false
+      let queryError;
+      let resultsSent = false;
 
       function continueOn() {
         if (!resultsSent) {
-          resultsSent = true
+          resultsSent = true;
           if (queryError) {
-            return reject(queryError)
+            return reject(queryError);
           }
-          return resolve({ rows, incomplete })
+          return resolve({ rows, incomplete });
         }
       }
 
-      const myQuery = myConnection.query(query)
+      const myQuery = myConnection.query(query);
       myQuery
         .on('error', function(err) {
           // Handle error,
           // an 'end' event will be emitted after this as well
           // so we'll call the callback there.
-          queryError = err
+          queryError = err;
         })
         .on('result', function(row) {
           // If we haven't hit the max yet add row to results
           if (rows.length < connection.maxRows) {
-            return rows.push(row)
+            return rows.push(row);
           }
 
           // Too many rows
-          incomplete = true
+          incomplete = true;
 
           // Stop the query stream
-          myConnection.pause()
+          myConnection.pause();
 
           // Destroy the underlying connection
           // Calling end() will wait and eventually time out
-          myConnection.destroy()
-          continueOn()
+          myConnection.destroy();
+          continueOn();
         })
         .on('end', function() {
           // all rows have been received
@@ -101,13 +101,13 @@ function runQuery(query, connection) {
           // myConnection.destroy()
           myConnection.end(error => {
             if (error) {
-              console.error('Error ending MySQL connection', error)
+              console.error('Error ending MySQL connection', error);
             }
-            continueOn()
-          })
-        })
-    })
-  })
+            continueOn();
+          });
+        });
+    });
+  });
 }
 
 /**
@@ -115,8 +115,8 @@ function runQuery(query, connection) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = "SELECT 'success' AS TestQuery;"
-  return runQuery(query, connection)
+  const query = "SELECT 'success' AS TestQuery;";
+  return runQuery(query, connection);
 }
 
 /**
@@ -124,10 +124,10 @@ function testConnection(connection) {
  * @param {*} connection
  */
 function getSchema(connection) {
-  const schemaSql = getSchemaSql(connection.database)
+  const schemaSql = getSchemaSql(connection.database);
   return runQuery(schemaSql, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 const fields = [
@@ -161,7 +161,7 @@ const fields = [
     formType: 'CHECKBOX',
     label: 'Use old/insecure pre 4.1 Auth System'
   }
-]
+];
 
 module.exports = {
   id,
@@ -170,4 +170,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/mysql/test.js
+++ b/server/drivers/mysql/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const mysql = require('./index.js')
+const assert = require('assert');
+const mysql = require('./index.js');
 
 const connection = {
   name: 'test mysql',
@@ -9,67 +9,67 @@ const connection = {
   username: 'sqlpad',
   password: 'sqlpad',
   maxRows: 50000
-}
+};
 
-const dropTable = 'DROP TABLE IF EXISTS test;'
-const createTable = 'CREATE TABLE test (id int);'
-const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);'
+const dropTable = 'DROP TABLE IF EXISTS test;';
+const createTable = 'CREATE TABLE test (id int);';
+const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);';
 
 describe('drivers/mysql', function() {
   before(function() {
-    this.timeout(10000)
+    this.timeout(10000);
     return mysql
       .runQuery(dropTable, connection)
       .then(() => mysql.runQuery(createTable, connection))
-      .then(() => mysql.runQuery(inserts, connection))
-  })
+      .then(() => mysql.runQuery(inserts, connection));
+  });
 
   it('tests connection', function() {
-    return mysql.testConnection(connection)
-  })
+    return mysql.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return mysql.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo.sqlpad, 'sqlpad')
-      assert(schemaInfo.sqlpad.test, 'sqlpad.test')
-      const columns = schemaInfo.sqlpad.test
-      assert.equal(columns.length, 1, 'columns.length')
-      assert.equal(columns[0].table_schema, 'sqlpad', 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
-      assert.equal(columns[0].column_name, 'id', 'column_name')
-      assert(columns[0].hasOwnProperty('data_type'), 'data_type')
-    })
-  })
+      assert(schemaInfo.sqlpad, 'sqlpad');
+      assert(schemaInfo.sqlpad.test, 'sqlpad.test');
+      const columns = schemaInfo.sqlpad.test;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, 'sqlpad', 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
+      assert.equal(columns[0].column_name, 'id', 'column_name');
+      assert(columns[0].hasOwnProperty('data_type'), 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return mysql
       .runQuery('SELECT id FROM test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'rows length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
 
   it('runQuery over limit', function() {
-    const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
+    const limitedConnection = Object.assign({}, connection, { maxRows: 2 });
     return mysql
       .runQuery('SELECT * FROM test;', limitedConnection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
 
   it('returns descriptive error message', function() {
-    let error
+    let error;
     return mysql
       .runQuery('SELECT * FROM missing_table;', connection)
       .catch(e => {
-        error = e
+        error = e;
       })
       .then(() => {
-        assert(error)
-        assert(error.toString().indexOf('missing_table') > -1)
-      })
-  })
-})
+        assert(error);
+        assert(error.toString().indexOf('missing_table') > -1);
+      });
+  });
+});

--- a/server/drivers/postgres/index.js
+++ b/server/drivers/postgres/index.js
@@ -1,11 +1,11 @@
-const fs = require('fs')
-const pg = require('pg')
-const PgCursor = require('pg-cursor')
-const SocksConnection = require('socksjs')
-const { formatSchemaQueryResults } = require('../utils')
+const fs = require('fs');
+const pg = require('pg');
+const PgCursor = require('pg-cursor');
+const SocksConnection = require('socksjs');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'postgres'
-const name = 'Postgres'
+const id = 'postgres';
+const name = 'Postgres';
 
 function createSocksConnection(connection) {
   if (connection.useSocks) {
@@ -20,7 +20,7 @@ function createSocksConnection(connection) {
         user: connection.socksUsername,
         pass: connection.socksPassword
       }
-    )
+    );
   }
 }
 
@@ -45,7 +45,7 @@ const SCHEMA_SQL = `
     ns.nspname,
     cls.relname,
     attr.attnum
-`
+`;
 
 /**
  * Run query for connection
@@ -61,66 +61,66 @@ function runQuery(query, connection) {
     host: connection.host,
     ssl: connection.postgresSsl,
     stream: createSocksConnection(connection)
-  }
+  };
   // TODO cache key/cert values
   if (connection.postgresKey && connection.postgresCert) {
     pgConfig.ssl = {
       key: fs.readFileSync(connection.postgresKey),
       cert: fs.readFileSync(connection.postgresCert)
-    }
+    };
     if (connection.postgresCA) {
-      pgConfig.ssl['ca'] = fs.readFileSync(connection.postgresCA)
+      pgConfig.ssl['ca'] = fs.readFileSync(connection.postgresCA);
     }
   }
-  if (connection.port) pgConfig.port = connection.port
+  if (connection.port) pgConfig.port = connection.port;
 
   return new Promise((resolve, reject) => {
-    const client = new pg.Client(pgConfig)
+    const client = new pg.Client(pgConfig);
     client.connect(err => {
       if (err) {
-        client.end()
-        return reject(err)
+        client.end();
+        return reject(err);
       }
-      const cursor = client.query(new PgCursor(query))
+      const cursor = client.query(new PgCursor(query));
       return cursor.read(connection.maxRows + 1, (err, rows) => {
         if (err) {
           // pg_cursor can't handle multi-statements at the moment
           // as a work around we'll retry the query the old way, but we lose the maxRows protection
           return client.query(query, (err, result) => {
-            client.end()
+            client.end();
             if (err) {
-              return reject(err)
+              return reject(err);
             }
-            return resolve({ rows: result.rows })
-          })
+            return resolve({ rows: result.rows });
+          });
         }
-        let incomplete = false
+        let incomplete = false;
         if (rows.length === connection.maxRows + 1) {
-          incomplete = true
-          rows.pop() // get rid of that extra record. we only get 1 more than the max to see if there would have been more...
+          incomplete = true;
+          rows.pop(); // get rid of that extra record. we only get 1 more than the max to see if there would have been more...
         }
         if (err) {
-          reject(err)
+          reject(err);
         } else {
-          resolve({ rows, incomplete })
+          resolve({ rows, incomplete });
         }
         cursor.close(err => {
           if (err) {
-            console.log('error closing pg-cursor:')
-            console.log(err)
+            console.log('error closing pg-cursor:');
+            console.log(err);
           }
           // Calling end() without setImmediate causes error within node-pg
           setImmediate(() => {
             client.end(error => {
               if (error) {
-                console.error(error)
+                console.error(error);
               }
-            })
-          })
-        })
-      })
-    })
-  })
+            });
+          });
+        });
+      });
+    });
+  });
 }
 
 /**
@@ -128,8 +128,8 @@ function runQuery(query, connection) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = "SELECT 'success' AS TestQuery;"
-  return runQuery(query, connection)
+  const query = "SELECT 'success' AS TestQuery;";
+  return runQuery(query, connection);
 }
 
 /**
@@ -139,7 +139,7 @@ function testConnection(connection) {
 function getSchema(connection) {
   return runQuery(SCHEMA_SQL, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 const fields = [
@@ -213,7 +213,7 @@ const fields = [
     formType: 'TEXT',
     label: 'Password for socks proxy'
   }
-]
+];
 
 module.exports = {
   id,
@@ -222,4 +222,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/postgres/test.js
+++ b/server/drivers/postgres/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const postgres = require('./index.js')
+const assert = require('assert');
+const postgres = require('./index.js');
 
 const connection = {
   name: 'test postgres',
@@ -9,36 +9,36 @@ const connection = {
   username: 'sqlpad',
   password: 'sqlpad',
   maxRows: 100
-}
+};
 
 describe('drivers/postgres', function() {
   it('tests connection', function() {
-    return postgres.testConnection(connection)
-  })
+    return postgres.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return postgres.getSchema(connection).then(schemaInfo => {
       // Should probably create tables and validate them here
       // For now this is a smoke test of sorts
-      assert(schemaInfo)
-    })
-  })
+      assert(schemaInfo);
+    });
+  });
 
   it('runQuery under limit', function() {
     return postgres
       .runQuery('SELECT * FROM generate_series(1, 10) gs;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 10, 'row length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 10, 'row length');
+      });
+  });
 
   it('runQuery over limit', function() {
     return postgres
       .runQuery('SELECT * FROM generate_series(1, 9000) gs;', connection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 100, 'row length')
-      })
-  })
-})
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 100, 'row length');
+      });
+  });
+});

--- a/server/drivers/presto/_presto.js
+++ b/server/drivers/presto/_presto.js
@@ -1,64 +1,64 @@
-const fetch = require('node-fetch')
-const NEXT_URI_TIMEOUT = 100
+const fetch = require('node-fetch');
+const NEXT_URI_TIMEOUT = 100;
 
-module.exports = { send }
+module.exports = { send };
 
 // Util - setTimeout as a promise
 function wait(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 // Get Presto headers from config
 function getHeaders(config) {
-  const headers = { 'X-Presto-User': config.user }
+  const headers = { 'X-Presto-User': config.user };
   if (config.catalog) {
-    headers['X-Presto-Catalog'] = config.catalog
+    headers['X-Presto-Catalog'] = config.catalog;
   }
   if (config.schema) {
-    headers['X-Presto-Schema'] = config.schema
+    headers['X-Presto-Schema'] = config.schema;
   }
-  return headers
+  return headers;
 }
 
 // Given config and query, returns promise with the results
 function send(config, query) {
   if (!config.url) {
-    return Promise.reject(new Error('config.url is required'))
+    return Promise.reject(new Error('config.url is required'));
   }
   const results = {
     data: []
-  }
+  };
   return fetch(`${config.url}/v1/statement`, {
     method: 'POST',
     body: query,
     headers: getHeaders(config)
   })
     .then(response => response.json())
-    .then(statement => handleStatementAndGetMore(results, statement, config))
+    .then(statement => handleStatementAndGetMore(results, statement, config));
 }
 
 function updateResults(results, statement) {
   if (statement.data && statement.data.length) {
-    results.data = results.data.concat(statement.data)
+    results.data = results.data.concat(statement.data);
   }
   if (statement.columns) {
-    results.columns = statement.columns
+    results.columns = statement.columns;
   }
-  return results
+  return results;
 }
 
 function handleStatementAndGetMore(results, statement, config) {
   if (statement.error) {
     // A lot of other error data available,
     // but error.message contains the detail on syntax issue
-    return Promise.reject(statement.error.message)
+    return Promise.reject(statement.error.message);
   }
-  results = updateResults(results, statement)
+  results = updateResults(results, statement);
   if (!statement.nextUri) {
-    return Promise.resolve(results)
+    return Promise.resolve(results);
   }
   return wait(NEXT_URI_TIMEOUT)
     .then(() => fetch(statement.nextUri, { headers: getHeaders(config) }))
     .then(response => response.json())
-    .then(statement => handleStatementAndGetMore(results, statement, config))
+    .then(statement => handleStatementAndGetMore(results, statement, config));
 }

--- a/server/drivers/presto/index.js
+++ b/server/drivers/presto/index.js
@@ -1,11 +1,11 @@
-const presto = require('./_presto')
-const { formatSchemaQueryResults } = require('../utils')
+const presto = require('./_presto');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'presto'
-const name = 'Presto'
+const id = 'presto';
+const name = 'Presto';
 
 function getPrestoSchemaSql(catalog, schema) {
-  const schemaSql = schema ? `AND table_schema = '${schema}'` : ''
+  const schemaSql = schema ? `AND table_schema = '${schema}'` : '';
   return `
     SELECT 
       c.table_schema, 
@@ -21,7 +21,7 @@ function getPrestoSchemaSql(catalog, schema) {
       c.table_schema, 
       c.table_name, 
       c.ordinal_position
-  `
+  `;
 }
 
 /**
@@ -31,33 +31,33 @@ function getPrestoSchemaSql(catalog, schema) {
  * @param {object} connection
  */
 function runQuery(query, connection) {
-  let incomplete = false
-  const rows = []
-  const port = connection.port || 8080
+  let incomplete = false;
+  const rows = [];
+  const port = connection.port || 8080;
   const prestoConfig = {
     url: `http://${connection.host}:${port}`,
     user: connection.username,
     catalog: connection.prestoCatalog,
     schema: connection.prestoSchema
-  }
+  };
   return presto.send(prestoConfig, query).then(result => {
     if (!result) {
-      throw new Error('No result returned')
+      throw new Error('No result returned');
     }
-    let { data, columns } = result
+    let { data, columns } = result;
     if (data.length > connection.maxRows) {
-      incomplete = true
-      data = data.slice(0, connection.maxRows)
+      incomplete = true;
+      data = data.slice(0, connection.maxRows);
     }
     for (let r = 0; r < data.length; r++) {
-      const row = {}
+      const row = {};
       for (let c = 0; c < columns.length; c++) {
-        row[columns[c].name] = data[r][c]
+        row[columns[c].name] = data[r][c];
       }
-      rows.push(row)
+      rows.push(row);
     }
-    return { rows, incomplete }
-  })
+    return { rows, incomplete };
+  });
 }
 
 /**
@@ -66,8 +66,8 @@ function runQuery(query, connection) {
  */
 function testConnection(connection) {
   // Presto cannot have ; at end of query
-  const query = "SELECT 'success' AS TestQuery"
-  return runQuery(query, connection)
+  const query = "SELECT 'success' AS TestQuery";
+  return runQuery(query, connection);
 }
 
 /**
@@ -78,10 +78,10 @@ function getSchema(connection) {
   const schemaSql = getPrestoSchemaSql(
     connection.prestoCatalog,
     connection.prestoSchema
-  )
+  );
   return runQuery(schemaSql, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 const fields = [
@@ -110,7 +110,7 @@ const fields = [
     formType: 'TEXT',
     label: 'Schema'
   }
-]
+];
 
 module.exports = {
   id,
@@ -119,4 +119,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/presto/test.js
+++ b/server/drivers/presto/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const presto = require('./index.js')
+const assert = require('assert');
+const presto = require('./index.js');
 
 const connection = {
   name: 'test presto',
@@ -10,86 +10,87 @@ const connection = {
   prestoCatalog: 'memory',
   // will be set after schema is created
   prestoSchema: null
-}
+};
 
-const schemaSql = 'CREATE SCHEMA test'
-const tableSql = 'CREATE TABLE test (id INT, some_text VARCHAR)'
+const schemaSql = 'CREATE SCHEMA test';
+const tableSql = 'CREATE TABLE test (id INT, some_text VARCHAR)';
 
 // For presto, we should test to make sure driver follows the nextUri links properly
 // To help with that we can add lots of data
-const values = []
+const values = [];
 for (let i = 0; i < 1000; i++) {
-  values.push(`(${i}, 'some text for the text field ${i}')`)
+  values.push(`(${i}, 'some text for the text field ${i}')`);
 }
 
-const insertSql = 'INSERT INTO test (id, some_text) VALUES ' + values.join(', ')
+const insertSql =
+  'INSERT INTO test (id, some_text) VALUES ' + values.join(', ');
 
 describe('drivers/presto', function() {
   before(function() {
-    this.timeout(60000)
+    this.timeout(60000);
     return presto
       .runQuery(schemaSql, connection)
       .then(() => {
         // prestoSchema needs to be set or otherwise always specified
-        connection.prestoSchema = 'test'
-        return presto.runQuery(tableSql, connection)
+        connection.prestoSchema = 'test';
+        return presto.runQuery(tableSql, connection);
       })
       .then(() => {
-        let seq = Promise.resolve()
+        let seq = Promise.resolve();
         for (let i = 0; i < 10; i++) {
-          seq = seq.then(() => presto.runQuery(insertSql, connection))
+          seq = seq.then(() => presto.runQuery(insertSql, connection));
         }
-        return seq
-      })
-  })
+        return seq;
+      });
+  });
 
   it('tests connection', function() {
-    return presto.testConnection(connection)
-  })
+    return presto.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return presto.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo)
-      assert(schemaInfo.test, 'test')
-      assert(schemaInfo.test.test, 'test.test')
-      const columns = schemaInfo.test.test
-      assert.equal(columns.length, 2, 'columns.length')
-      assert.equal(columns[0].table_schema, 'test', 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
-      assert.equal(columns[0].column_name, 'id', 'column_name')
-      assert(columns[0].hasOwnProperty('data_type'), 'data_type')
-    })
-  })
+      assert(schemaInfo);
+      assert(schemaInfo.test, 'test');
+      assert(schemaInfo.test.test, 'test.test');
+      const columns = schemaInfo.test.test;
+      assert.equal(columns.length, 2, 'columns.length');
+      assert.equal(columns[0].table_schema, 'test', 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
+      assert.equal(columns[0].column_name, 'id', 'column_name');
+      assert(columns[0].hasOwnProperty('data_type'), 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return presto
       .runQuery('SELECT id FROM test WHERE id = 1 LIMIT 1', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'rows length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
 
   it('runQuery over limit', function() {
-    const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
+    const limitedConnection = Object.assign({}, connection, { maxRows: 2 });
     return presto
       .runQuery('SELECT * FROM test LIMIT 10', limitedConnection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
 
   it('returns descriptive error message', function() {
-    let error
+    let error;
     return presto
       .runQuery('SELECT * FROM missing_table', connection)
       .catch(e => {
-        error = e
+        error = e;
       })
       .then(() => {
-        assert(error)
-        assert(error.toString().indexOf('missing_table') > -1)
-      })
-  })
-})
+        assert(error);
+        assert(error.toString().indexOf('missing_table') > -1);
+      });
+  });
+});

--- a/server/drivers/sqlserver/test.js
+++ b/server/drivers/sqlserver/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const sqlserver = require('./index.js')
+const assert = require('assert');
+const sqlserver = require('./index.js');
 
 const masterConnection = {
   name: 'test sqlserver',
@@ -8,7 +8,7 @@ const masterConnection = {
   database: 'master',
   username: 'sa',
   password: 'SuperP4ssw0rd!'
-}
+};
 
 const connection = {
   name: 'test sqlserver',
@@ -18,53 +18,53 @@ const connection = {
   username: 'sa',
   password: 'SuperP4ssw0rd!',
   maxRows: 2
-}
+};
 
-const createDb = 'CREATE DATABASE test;'
-const createTable = 'CREATE TABLE test (id int);'
-const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);'
+const createDb = 'CREATE DATABASE test;';
+const createTable = 'CREATE TABLE test (id int);';
+const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);';
 
 describe('drivers/sqlserver', function() {
   before(function() {
-    this.timeout(10000)
+    this.timeout(10000);
     return sqlserver
       .runQuery(createDb, masterConnection)
       .then(() => sqlserver.runQuery(createTable, connection))
-      .then(() => sqlserver.runQuery(inserts, connection))
-  })
+      .then(() => sqlserver.runQuery(inserts, connection));
+  });
 
   it('tests connection', function() {
-    return sqlserver.testConnection(connection)
-  })
+    return sqlserver.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return sqlserver.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo.dbo, 'dbo')
-      assert(schemaInfo.dbo.test, 'dbo.test')
-      const columns = schemaInfo.dbo.test
-      assert.equal(columns.length, 1, 'columns.length')
-      assert.equal(columns[0].table_schema, 'dbo', 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
-      assert.equal(columns[0].column_name, 'id', 'column_name')
-      assert.equal(columns[0].data_type, 'int', 'data_type')
-    })
-  })
+      assert(schemaInfo.dbo, 'dbo');
+      assert(schemaInfo.dbo.test, 'dbo.test');
+      const columns = schemaInfo.dbo.test;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, 'dbo', 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
+      assert.equal(columns[0].column_name, 'id', 'column_name');
+      assert.equal(columns[0].data_type, 'int', 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return sqlserver
       .runQuery('SELECT * FROM test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'row length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'row length');
+      });
+  });
 
   it('runQuery over limit', function() {
     return sqlserver
       .runQuery('SELECT * FROM test;', connection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
-})
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
+});

--- a/server/drivers/unixodbc/index.js
+++ b/server/drivers/unixodbc/index.js
@@ -1,8 +1,8 @@
-const odbc = require('odbc')()
-const { formatSchemaQueryResults } = require('../utils')
+const odbc = require('odbc')();
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'unixodbc'
-const name = 'unixODBC'
+const id = 'unixodbc';
+const name = 'unixODBC';
 
 // Default to using INFORMATION_SCHEMA with old-style join for maximum compatibility
 // INFORMATION_SCHEMA is not supported by every DBMS but it is supported by
@@ -23,7 +23,7 @@ const SCHEMA_SQL_INFORMATION_SCHEMA = `
     c.table_schema,
     c.table_name,
     c.ordinal_position
-`
+`;
 
 /**
  * Run query for connection
@@ -37,53 +37,53 @@ function runQuery(query, connection) {
     user: connection.username,
     password: connection.password,
     connection_string: connection.connection_string
-  }
+  };
   // TODO use connection pool
   // TODO handle connection.maxRows
 
-  let cn = config.connection_string
+  let cn = config.connection_string;
 
   // Not all drivers require auth
   if (config.user) {
-    cn = cn + ';Uid=' + config.user
+    cn = cn + ';Uid=' + config.user;
   }
   if (config.password) {
-    cn = cn + ';Pwd=' + config.password
+    cn = cn + ';Pwd=' + config.password;
   }
 
   return openConnection(cn)
     .then(connectionStatus => {
-      return executeQuery(query)
+      return executeQuery(query);
     })
     .then(queryResult => {
-      odbc.close() // TODO consider putting into finally()?
-      return Promise.resolve({ rows: queryResult, incomplete: false })
+      odbc.close(); // TODO consider putting into finally()?
+      return Promise.resolve({ rows: queryResult, incomplete: false });
     })
     .catch(function(e) {
-      console.error(e, e.stack)
-    })
+      console.error(e, e.stack);
+    });
 }
 
 function executeQuery(sqlString) {
   return new Promise((resolve, reject) => {
     odbc.query(sqlString, function(err, data) {
       if (err) {
-        reject(err)
+        reject(err);
       }
-      resolve(data)
-    })
-  })
+      resolve(data);
+    });
+  });
 }
 
 function openConnection(connectionString) {
   return new Promise((resolve, reject) => {
     odbc.open(connectionString, function(err) {
       if (err) {
-        reject(err)
+        reject(err);
       }
-      resolve('Connection Open')
-    })
-  })
+      resolve('Connection Open');
+    });
+  });
 }
 
 /**
@@ -91,8 +91,8 @@ function openConnection(connectionString) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = "SELECT 'success' AS TestQuery;"
-  return runQuery(query, connection)
+  const query = "SELECT 'success' AS TestQuery;";
+  return runQuery(query, connection);
 }
 
 // TODO - reviewed no change needed? datatypes need reviewing
@@ -103,10 +103,10 @@ function testConnection(connection) {
 function getSchema(connection) {
   const schema_sql = connection.schema_sql
     ? connection.schema_sql
-    : SCHEMA_SQL_INFORMATION_SCHEMA
+    : SCHEMA_SQL_INFORMATION_SCHEMA;
   return runQuery(schema_sql, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 const fields = [
@@ -132,7 +132,7 @@ const fields = [
     formType: 'PASSWORD',
     label: 'Database Password (optional)'
   }
-]
+];
 
 module.exports = {
   id,
@@ -141,4 +141,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/unixodbc/test.js
+++ b/server/drivers/unixodbc/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const unixodbc = require('./index.js')
+const assert = require('assert');
+const unixodbc = require('./index.js');
 
 const connection = {
   connection_string: process.env.ODBC_CONNECTION_STRING, // I.e. ensure os variable is set to connection string
@@ -12,13 +12,13 @@ const connection = {
     FROM sqlite_master
     WHERE type = 'table';
 `
-}
-const test_schema_name = 'dba' // sqlite3 does not really have owner
+};
+const test_schema_name = 'dba'; // sqlite3 does not really have owner
 
-const createTable = 'CREATE TABLE test (id integer);' // NOTE test(s) will fail if table already exists, expect empty database
-const insert1 = 'INSERT INTO test (id) VALUES (1);'
-const insert2 = 'INSERT INTO test (id) VALUES (2);'
-const insert3 = 'INSERT INTO test (id) VALUES (3);'
+const createTable = 'CREATE TABLE test (id integer);'; // NOTE test(s) will fail if table already exists, expect empty database
+const insert1 = 'INSERT INTO test (id) VALUES (1);';
+const insert2 = 'INSERT INTO test (id) VALUES (2);';
+const insert3 = 'INSERT INTO test (id) VALUES (3);';
 
 // TODO test more datatypes:
 //   * integer (different sizes
@@ -31,47 +31,47 @@ const insert3 = 'INSERT INTO test (id) VALUES (3);'
 //   * interval
 describe('drivers/unixodbc', function() {
   before(function() {
-    this.timeout(10000)
+    this.timeout(10000);
     return unixodbc
       .runQuery(createTable, connection)
       .then(() => unixodbc.runQuery(insert1, connection))
       .then(() => unixodbc.runQuery(insert2, connection))
-      .then(() => unixodbc.runQuery(insert3, connection))
-  })
+      .then(() => unixodbc.runQuery(insert3, connection));
+  });
 
   it('tests connection', function() {
-    return unixodbc.testConnection(connection)
-  })
+    return unixodbc.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return unixodbc.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo[test_schema_name], test_schema_name)
-      assert(schemaInfo[test_schema_name].test, test_schema_name + '.test')
-      const columns = schemaInfo[test_schema_name].test
-      assert.equal(columns.length, 1, 'columns.length')
-      assert.equal(columns[0].table_schema, test_schema_name, 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
+      assert(schemaInfo[test_schema_name], test_schema_name);
+      assert(schemaInfo[test_schema_name].test, test_schema_name + '.test');
+      const columns = schemaInfo[test_schema_name].test;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, test_schema_name, 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
       // column metadata not available in sqlite3
-      assert.equal(columns[0].column_name, 'unknown', 'column_name')
-      assert.equal(columns[0].data_type, 'unknown', 'data_type')
-    })
-  })
+      assert.equal(columns[0].column_name, 'unknown', 'column_name');
+      assert.equal(columns[0].data_type, 'unknown', 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return unixodbc
       .runQuery('SELECT * FROM test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'row length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'row length');
+      });
+  });
 
   it('runQuery over limit', function() {
     return unixodbc
       .runQuery('SELECT * FROM test;', connection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
-})
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
+});

--- a/server/drivers/utils.js
+++ b/server/drivers/utils.js
@@ -1,4 +1,4 @@
-const _ = require('lodash')
+const _ = require('lodash');
 
 /**
  * Formats schema query results into
@@ -7,29 +7,29 @@ const _ = require('lodash')
  */
 function formatSchemaQueryResults(queryResult) {
   if (!queryResult || !queryResult.rows || !queryResult.rows.length) {
-    return {}
+    return {};
   }
 
   // queryResult row casing may not always be consistent with what is specified in query
   // HANA is always uppercase despire aliasing as lower case for example
   // To account for this loop through rows and normalize the case
   const rows = queryResult.rows.map(row => {
-    const cleanRow = {}
+    const cleanRow = {};
     Object.keys(row).forEach(key => {
-      cleanRow[key.toLowerCase()] = row[key]
-    })
-    return cleanRow
-  })
+      cleanRow[key.toLowerCase()] = row[key];
+    });
+    return cleanRow;
+  });
 
-  const tree = {}
-  const bySchema = _.groupBy(rows, 'table_schema')
+  const tree = {};
+  const bySchema = _.groupBy(rows, 'table_schema');
   for (const schema in bySchema) {
     if (bySchema.hasOwnProperty(schema)) {
-      tree[schema] = {}
-      const byTableName = _.groupBy(bySchema[schema], 'table_name')
+      tree[schema] = {};
+      const byTableName = _.groupBy(bySchema[schema], 'table_name');
       for (const tableName in byTableName) {
         if (byTableName.hasOwnProperty(tableName)) {
-          tree[schema][tableName] = byTableName[tableName]
+          tree[schema][tableName] = byTableName[tableName];
         }
       }
     }
@@ -47,7 +47,7 @@ function formatSchemaQueryResults(queryResult) {
       }
     }
   */
-  return tree
+  return tree;
 }
 
 /**
@@ -58,21 +58,21 @@ function formatSchemaQueryResults(queryResult) {
  */
 function ensureBoolean(value) {
   if (typeof value === 'boolean') {
-    return value
+    return value;
   }
   if (typeof value === 'string' && value.toLowerCase() === 'true') {
-    return true
+    return true;
   } else if (typeof value === 'string' && value.toLowerCase() === 'false') {
-    return false
+    return false;
   } else if (value === 1) {
-    return true
+    return true;
   } else if (value === 0) {
-    return false
+    return false;
   }
-  throw new Error(`Unexpected value for boolean: ${value}`)
+  throw new Error(`Unexpected value for boolean: ${value}`);
 }
 
 module.exports = {
   ensureBoolean,
   formatSchemaQueryResults
-}
+};

--- a/server/drivers/vertica/index.js
+++ b/server/drivers/vertica/index.js
@@ -1,8 +1,8 @@
-const vertica = require('vertica')
-const { formatSchemaQueryResults } = require('../utils')
+const vertica = require('vertica');
+const { formatSchemaQueryResults } = require('../utils');
 
-const id = 'vertica'
-const name = 'Vertica'
+const id = 'vertica';
+const name = 'Vertica';
 
 const SCHEMA_SQL = `
   SELECT 
@@ -20,7 +20,7 @@ const SCHEMA_SQL = `
     vt.table_schema, 
     vt.table_name, 
     vc.ordinal_position
-`
+`;
 
 /**
  * Run query for connection
@@ -35,59 +35,59 @@ function runQuery(query, connection) {
     user: connection.username,
     password: connection.password,
     database: connection.database
-  }
+  };
 
   return new Promise((resolve, reject) => {
     const client = vertica.connect(params, function(err) {
       if (err) {
-        client.disconnect()
-        return reject(err)
+        client.disconnect();
+        return reject(err);
       }
 
-      let incomplete = false
-      const rows = []
-      let finished = false
-      let columnNames = []
+      let incomplete = false;
+      const rows = [];
+      let finished = false;
+      let columnNames = [];
 
-      const verticaQuery = client.query(query)
+      const verticaQuery = client.query(query);
 
       verticaQuery.on('fields', fields => {
-        columnNames = fields.map(field => field.name)
-      })
+        columnNames = fields.map(field => field.name);
+      });
 
       verticaQuery.on('row', function(row) {
         if (rows.length < connection.maxRows) {
-          const resultRow = {}
+          const resultRow = {};
           row.forEach((value, index) => {
-            resultRow[columnNames[index]] = value
-          })
-          return rows.push(resultRow)
+            resultRow[columnNames[index]] = value;
+          });
+          return rows.push(resultRow);
         }
         if (!finished) {
-          finished = true
-          client.disconnect()
-          incomplete = true
-          return resolve({ rows, incomplete })
+          finished = true;
+          client.disconnect();
+          incomplete = true;
+          return resolve({ rows, incomplete });
         }
-      })
+      });
 
       verticaQuery.on('end', function() {
         if (!finished) {
-          finished = true
-          client.disconnect()
-          return resolve({ rows, incomplete })
+          finished = true;
+          client.disconnect();
+          return resolve({ rows, incomplete });
         }
-      })
+      });
 
       verticaQuery.on('error', function(err) {
         if (!finished) {
-          finished = true
-          client.disconnect()
-          return reject(err)
+          finished = true;
+          client.disconnect();
+          return reject(err);
         }
-      })
-    })
-  })
+      });
+    });
+  });
 }
 
 /**
@@ -95,8 +95,8 @@ function runQuery(query, connection) {
  * @param {*} connection
  */
 function testConnection(connection) {
-  const query = "SELECT 'success' AS TestQuery;"
-  return runQuery(query, connection)
+  const query = "SELECT 'success' AS TestQuery;";
+  return runQuery(query, connection);
 }
 
 /**
@@ -106,7 +106,7 @@ function testConnection(connection) {
 function getSchema(connection) {
   return runQuery(SCHEMA_SQL, connection).then(queryResult =>
     formatSchemaQueryResults(queryResult)
-  )
+  );
 }
 
 const fields = [
@@ -135,7 +135,7 @@ const fields = [
     formType: 'PASSWORD',
     label: 'Database Password'
   }
-]
+];
 
 module.exports = {
   id,
@@ -144,4 +144,4 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection
-}
+};

--- a/server/drivers/vertica/test.js
+++ b/server/drivers/vertica/test.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const vertica = require('./index.js')
+const assert = require('assert');
+const vertica = require('./index.js');
 
 const connection = {
   name: 'test vertica',
@@ -7,7 +7,7 @@ const connection = {
   host: 'localhost',
   username: 'dbadmin',
   maxRows: 50000
-}
+};
 
 const initSql = `
   DROP TABLE IF EXISTS test;
@@ -20,60 +20,60 @@ const initSql = `
   INSERT INTO test (id) VALUES (2);
   INSERT INTO test (id) VALUES (3);
   COMMIT;
-`
+`;
 
 describe('drivers/vertica', function() {
   before(function() {
-    this.timeout(10000)
-    return vertica.runQuery(initSql, connection)
-  })
+    this.timeout(10000);
+    return vertica.runQuery(initSql, connection);
+  });
 
   it('tests connection', function() {
-    return vertica.testConnection(connection)
-  })
+    return vertica.testConnection(connection);
+  });
 
   it('getSchema()', function() {
     return vertica.getSchema(connection).then(schemaInfo => {
-      assert(schemaInfo.public, 'public')
-      assert(schemaInfo.public.test, 'public.test')
-      const columns = schemaInfo.public.test
-      assert.equal(columns.length, 1, 'columns.length')
-      assert.equal(columns[0].table_schema, 'public', 'table_schema')
-      assert.equal(columns[0].table_name, 'test', 'table_name')
-      assert.equal(columns[0].column_name, 'id', 'column_name')
-      assert(columns[0].hasOwnProperty('data_type'), 'data_type')
-    })
-  })
+      assert(schemaInfo.public, 'public');
+      assert(schemaInfo.public.test, 'public.test');
+      const columns = schemaInfo.public.test;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, 'public', 'table_schema');
+      assert.equal(columns[0].table_name, 'test', 'table_name');
+      assert.equal(columns[0].column_name, 'id', 'column_name');
+      assert(columns[0].hasOwnProperty('data_type'), 'data_type');
+    });
+  });
 
   it('runQuery under limit', function() {
     return vertica
       .runQuery('SELECT id FROM test WHERE id = 1;', connection)
       .then(results => {
-        assert(!results.incomplete, 'not incomplete')
-        assert.equal(results.rows.length, 1, 'rows length')
-      })
-  })
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
 
   it('runQuery over limit', function() {
-    const limitedConnection = Object.assign({}, connection, { maxRows: 2 })
+    const limitedConnection = Object.assign({}, connection, { maxRows: 2 });
     return vertica
       .runQuery('SELECT * FROM test;', limitedConnection)
       .then(results => {
-        assert(results.incomplete, 'incomplete')
-        assert.equal(results.rows.length, 2, 'row length')
-      })
-  })
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
 
   it('returns descriptive error message', function() {
-    let error
+    let error;
     return vertica
       .runQuery('SELECT * FROM missing_table;', connection)
       .catch(e => {
-        error = e
+        error = e;
       })
       .then(() => {
-        assert(error)
-        assert(error.toString().indexOf('missing_table') > -1)
-      })
-  })
-})
+        assert(error);
+        assert(error.toString().indexOf('missing_table') > -1);
+      });
+  });
+});

--- a/server/lib/check-whitelist.js
+++ b/server/lib/check-whitelist.js
@@ -17,12 +17,12 @@
  */
 module.exports = function checkWhitelist(whitelistedDomains, email) {
   if (whitelistedDomains) {
-    const domain = email.split('@')[1]
+    const domain = email.split('@')[1];
     const whitelistDomains = whitelistedDomains
       .split(' ')
-      .map(domain => domain.trim())
+      .map(domain => domain.trim());
 
-    return whitelistDomains.includes(domain)
+    return whitelistDomains.includes(domain);
   }
-  return false
-}
+  return false;
+};

--- a/server/lib/cipher.js
+++ b/server/lib/cipher.js
@@ -1,8 +1,8 @@
-const crypto = require('crypto')
-const algorithm = 'aes256'
-const { passphrase } = require('../lib/config').getPreDbConfig()
+const crypto = require('crypto');
+const algorithm = 'aes256';
+const { passphrase } = require('../lib/config').getPreDbConfig();
 
 module.exports = function(text) {
-  const myCipher = crypto.createCipher(algorithm, passphrase)
-  return myCipher.update(text, 'utf8', 'hex') + myCipher.final('hex')
-}
+  const myCipher = crypto.createCipher(algorithm, passphrase);
+  return myCipher.update(text, 'utf8', 'hex') + myCipher.final('hex');
+};

--- a/server/lib/cli-flow.js
+++ b/server/lib/cli-flow.js
@@ -1,11 +1,11 @@
-const fs = require('fs')
-const path = require('path')
-const minimist = require('minimist')
-const argv = minimist(process.argv.slice(2))
-const packageJson = require('../package.json')
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+const argv = minimist(process.argv.slice(2));
+const packageJson = require('../package.json');
 const userHome =
-  process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME
-const savedCliFilePath = path.join(userHome, '.sqlpadrc')
+  process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME;
+const savedCliFilePath = path.join(userHome, '.sqlpadrc');
 
 const helpText = `
 
@@ -47,38 +47,38 @@ Example:
 
   sqlpad --dir ./sqlpaddata --ip 127.0.0.1 --port 3000 --passphrase secr3t
 
-`
+`;
 
 // If version is requested show version then exit
 if (argv.v || argv.version) {
-  console.log('SQLPad version ' + packageJson.version)
-  process.exit()
+  console.log('SQLPad version ' + packageJson.version);
+  process.exit();
 }
 
 // If help is requested show help
 if (argv.h || argv.help) {
-  console.log(helpText)
-  process.exit()
+  console.log(helpText);
+  process.exit();
 }
 
 // if --save was passed in via cli, we should save the cli args
 // this file is a simple key/value object where key is the config item key
 if (argv.save) {
-  console.log('Saving your configuration.')
-  console.log("Next time just run 'sqlpad' and this config will be loaded.")
-  fs.writeFileSync(savedCliFilePath, JSON.stringify(argv, null, 2))
+  console.log('Saving your configuration.');
+  console.log("Next time just run 'sqlpad' and this config will be loaded.");
+  fs.writeFileSync(savedCliFilePath, JSON.stringify(argv, null, 2));
 }
 
 // if --forget was passed in via cli we should remove the saved cli args file
 if (argv.forget) {
   if (fs.existsSync(savedCliFilePath)) {
-    fs.unlinkSync(savedCliFilePath)
-    console.log('Previous configuration removed.')
+    fs.unlinkSync(savedCliFilePath);
+    console.log('Previous configuration removed.');
   } else {
     console.log(
       'No previous configuration saved. Maybe it was a different user?'
-    )
+    );
   }
-  console.log('Exiting...')
-  process.exit()
+  console.log('Exiting...');
+  process.exit();
 }

--- a/server/lib/config/configItems.js
+++ b/server/lib/config/configItems.js
@@ -277,6 +277,6 @@ const configItems = [
       'If disabled, SQLPad will no longer poll npmjs.com to see if an update is available.',
     default: false
   }
-]
+];
 
-module.exports = configItems
+module.exports = configItems;

--- a/server/lib/config/fromCli.js
+++ b/server/lib/config/fromCli.js
@@ -1,4 +1,4 @@
-const definitions = require('./configItems')
+const definitions = require('./configItems');
 
 /**
  * Gets config values from argv param
@@ -9,16 +9,16 @@ module.exports = function getCliConfig(argv) {
   return definitions
     .filter(definition => definition.hasOwnProperty('cliFlag'))
     .reduce((confMap, definition) => {
-      const { key, cliFlag } = definition
+      const { key, cliFlag } = definition;
 
       // cliFlag could have multiple flags defined
       // TODO make consistent then deprecate old ones
-      const flags = Array.isArray(cliFlag) ? cliFlag : [cliFlag]
+      const flags = Array.isArray(cliFlag) ? cliFlag : [cliFlag];
       flags.forEach(flag => {
         if (argv[flag] != null) {
-          confMap[key] = argv[flag]
+          confMap[key] = argv[flag];
         }
-      })
-      return confMap
-    }, {})
-}
+      });
+      return confMap;
+    }, {});
+};

--- a/server/lib/config/fromDb.js
+++ b/server/lib/config/fromDb.js
@@ -1,8 +1,8 @@
-const definitions = require('./configItems')
+const definitions = require('./configItems');
 
 const uiKeys = definitions
   .filter(definition => definition.interface === 'ui')
-  .map(definition => definition.key)
+  .map(definition => definition.key);
 
 /**
  * Gets config values set in ui from db
@@ -11,18 +11,18 @@ const uiKeys = definitions
  */
 module.exports = function getUiConfig(db) {
   if (!db) {
-    return Promise.reject(new Error('db not provided'))
+    return Promise.reject(new Error('db not provided'));
   }
   return db.config.find({}).then(docs => {
     if (!docs || !docs.length) {
-      return {}
+      return {};
     }
-    const configMap = {}
+    const configMap = {};
     docs
       .filter(doc => uiKeys.includes(doc.key))
       .forEach(doc => {
-        configMap[doc.key] = doc.value
-      })
-    return configMap
-  })
-}
+        configMap[doc.key] = doc.value;
+      });
+    return configMap;
+  });
+};

--- a/server/lib/config/fromDefault.js
+++ b/server/lib/config/fromDefault.js
@@ -1,5 +1,5 @@
-const path = require('path')
-const definitions = require('./configItems')
+const path = require('path');
+const definitions = require('./configItems');
 
 /**
  * Gets default config values
@@ -7,20 +7,20 @@ const definitions = require('./configItems')
  * @returns {object} configMap
  */
 module.exports = function getDefaultConfig() {
-  const defaultMap = {}
+  const defaultMap = {};
 
   definitions.forEach(definition => {
     if (definition.key === 'dbPath') {
       const userHome =
         process.platform === 'win32'
           ? process.env.USERPROFILE
-          : process.env.HOME
-      const defaultDbPath = path.join(userHome, 'sqlpad/db')
-      defaultMap.dbPath = defaultDbPath
+          : process.env.HOME;
+      const defaultDbPath = path.join(userHome, 'sqlpad/db');
+      defaultMap.dbPath = defaultDbPath;
     } else if (definition.hasOwnProperty('default')) {
-      defaultMap[definition.key] = definition.default
+      defaultMap[definition.key] = definition.default;
     }
-  })
+  });
 
-  return defaultMap
-}
+  return defaultMap;
+};

--- a/server/lib/config/fromEnv.js
+++ b/server/lib/config/fromEnv.js
@@ -1,4 +1,4 @@
-const definitions = require('./configItems')
+const definitions = require('./configItems');
 
 /**
  * Gets config values from environment
@@ -9,10 +9,10 @@ module.exports = function getEnvConfig(env = process.env) {
   return definitions
     .filter(definition => definition.hasOwnProperty('envVar'))
     .reduce((envMap, definition) => {
-      const { key, envVar } = definition
+      const { key, envVar } = definition;
       if (env[envVar]) {
-        envMap[key] = env[envVar]
+        envMap[key] = env[envVar];
       }
-      return envMap
-    }, {})
-}
+      return envMap;
+    }, {});
+};

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -1,15 +1,15 @@
-const path = require('path')
-const datastore = require('nedb-promise')
-const mkdirp = require('mkdirp')
-const { admin, dbPath, debug, port } = require('./config').getPreDbConfig()
-const migrateSchema = require('./migrate-schema.js')
+const path = require('path');
+const datastore = require('nedb-promise');
+const mkdirp = require('mkdirp');
+const { admin, dbPath, debug, port } = require('./config').getPreDbConfig();
+const migrateSchema = require('./migrate-schema.js');
 
-mkdirp.sync(path.join(dbPath, '/cache'))
+mkdirp.sync(path.join(dbPath, '/cache'));
 
 // TODO return db as a Promise
-let loaded = false
-let loadError = null
-const onLoads = []
+let loaded = false;
+let loadError = null;
+const onLoads = [];
 
 const db = {
   users: datastore({ filename: path.join(dbPath, 'users.db') }),
@@ -22,24 +22,24 @@ const db = {
   instances: ['users', 'connections', 'queries', 'cache', 'config'],
   onLoad: function(fn) {
     if (loaded) {
-      return fn(loadError)
+      return fn(loadError);
     }
-    onLoads.push(fn)
+    onLoads.push(fn);
   }
-}
+};
 
-module.exports = db
+module.exports = db;
 
 // Load dbs, migrate data, and apply indexes
 Promise.resolve()
   .then(() => {
     const loadTasks = db.instances.map(dbname => {
       if (debug) {
-        console.log('Loading %s..', dbname)
+        console.log('Loading %s..', dbname);
       }
-      return db[dbname].loadDatabase()
-    })
-    return Promise.all(loadTasks)
+      return db[dbname].loadDatabase();
+    });
+    return Promise.all(loadTasks);
   })
   .then(() => migrateSchema(db))
   .then(() => db.users.ensureIndex({ fieldName: 'email', unique: true }))
@@ -47,24 +47,24 @@ Promise.resolve()
   .then(() => db.config.ensureIndex({ fieldName: 'key', unique: true }))
   .then(() => {
     // set autocompaction
-    const tenMinutes = 1000 * 60 * 10
+    const tenMinutes = 1000 * 60 * 10;
     db.instances.forEach(function(dbname) {
-      db[dbname].nedb.persistence.setAutocompactionInterval(tenMinutes)
-    })
-    return ensureAdmin()
+      db[dbname].nedb.persistence.setAutocompactionInterval(tenMinutes);
+    });
+    return ensureAdmin();
   })
   .then(() => {
-    loaded = true
-    onLoads.forEach(fn => fn())
+    loaded = true;
+    onLoads.forEach(fn => fn());
   })
   .catch(error => {
-    onLoads.forEach(fn => fn(error))
-  })
+    onLoads.forEach(fn => fn(error));
+  });
 
 function ensureAdmin() {
-  const adminEmail = admin
+  const adminEmail = admin;
   if (!adminEmail) {
-    return Promise.resolve()
+    return Promise.resolve();
   }
 
   // if an admin was passed in the command line, check to see if a user exists with that email
@@ -76,32 +76,32 @@ function ensureAdmin() {
       return db.users
         .update({ _id: user._id }, { $set: { role: 'admin' } }, {})
         .then(() => {
-          console.log(adminEmail + ' should now have admin access.')
+          console.log(adminEmail + ' should now have admin access.');
         })
         .catch(error => {
-          console.log('ERROR: could not make ' + adminEmail + ' an admin.')
-          throw error
-        })
+          console.log('ERROR: could not make ' + adminEmail + ' an admin.');
+          throw error;
+        });
     }
     const newAdmin = {
       email: adminEmail,
       role: 'admin'
-    }
+    };
     return db.users
       .insert(newAdmin)
       .then(() => {
         console.log(
           '\n' + adminEmail + ' has been whitelisted with admin access.'
-        )
+        );
         console.log(
           '\nPlease visit http://localhost:' +
             port +
             '/signup/ to complete registration.'
-        )
+        );
       })
       .catch(error => {
-        console.log('\n/ERROR: could not make ' + adminEmail + ' an admin.')
-        throw error
-      })
-  })
+        console.log('\n/ERROR: could not make ' + adminEmail + ' an admin.');
+        throw error;
+      });
+  });
 }

--- a/server/lib/decipher.js
+++ b/server/lib/decipher.js
@@ -1,19 +1,19 @@
-const crypto = require('crypto')
-const algorithm = 'aes256'
-const { passphrase } = require('../lib/config').getPreDbConfig()
+const crypto = require('crypto');
+const algorithm = 'aes256';
+const { passphrase } = require('../lib/config').getPreDbConfig();
 
 /**
  * @param {string} gibberish ciphered value that needs deciphering
  * @returns {string} deciphered value
  */
 module.exports = function decipher(gibberish) {
-  let returnValue = ''
+  let returnValue = '';
   try {
-    const myDecipher = crypto.createDecipher(algorithm, passphrase)
+    const myDecipher = crypto.createDecipher(algorithm, passphrase);
     returnValue =
-      myDecipher.update(gibberish, 'hex', 'utf8') + myDecipher.final('utf8')
+      myDecipher.update(gibberish, 'hex', 'utf8') + myDecipher.final('utf8');
   } catch (e) {
-    console.error(e)
+    console.error(e);
   }
-  return returnValue
-}
+  return returnValue;
+};

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -1,49 +1,49 @@
-const nodemailer = require('nodemailer')
-const configUtil = require('./config')
-const db = require('./db')
-const { baseUrl, port, publicUrl } = require('./config').getPreDbConfig()
+const nodemailer = require('nodemailer');
+const configUtil = require('./config');
+const db = require('./db');
+const { baseUrl, port, publicUrl } = require('./config').getPreDbConfig();
 
 /**
  * Get full sqlpad url
  * @param {string} path - path (leading slash)
  */
 function fullUrl(path) {
-  const urlPort = port === 80 ? '' : ':' + port
-  const urlPublicUrl = publicUrl
-  const urlBaseUrl = baseUrl
-  return `${urlPublicUrl}${urlPort}${urlBaseUrl}${path}`
+  const urlPort = port === 80 ? '' : ':' + port;
+  const urlPublicUrl = publicUrl;
+  const urlBaseUrl = baseUrl;
+  return `${urlPublicUrl}${urlPort}${urlBaseUrl}${path}`;
 }
 
 function sendForgotPassword(to, passwordResetPath) {
-  const url = fullUrl(passwordResetPath)
-  const text = `Hello! \n\nYou recently requested a password reset for your SQLPad account. \n\nTo reset your password, visit ${url}.`
+  const url = fullUrl(passwordResetPath);
+  const text = `Hello! \n\nYou recently requested a password reset for your SQLPad account. \n\nTo reset your password, visit ${url}.`;
   const html = `
     <p>Hello!</p>
     <p>You recently requested a password reset for your SQLPad account.</p>
     <p>To reset your password, visit <a href="${url}">${url}</a>.</p>
-  `
-  return send(to, 'SQLPad Password Reset', text, html)
+  `;
+  return send(to, 'SQLPad Password Reset', text, html);
 }
 
 function sendInvite(to) {
-  const url = fullUrl('/signup')
-  const text = `Hello! \n\nA colleague has invited you to SQLPad. \n\nTo sign up, visit ${url}.`
+  const url = fullUrl('/signup');
+  const text = `Hello! \n\nA colleague has invited you to SQLPad. \n\nTo sign up, visit ${url}.`;
   const html = `
     <p>Hello!</p> 
     <p>A colleague has invited you to SQLPad.</p> 
     <p>To sign up, visit <a href="${url}">'${url}</a>.</p>
-  `
-  return send(to, "You've been invited to SQLPad", text, html)
+  `;
+  return send(to, "You've been invited to SQLPad", text, html);
 }
 
 function send(to, subject, text, html) {
   return configUtil.getHelper(db).then(config => {
     if (!config.smtpConfigured()) {
-      console.error('email.send() called without being configured')
-      return
+      console.error('email.send() called without being configured');
+      return;
     }
     if (config.get('debug')) {
-      console.log('sending email')
+      console.log('sending email');
     }
     const smtpConfig = {
       host: config.get('smtpHost'),
@@ -56,28 +56,28 @@ function send(to, subject, text, html) {
       tls: {
         ciphers: 'SSLv3'
       }
-    }
+    };
     return new Promise((resolve, reject) => {
-      const transporter = nodemailer.createTransport(smtpConfig)
+      const transporter = nodemailer.createTransport(smtpConfig);
       const mailOptions = {
         from: config.get('smtpFrom'),
         to,
         subject,
         text,
         html
-      }
+      };
       transporter.sendMail(mailOptions, function(err, info) {
         if (config.get('debug')) {
-          console.log('sent email: ' + info)
+          console.log('sent email: ' + info);
         }
         if (err) {
-          console.error(err)
-          return reject(err)
+          console.error(err);
+          return reject(err);
         }
-        resolve(info)
-      })
-    })
-  })
+        resolve(info);
+      });
+    });
+  });
 }
 
 module.exports = {
@@ -85,4 +85,4 @@ module.exports = {
   send,
   sendForgotPassword,
   sendInvite
-}
+};

--- a/server/lib/getMeta.js
+++ b/server/lib/getMeta.js
@@ -1,4 +1,4 @@
-const _ = require('lodash')
+const _ = require('lodash');
 
 /**
  * Derive whether value is a number number or number as a string
@@ -8,22 +8,22 @@ const _ = require('lodash')
  */
 function isNumeric(value) {
   if (_.isNumber(value)) {
-    return true
+    return true;
   }
   if (_.isString(value)) {
     if (!isFinite(value)) {
-      return false
+      return false;
     }
     // str is a finite number, but not all number strings should be numbers
     // If the string starts with 0, is more than 1 character, and does not have a period, it should stay a string
     // It could be an account number for example
     if (value[0] === '0' && value.length > 1 && value.indexOf('.') === -1) {
-      return false
+      return false;
     }
 
-    return true
+    return true;
   }
-  return false
+  return false;
 }
 
 /**
@@ -31,7 +31,7 @@ function isNumeric(value) {
  * @param {array<object>} rows
  */
 module.exports = function getMeta(rows) {
-  const meta = {}
+  const meta = {};
 
   rows.forEach(row => {
     _.forOwn(row, (value, key) => {
@@ -41,22 +41,22 @@ module.exports = function getMeta(rows) {
           max: null,
           min: null,
           maxValueLength: 0
-        }
+        };
       }
 
       // if there is no value none of what follows will be helpful
       if (value == null) {
-        return
+        return;
       }
 
       // if we don't have a data type and we have a value yet lets try and figure it out
       if (!meta[key].datatype) {
         if (_.isDate(value)) {
-          meta[key].datatype = 'date'
+          meta[key].datatype = 'date';
         } else if (isNumeric(value)) {
-          meta[key].datatype = 'number'
+          meta[key].datatype = 'number';
         } else if (_.isString(value)) {
-          meta[key].datatype = 'string'
+          meta[key].datatype = 'string';
         }
       }
 
@@ -71,51 +71,51 @@ module.exports = function getMeta(rows) {
         _.isString(value) &&
         !isNumeric(value)
       ) {
-        meta[key].datatype = 'string'
+        meta[key].datatype = 'string';
       }
 
       // For strings, get max length of the string for display purposes
       if (meta[key].datatype === 'string' && _.isString(value)) {
         if (meta[key].maxValueLength < value.length) {
-          meta[key].maxValueLength = value.length
+          meta[key].maxValueLength = value.length;
         }
       }
 
       // if we have a value and are dealing with a number or date, we should get min and max
       if (meta[key].datatype === 'number' && isNumeric(value)) {
-        value = Number(value)
+        value = Number(value);
         // if we haven't yet defined a max and this row contains a number
         if (!meta[key].max) {
-          meta[key].max = value
+          meta[key].max = value;
         } else if (value > meta[key].max) {
           // otherwise this field in this row contains a number, and we should see if its bigger
-          meta[key].max = value
+          meta[key].max = value;
         }
         // then do the same thing for min
         if (!meta[key].min) {
-          meta[key].min = value
+          meta[key].min = value;
         } else if (value < meta[key].min) {
-          meta[key].min = value
+          meta[key].min = value;
         }
       }
 
       if (meta[key].datatype === 'date' && _.isDate(value)) {
         // if we haven't yet defined a max and this row contains a number
         if (!meta[key].max) {
-          meta[key].max = value
+          meta[key].max = value;
         } else if (value > meta[key].max) {
           // otherwise this field in this row contains a number, and we should see if its bigger
-          meta[key].max = value
+          meta[key].max = value;
         }
         // then do the same thing for min
         if (!meta[key].min) {
-          meta[key].min = value
+          meta[key].min = value;
         } else if (value < meta[key].min) {
-          meta[key].min = value
+          meta[key].min = value;
         }
       }
-    })
-  })
+    });
+  });
 
-  return meta
-}
+  return meta;
+};

--- a/server/lib/sendError.js
+++ b/server/lib/sendError.js
@@ -6,9 +6,9 @@
  */
 module.exports = function sendError(res, error, message) {
   if (error) {
-    console.error(error)
+    console.error(error);
   }
   return res.json({
     error: message || (error ? error.toString() : 'Something happened')
-  })
-}
+  });
+};

--- a/server/lib/version.js
+++ b/server/lib/version.js
@@ -1,17 +1,17 @@
-const packageJson = require('../package.json')
-const latestVersion = require('latest-version')
-const semverDiff = require('semver-diff')
-const db = require('./db.js')
-const configUtil = require('./config')
+const packageJson = require('../package.json');
+const latestVersion = require('latest-version');
+const semverDiff = require('semver-diff');
+const db = require('./db.js');
+const configUtil = require('./config');
 
-const ONE_DAY = 1000 * 60 * 60 * 24
+const ONE_DAY = 1000 * 60 * 60 * 24;
 
 const version = {
   updateAvailable: false,
   updateType: null,
   current: packageJson.version,
   latest: null
-}
+};
 
 function logUpdateAvailable(version) {
   console.log(`
@@ -22,7 +22,7 @@ function logUpdateAvailable(version) {
 
   run npm i -g ${packageJson.name} to update
   ===================================================================
-  `)
+  `);
 }
 
 function checkForUpdate() {
@@ -30,29 +30,29 @@ function checkForUpdate() {
     .getHelper(db)
     .then(config => {
       if (config.get('disableUpdateCheck')) {
-        return
+        return;
       }
       return latestVersion(packageJson.name).then(npmVersion => {
-        version.latest = npmVersion
-        const difference = semverDiff(version.current, npmVersion)
+        version.latest = npmVersion;
+        const difference = semverDiff(version.current, npmVersion);
         if (difference) {
-          version.updateAvailable = true
-          version.updateType = difference
-          logUpdateAvailable(version)
+          version.updateAvailable = true;
+          version.updateType = difference;
+          logUpdateAvailable(version);
         }
-      })
+      });
     })
     .catch(error => {
-      console.log(error)
-    })
+      console.log(error);
+    });
 }
 
 module.exports = {
   get: function() {
-    return Object.assign({}, version)
+    return Object.assign({}, version);
   },
   scheduleUpdateChecks: function() {
-    setInterval(checkForUpdate, ONE_DAY)
-    setTimeout(checkForUpdate, 5000)
+    setInterval(checkForUpdate, ONE_DAY);
+    setTimeout(checkForUpdate, 5000);
   }
-}
+};

--- a/server/middleware/must-be-admin.js
+++ b/server/middleware/must-be-admin.js
@@ -1,11 +1,11 @@
-const mustBeAuthenticated = require('./must-be-authenticated')
+const mustBeAuthenticated = require('./must-be-authenticated');
 
 module.exports = [
   mustBeAuthenticated,
   function mustBeAdmin(req, res, next) {
     if (req.user.role === 'admin') {
-      return next()
+      return next();
     }
-    return res.status(403).json({ error: 'Forbidden' })
+    return res.status(403).json({ error: 'Forbidden' });
   }
-]
+];

--- a/server/middleware/must-be-authenticated-or-chart-link-noauth.js
+++ b/server/middleware/must-be-authenticated-or-chart-link-noauth.js
@@ -1,15 +1,15 @@
-const passport = require('passport')
+const passport = require('passport');
 
 // If authenticated continue
 // If not and auth header is present, try authenticated with http basic
 // Otherwise redirect user to signin
 module.exports = function mustBeAuthenticatedOrChartLinkNoAuth(req, res, next) {
-  const { config } = req
+  const { config } = req;
   if (req.isAuthenticated() || !config.get('tableChartLinksRequireAuth')) {
-    return next()
+    return next();
   }
   if (req.headers.authorization) {
-    return passport.authenticate('basic', { session: false })(req, res, next)
+    return passport.authenticate('basic', { session: false })(req, res, next);
   }
-  res.redirect(config.get('baseUrl') + '/signin')
-}
+  res.redirect(config.get('baseUrl') + '/signin');
+};

--- a/server/middleware/must-be-authenticated.js
+++ b/server/middleware/must-be-authenticated.js
@@ -1,15 +1,15 @@
-const passport = require('passport')
+const passport = require('passport');
 
 // If authenticated continue
 // If not and auth header is present, try authenticated with http basic
 // Otherwise redirect user to signin
 module.exports = function mustBeAuthenticated(req, res, next) {
-  const { config } = req
+  const { config } = req;
   if (req.isAuthenticated()) {
-    return next()
+    return next();
   }
   if (req.headers.authorization) {
-    return passport.authenticate('basic', { session: false })(req, res, next)
+    return passport.authenticate('basic', { session: false })(req, res, next);
   }
-  res.redirect(config.get('baseUrl') + '/signin')
-}
+  res.redirect(config.get('baseUrl') + '/signin');
+};

--- a/server/models/Cache.js
+++ b/server/models/Cache.js
@@ -1,10 +1,10 @@
-const fs = require('fs')
-const path = require('path')
-const Joi = require('joi')
-const db = require('../lib/db.js')
-const xlsx = require('node-xlsx')
-const json2csv = require('json2csv')
-const { dbPath } = require('../lib/config').getPreDbConfig()
+const fs = require('fs');
+const path = require('path');
+const Joi = require('joi');
+const db = require('../lib/db.js');
+const xlsx = require('node-xlsx');
+const json2csv = require('json2csv');
+const { dbPath } = require('../lib/config').getPreDbConfig();
 
 const schema = {
   _id: Joi.string().optional(), // will be auto-gen by nedb
@@ -14,122 +14,122 @@ const schema = {
   schema: Joi.any().optional(), // schema tree in JSON if that's what we're caching
   createdDate: Joi.date().default(new Date(), 'time of creation'),
   modifiedDate: Joi.date().default(new Date(), 'time of modification')
-}
+};
 
 function Cache(data) {
-  this._id = data._id
-  this.cacheKey = data.cacheKey
-  this.expiration = data.expiration
-  this.queryName = data.queryName
-  this.schema = data.schema // schema tree in JSON if that's what we're caching
-  this.createdDate = data.createdDate
-  this.modifiedDate = data.modifiedDate
+  this._id = data._id;
+  this.cacheKey = data.cacheKey;
+  this.expiration = data.expiration;
+  this.queryName = data.queryName;
+  this.schema = data.schema; // schema tree in JSON if that's what we're caching
+  this.createdDate = data.createdDate;
+  this.modifiedDate = data.modifiedDate;
 }
 
 Cache.prototype.xlsxFilePath = function xlsxFilePath() {
-  return path.join(dbPath, '/cache/', this.cacheKey + '.xlsx')
-}
+  return path.join(dbPath, '/cache/', this.cacheKey + '.xlsx');
+};
 
 Cache.prototype.csvFilePath = function csvFilePath() {
-  return path.join(dbPath, '/cache/', this.cacheKey + '.csv')
-}
+  return path.join(dbPath, '/cache/', this.cacheKey + '.csv');
+};
 
 Cache.prototype.filePaths = function filePaths() {
   // these may not exist.
   // eventually actual files should be stored on the cache item
-  return [this.xlsxFilePath(), this.csvFilePath()]
-}
+  return [this.xlsxFilePath(), this.csvFilePath()];
+};
 
 Cache.prototype.removeFiles = function removeFiles() {
-  const filepaths = this.filePaths()
+  const filepaths = this.filePaths();
   filepaths.forEach(fp => {
     if (fs.existsSync(fp)) {
-      fs.unlinkSync(fp)
+      fs.unlinkSync(fp);
     }
-  })
-}
+  });
+};
 
 Cache.prototype.expire = function expire() {
-  this.removeFiles()
-  return db.cache.remove({ _id: this._id }, {})
-}
+  this.removeFiles();
+  return db.cache.remove({ _id: this._id }, {});
+};
 
 Cache.prototype.writeXlsx = function writeXlsx(queryResult) {
-  const self = this
+  const self = this;
   // loop through rows and build out an array of arrays
-  const resultArray = []
-  resultArray.push(queryResult.fields)
+  const resultArray = [];
+  resultArray.push(queryResult.fields);
   for (let i = 0; i < queryResult.rows.length; i++) {
-    const row = []
+    const row = [];
     for (let c = 0; c < queryResult.fields.length; c++) {
-      const fieldName = queryResult.fields[c]
-      row.push(queryResult.rows[i][fieldName])
+      const fieldName = queryResult.fields[c];
+      row.push(queryResult.rows[i][fieldName]);
     }
-    resultArray.push(row)
+    resultArray.push(row);
   }
-  const xlsxBuffer = xlsx.build([{ name: 'query-results', data: resultArray }])
+  const xlsxBuffer = xlsx.build([{ name: 'query-results', data: resultArray }]);
   return new Promise((resolve, reject) => {
     fs.writeFile(self.xlsxFilePath(), xlsxBuffer, function(err) {
       // if there's an error log it but otherwise continue on
       // we can still send results even if download file failed to create
       if (err) {
-        console.log(err)
+        console.log(err);
       }
-      return resolve()
-    })
-  })
-}
+      return resolve();
+    });
+  });
+};
 
 Cache.prototype.writeCsv = function writeCsv(queryResult) {
-  const self = this
+  const self = this;
   return new Promise((resolve, reject) => {
     json2csv({ data: queryResult.rows, fields: queryResult.fields }, function(
       err,
       csv
     ) {
       if (err) {
-        console.log(err)
-        return resolve()
+        console.log(err);
+        return resolve();
       }
       fs.writeFile(self.csvFilePath(), csv, function(err) {
         if (err) {
-          console.log(err)
+          console.log(err);
         }
-        return resolve()
-      })
-    })
-  })
-}
+        return resolve();
+      });
+    });
+  });
+};
 
 Cache.prototype.save = function save() {
-  const self = this
-  this.modifiedDate = new Date()
-  const joiResult = Joi.validate(self, schema)
+  const self = this;
+  this.modifiedDate = new Date();
+  const joiResult = Joi.validate(self, schema);
   if (joiResult.error) {
-    return Promise.reject(joiResult.error)
+    return Promise.reject(joiResult.error);
   }
   return db.cache
     .update({ cacheKey: self.cacheKey }, joiResult.value, { upsert: true })
-    .then(() => Cache.findOneByCacheKey(self.cacheKey))
-}
+    .then(() => Cache.findOneByCacheKey(self.cacheKey));
+};
 
 /*  Query methods
 ============================================================================== */
 Cache.findOneByCacheKey = cacheKey =>
-  db.cache.findOne({ cacheKey }).then(doc => doc && new Cache(doc))
+  db.cache.findOne({ cacheKey }).then(doc => doc && new Cache(doc));
 
 Cache.findExpired = () =>
   db.cache
     .find({ expiration: { $lt: new Date() } })
-    .then(docs => docs.map(doc => new Cache(doc)))
+    .then(docs => docs.map(doc => new Cache(doc)));
 
 Cache.removeExpired = () =>
   Cache.findExpired()
     .then(caches => Promise.all(caches.map(cache => cache.expire())))
-    .catch(console.error)
+    .catch(console.error);
 
 // Every five minutes check and expire cache
-const FIVE_MINUTES = 1000 * 60 * 5
-setInterval(Cache.removeExpired, FIVE_MINUTES)
+const FIVE_MINUTES = 1000 * 60 * 5;
+setInterval(Cache.removeExpired, FIVE_MINUTES);
 
-module.exports = Cache
+module.exports = Cache;

--- a/server/models/Query.js
+++ b/server/models/Query.js
@@ -1,7 +1,7 @@
-const db = require('../lib/db.js')
-const configUtil = require('../lib/config')
-const Joi = require('joi')
-const request = require('request')
+const db = require('../lib/db.js');
+const configUtil = require('../lib/config');
+const Joi = require('joi');
+const request = require('request');
 
 /*
 "chartConfiguration": {
@@ -44,57 +44,57 @@ const schema = {
   createdBy: Joi.string().required(),
   modifiedBy: Joi.string().required(),
   lastAccessDate: Joi.date().default(new Date(), 'time of last access')
-}
+};
 
 function Query(data) {
-  this._id = data._id
-  this.name = data.name
-  this.tags = data.tags
-  this.connectionId = data.connectionId
-  this.queryText = data.queryText
-  this.chartConfiguration = data.chartConfiguration
-  this.createdDate = data.createdDate
-  this.createdBy = data.createdBy
-  this.modifiedDate = data.modifiedDate
-  this.modifiedBy = data.modifiedBy
-  this.lastAccessDate = data.lastAccessedDate
+  this._id = data._id;
+  this.name = data.name;
+  this.tags = data.tags;
+  this.connectionId = data.connectionId;
+  this.queryText = data.queryText;
+  this.chartConfiguration = data.chartConfiguration;
+  this.createdDate = data.createdDate;
+  this.createdBy = data.createdBy;
+  this.modifiedDate = data.modifiedDate;
+  this.modifiedBy = data.modifiedBy;
+  this.lastAccessDate = data.lastAccessedDate;
 }
 
 Query.prototype.save = function save() {
-  const self = this
-  this.modifiedDate = new Date()
-  this.lastAccessDate = new Date()
+  const self = this;
+  this.modifiedDate = new Date();
+  this.lastAccessDate = new Date();
   // clean tags if present
   // sqlpad v1 saved a lot of bad inputs
   if (Array.isArray(self.tags)) {
     self.tags = self.tags
       .filter(tag => {
-        return typeof tag === 'string' && tag.trim() !== ''
+        return typeof tag === 'string' && tag.trim() !== '';
       })
       .map(tag => {
-        return tag.trim()
-      })
+        return tag.trim();
+      });
   }
-  const joiResult = Joi.validate(self, schema)
+  const joiResult = Joi.validate(self, schema);
   if (joiResult.error) {
-    return Promise.reject(joiResult.error)
+    return Promise.reject(joiResult.error);
   }
   if (self._id) {
     return db.queries
       .update({ _id: self._id }, joiResult.value, { upsert: true })
-      .then(() => Query.findOneById(self._id))
+      .then(() => Query.findOneById(self._id));
   }
-  return db.queries.insert(joiResult.value).then(doc => new Query(doc))
-}
+  return db.queries.insert(joiResult.value).then(doc => new Query(doc));
+};
 
 Query.prototype.pushQueryToSlackIfSetup = function() {
   return configUtil
     .getHelper(db)
     .then(config => {
-      const SLACK_WEBHOOK = config.get('slackWebhook')
+      const SLACK_WEBHOOK = config.get('slackWebhook');
       if (SLACK_WEBHOOK) {
-        const PUBLIC_URL = config.get('publicUrl')
-        const BASE_URL = config.get('baseUrl')
+        const PUBLIC_URL = config.get('publicUrl');
+        const BASE_URL = config.get('baseUrl');
         const options = {
           method: 'post',
           body: {
@@ -108,41 +108,41 @@ Query.prototype.pushQueryToSlackIfSetup = function() {
           },
           json: true,
           url: SLACK_WEBHOOK
-        }
+        };
         request(options, function(err, httpResponse, body) {
           if (err) {
-            console.error('Something went wrong while sending to Slack.')
-            console.error(err)
+            console.error('Something went wrong while sending to Slack.');
+            console.error(err);
           }
-        })
+        });
       }
     })
     .catch(error => {
-      console.log('error getting config helper')
-      console.error(error)
-    })
-}
+      console.log('error getting config helper');
+      console.error(error);
+    });
+};
 
 /*  Query methods
 ============================================================================== */
 Query.findOneById = id =>
-  db.queries.findOne({ _id: id }).then(doc => new Query(doc))
+  db.queries.findOne({ _id: id }).then(doc => new Query(doc));
 
 Query.findAll = () =>
-  db.queries.find({}).then(docs => docs.map(doc => new Query(doc)))
+  db.queries.find({}).then(docs => docs.map(doc => new Query(doc)));
 
 Query.findByFilter = filter =>
-  db.queries.find(filter).then(docs => docs.map(doc => new Query(doc)))
+  db.queries.find(filter).then(docs => docs.map(doc => new Query(doc)));
 
 Query.prototype.logAccess = function logAccess() {
-  const self = this
+  const self = this;
   return db.queries.update(
     { _id: self._id },
     { $set: { lastAccessedDate: new Date() } },
     {}
-  )
-}
+  );
+};
 
-Query.removeOneById = id => db.queries.remove({ _id: id })
+Query.removeOneById = id => db.queries.remove({ _id: id });
 
-module.exports = Query
+module.exports = Query;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,6 +1,6 @@
-const Joi = require('joi')
-const db = require('../lib/db.js')
-const bcrypt = require('bcrypt-nodejs')
+const Joi = require('joi');
+const db = require('../lib/db.js');
+const bcrypt = require('bcrypt-nodejs');
 
 const schema = {
   _id: Joi.string().optional(), // will be auto-gen by nedb
@@ -19,23 +19,23 @@ const schema = {
   createdDate: Joi.date().default(new Date(), 'time of creation'),
   modifiedDate: Joi.date().default(new Date(), 'time of modification'),
   signupDate: Joi.date().optional()
-}
+};
 
 function User(data) {
-  this._id = data._id
-  this.email = data.email
-  this.role = data.role
-  this.passwordResetId = data.passwordResetId
-  this.passhash = data.passhash
-  this.password = data.password
-  this.createdDate = data.createdDate
-  this.modifiedDate = data.modifiedDate
-  this.signupDate = data.signupDate
+  this._id = data._id;
+  this.email = data.email;
+  this.role = data.role;
+  this.passwordResetId = data.passwordResetId;
+  this.passhash = data.passhash;
+  this.password = data.password;
+  this.createdDate = data.createdDate;
+  this.modifiedDate = data.modifiedDate;
+  this.signupDate = data.signupDate;
 }
 
 User.prototype.save = function save() {
-  const self = this
-  this.modifiedDate = new Date()
+  const self = this;
+  this.modifiedDate = new Date();
   return Promise.resolve()
     .then(() => {
       // if user has password set, we need to hash it before saving
@@ -43,25 +43,25 @@ User.prototype.save = function save() {
         return new Promise((resolve, reject) => {
           bcrypt.hash(this.password, null, null, (err, hash) => {
             if (err) {
-              return reject(err)
+              return reject(err);
             }
-            self.passhash = hash
-            return resolve()
-          })
-        })
+            self.passhash = hash;
+            return resolve();
+          });
+        });
       }
     })
     .then(() => {
       // validate and save
-      const joiResult = Joi.validate(self, schema)
+      const joiResult = Joi.validate(self, schema);
       if (joiResult.error) {
-        return Promise.reject(joiResult.error)
+        return Promise.reject(joiResult.error);
       }
       return db.users
         .update({ email: self.email }, joiResult.value, { upsert: true })
-        .then(() => User.findOneByEmail(self.email))
-    })
-}
+        .then(() => User.findOneByEmail(self.email));
+    });
+};
 
 /**
  * Compare password to hash. Returns promise
@@ -73,40 +73,40 @@ User.prototype.comparePasswordToHash = function comparePasswordToHash(
   return new Promise((resolve, reject) => {
     bcrypt.compare(password, this.passhash, (err, isMatch) => {
       if (err) {
-        return reject(err)
+        return reject(err);
       }
-      resolve(isMatch)
-    })
-  })
-}
+      resolve(isMatch);
+    });
+  });
+};
 
 /*  Query methods
 ============================================================================== */
 User.findOneByEmail = email =>
   db.users
     .findOne({ email: { $regex: new RegExp(email, 'i') } })
-    .then(doc => doc && new User(doc))
+    .then(doc => doc && new User(doc));
 
 User.findOneById = id =>
-  db.users.findOne({ _id: id }).then(doc => doc && new User(doc))
+  db.users.findOne({ _id: id }).then(doc => doc && new User(doc));
 
 User.findOneByPasswordResetId = id =>
-  db.users.findOne({ passwordResetId: id }).then(doc => doc && new User(doc))
+  db.users.findOne({ passwordResetId: id }).then(doc => doc && new User(doc));
 
 User.findAll = () =>
   db.users
     .cfind({}, { password: 0, passhash: 0 })
     .sort({ email: 1 })
     .exec()
-    .then(docs => docs.map(doc => new User(doc)))
+    .then(docs => docs.map(doc => new User(doc)));
 
 /**
  * Returns boolean regarding whether admin registration should be open or not
  * @returns {Promise<boolean>} administrationOpen
  */
 User.adminRegistrationOpen = () =>
-  db.users.findOne({ role: 'admin' }).then(doc => !doc)
+  db.users.findOne({ role: 'admin' }).then(doc => !doc);
 
-User.removeOneById = id => db.users.remove({ _id: id })
+User.removeOneById = id => db.users.remove({ _id: id });
 
-module.exports = User
+module.exports = User;

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -1,8 +1,8 @@
-const db = require('../lib/db.js')
-const _ = require('lodash')
-const drivers = require('../drivers')
-const cipher = require('../lib/cipher.js')
-const decipher = require('../lib/decipher')
+const db = require('../lib/db.js');
+const _ = require('lodash');
+const drivers = require('../drivers');
+const cipher = require('../lib/cipher.js');
+const decipher = require('../lib/decipher');
 
 // TODO this file being named connections makes it awkward to use
 // because you'll want to do the following:
@@ -12,58 +12,58 @@ const decipher = require('../lib/decipher')
 
 function decipherConnection(connection) {
   if (connection.username) {
-    connection.username = decipher(connection.username)
+    connection.username = decipher(connection.username);
   }
   if (connection.password) {
-    connection.password = decipher(connection.password)
+    connection.password = decipher(connection.password);
   }
-  return connection
+  return connection;
 }
 
 const findAll = () =>
   db.connections
     .find({})
     .then(connections => _.sortBy(connections, c => c.name.toLowerCase()))
-    .then(connections => connections.map(decipherConnection))
+    .then(connections => connections.map(decipherConnection));
 
 const findOneById = id =>
   db.connections
     .findOne({ _id: id })
-    .then(connection => decipherConnection(connection))
+    .then(connection => decipherConnection(connection));
 
-const removeOneById = id => db.connections.remove({ _id: id })
+const removeOneById = id => db.connections.remove({ _id: id });
 
 const save = connection => {
   if (!connection) {
-    return Promise.reject('connections.save() requires a connection')
+    return Promise.reject('connections.save() requires a connection');
   }
 
-  connection.username = cipher(connection.username || '')
-  connection.password = cipher(connection.password || '')
+  connection.username = cipher(connection.username || '');
+  connection.password = cipher(connection.password || '');
 
   return Promise.resolve().then(() => {
     if (!connection.createdDate) {
-      connection.createdDate = new Date()
+      connection.createdDate = new Date();
     }
-    connection.modifiedDate = new Date()
+    connection.modifiedDate = new Date();
 
-    connection = drivers.validateConnection(connection)
-    const { _id } = connection
+    connection = drivers.validateConnection(connection);
+    const { _id } = connection;
 
     if (_id) {
       return db.connections
         .update({ _id }, connection, {})
-        .then(() => findOneById(_id))
+        .then(() => findOneById(_id));
     }
     return db.connections
       .insert(connection)
-      .then(newDoc => findOneById(newDoc._id))
-  })
-}
+      .then(newDoc => findOneById(newDoc._id));
+  });
+};
 
 module.exports = {
   findAll,
   findOneById,
   removeOneById,
   save
-}
+};

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -1,14 +1,14 @@
-const router = require('express').Router()
-const passport = require('passport')
-const version = require('../lib/version.js')
-const User = require('../models/User.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const passport = require('passport');
+const version = require('../lib/version.js');
+const User = require('../models/User.js');
+const sendError = require('../lib/sendError');
 
 // NOTE: this route needs a wildcard because it is fetched as a relative url
 // from the front-end. The static SPA does not know if sqlpad is mounted at
 // the root of a domain or if there is a base-url provided in the config
 router.get('*/api/app', function(req, res) {
-  const { config } = req
+  const { config } = req;
 
   return User.adminRegistrationOpen()
     .then(adminRegistrationOpen => {
@@ -19,15 +19,15 @@ router.get('*/api/app', function(req, res) {
               email: req.user.email,
               role: req.user.role
             }
-          : undefined
+          : undefined;
 
       const strategies = Object.keys(passport._strategies).reduce(
         (prev, curr) => {
-          prev[curr] = true
-          return prev
+          prev[curr] = true;
+          return prev;
         },
         {}
-      )
+      );
 
       res.json({
         adminRegistrationOpen,
@@ -39,9 +39,9 @@ router.get('*/api/app', function(req, res) {
         passport: {
           strategies
         }
-      })
+      });
     })
-    .catch(error => sendError(res, error, 'Problem querying users'))
-})
+    .catch(error => sendError(res, error, 'Problem querying users'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/config-items.js
+++ b/server/routes/config-items.js
@@ -1,11 +1,11 @@
-const router = require('express').Router()
-const mustBeAdmin = require('../middleware/must-be-admin.js')
+const router = require('express').Router();
+const mustBeAdmin = require('../middleware/must-be-admin.js');
 
 router.get('/api/config-items', mustBeAdmin, function(req, res) {
-  const { config } = req
+  const { config } = req;
   return res.json({
     configItems: config.getConfigItems()
-  })
-})
+  });
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/config-values.js
+++ b/server/routes/config-values.js
@@ -1,13 +1,13 @@
-const router = require('express').Router()
-const mustBeAdmin = require('../middleware/must-be-admin.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const mustBeAdmin = require('../middleware/must-be-admin.js');
+const sendError = require('../lib/sendError');
 
 router.post('/api/config-values/:key', mustBeAdmin, function(req, res) {
-  const { body, config, params } = req
+  const { body, config, params } = req;
   config
     .save(params.key, body.value)
     .then(() => res.json({}))
-    .catch(error => sendError(res, error, 'Problem saving config value'))
-})
+    .catch(error => sendError(res, error, 'Problem saving config value'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -1,12 +1,12 @@
-const router = require('express').Router()
-const connections = require('../models/connections.js')
-const mustBeAdmin = require('../middleware/must-be-admin.js')
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const connections = require('../models/connections.js');
+const mustBeAdmin = require('../middleware/must-be-admin.js');
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const sendError = require('../lib/sendError');
 
 function removePassword(connection) {
-  connection.password = ''
-  return connection
+  connection.password = '';
+  return connection;
 }
 
 router.get('/api/connections', mustBeAuthenticated, function(req, res) {
@@ -19,24 +19,24 @@ router.get('/api/connections', mustBeAuthenticated, function(req, res) {
     )
     .catch(error =>
       sendError(res, error, 'Problem querying connection database')
-    )
-})
+    );
+});
 
 router.get('/api/connections/:_id', mustBeAuthenticated, function(req, res) {
   return connections
     .findOneById(req.params._id)
     .then(connection => {
       if (!connection) {
-        return sendError(res, null, 'Connection not found')
+        return sendError(res, null, 'Connection not found');
       }
       return res.json({
         connection: removePassword(connection)
-      })
+      });
     })
     .catch(error =>
       sendError(res, error, 'Problem querying connection database')
-    )
-})
+    );
+});
 
 router.post('/api/connections', mustBeAdmin, function(req, res) {
   return connections
@@ -46,33 +46,33 @@ router.post('/api/connections', mustBeAdmin, function(req, res) {
         connection: removePassword(newConnection)
       })
     )
-    .catch(error => sendError(res, error, 'Problem saving connection'))
-})
+    .catch(error => sendError(res, error, 'Problem saving connection'));
+});
 
 router.put('/api/connections/:_id', mustBeAdmin, function(req, res) {
   return connections
     .findOneById(req.params._id)
     .then(connection => {
       if (!connection) {
-        return sendError(res, null, 'Connection not found')
+        return sendError(res, null, 'Connection not found');
       }
 
-      Object.assign(connection, req.body)
+      Object.assign(connection, req.body);
 
       return connections.save(connection).then(connection =>
         res.json({
           connection: removePassword(connection)
         })
-      )
+      );
     })
-    .catch(error => sendError(res, error, 'Problem saving connection'))
-})
+    .catch(error => sendError(res, error, 'Problem saving connection'));
+});
 
 router.delete('/api/connections/:_id', mustBeAdmin, function(req, res) {
   return connections
     .removeOneById(req.params._id)
     .then(() => res.json({}))
-    .catch(error => sendError(res, error, 'Problem deleting connection'))
-})
+    .catch(error => sendError(res, error, 'Problem deleting connection'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/download-results.js
+++ b/server/routes/download-results.js
@@ -1,56 +1,56 @@
-const fs = require('fs')
-const router = require('express').Router()
-const Cache = require('../models/Cache.js')
+const fs = require('fs');
+const router = require('express').Router();
+const Cache = require('../models/Cache.js');
 
 router.get('/download-results/:cacheKey.csv', function(req, res, next) {
-  const { config } = req
+  const { config } = req;
   if (config.get('allowCsvDownload')) {
     return Cache.findOneByCacheKey(req.params.cacheKey)
       .then(cache => {
         if (!cache) {
-          return next(new Error('Cache not found'))
+          return next(new Error('Cache not found'));
         }
-        var filename = cache.queryName + '.csv'
+        var filename = cache.queryName + '.csv';
         res.setHeader(
           'Content-disposition',
           'attachment; filename="' + encodeURIComponent(filename) + '"'
-        )
-        res.setHeader('Content-Type', 'text/csv')
-        fs.createReadStream(cache.csvFilePath()).pipe(res)
+        );
+        res.setHeader('Content-Type', 'text/csv');
+        fs.createReadStream(cache.csvFilePath()).pipe(res);
       })
       .catch(error => {
-        console.error(error)
+        console.error(error);
         // TODO figure out what this sends and set manually
-        return next(error)
-      })
+        return next(error);
+      });
   }
-})
+});
 
 router.get('/download-results/:cacheKey.xlsx', function(req, res, next) {
-  const { config } = req
+  const { config } = req;
   if (config.get('allowCsvDownload')) {
     return Cache.findOneByCacheKey(req.params.cacheKey)
       .then(cache => {
         if (!cache) {
-          return next(new Error('Cache not found'))
+          return next(new Error('Cache not found'));
         }
-        var filename = cache.queryName + '.xlsx'
+        var filename = cache.queryName + '.xlsx';
         res.setHeader(
           'Content-disposition',
           'attachment; filename="' + encodeURIComponent(filename) + '"'
-        )
+        );
         res.setHeader(
           'Content-Type',
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-        )
-        fs.createReadStream(cache.xlsxFilePath()).pipe(res)
+        );
+        fs.createReadStream(cache.xlsxFilePath()).pipe(res);
       })
       .catch(error => {
-        console.error(error)
+        console.error(error);
         // TODO figure out what this sends and set manually
-        return next(error)
-      })
+        return next(error);
+      });
   }
-})
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/drivers.js
+++ b/server/routes/drivers.js
@@ -1,16 +1,16 @@
-const router = require('express').Router()
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const drivers = require('../drivers')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const drivers = require('../drivers');
+const sendError = require('../lib/sendError');
 
 router.get('/api/drivers', mustBeAuthenticated, function(req, res) {
   try {
     return res.json({
       drivers: drivers.getDrivers()
-    })
+    });
   } catch (error) {
-    return sendError(res, error, 'Error getting drivers')
+    return sendError(res, error, 'Error getting drivers');
   }
-})
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/forgot-password.js
+++ b/server/routes/forgot-password.js
@@ -1,17 +1,17 @@
-const router = require('express').Router()
-const uuid = require('uuid')
-const User = require('../models/User.js')
-const email = require('../lib/email')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const uuid = require('uuid');
+const User = require('../models/User.js');
+const email = require('../lib/email');
+const sendError = require('../lib/sendError');
 
 router.post('/api/forgot-password', function(req, res) {
-  const { config } = req
+  const { config } = req;
 
   if (!req.body.email) {
-    return sendError(res, null, 'Email address must be provided')
+    return sendError(res, null, 'Email address must be provided');
   }
   if (!config.smtpConfigured()) {
-    return sendError(res, null, 'Email must be configured')
+    return sendError(res, null, 'Email must be configured');
   }
 
   return User.findOneByEmail(req.body.email)
@@ -19,22 +19,22 @@ router.post('/api/forgot-password', function(req, res) {
       // If user not found send success regardless
       // This is not a user-validation service
       if (!user) {
-        return res.json({})
+        return res.json({});
       }
 
-      user.passwordResetId = uuid.v4()
+      user.passwordResetId = uuid.v4();
 
       return user.save().then(() => {
-        const resetPath = `/password-reset/${user.passwordResetId}`
+        const resetPath = `/password-reset/${user.passwordResetId}`;
         // Send email, but do not block response to client
         email
           .sendForgotPassword(req.body.email, resetPath)
-          .catch(error => console.error(error))
+          .catch(error => console.error(error));
 
-        return res.json({})
-      })
+        return res.json({});
+      });
     })
-    .catch(error => sendError(res, error, 'Problem saving user'))
-})
+    .catch(error => sendError(res, error, 'Problem saving user'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -1,25 +1,25 @@
-const router = require('express').Router()
-const connections = require('../models/connections.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const connections = require('../models/connections.js');
+const sendError = require('../lib/sendError');
 
 // TODO FIXME - This was meant to redirect user to appropriate page depending on state of setup
 // I do not think it works anymore and should be revisited (this can be done client-side too)
 router.get('/', function(req, res, next) {
-  const { config } = req
-  const BASE_URL = config.get('baseUrl')
+  const { config } = req;
+  const BASE_URL = config.get('baseUrl');
 
   return connections
     .findAll()
     .then(docs => {
       if (!req.user) {
-        return res.redirect(BASE_URL + '/signin')
+        return res.redirect(BASE_URL + '/signin');
       }
       if (docs.length === 0 && req.user.role === 'admin') {
-        return res.redirect(BASE_URL + '/connections')
+        return res.redirect(BASE_URL + '/connections');
       }
-      return res.redirect(BASE_URL + '/queries')
+      return res.redirect(BASE_URL + '/queries');
     })
-    .catch(error => sendError(res, error))
-})
+    .catch(error => sendError(res, error));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/oauth.js
+++ b/server/routes/oauth.js
@@ -1,11 +1,11 @@
-const passport = require('passport')
-const router = require('express').Router()
-const { baseUrl } = require('../lib/config').getPreDbConfig()
+const passport = require('passport');
+const router = require('express').Router();
+const { baseUrl } = require('../lib/config').getPreDbConfig();
 
 router.get(
   '/auth/google',
   passport.authenticate('google', { scope: ['profile email'] })
-)
+);
 
 router.get(
   '/auth/google/callback',
@@ -13,6 +13,6 @@ router.get(
     successRedirect: baseUrl + '/',
     failureRedirect: baseUrl + '/signin'
   })
-)
+);
 
-module.exports = router
+module.exports = router;

--- a/server/routes/password-reset.js
+++ b/server/routes/password-reset.js
@@ -1,25 +1,25 @@
-const router = require('express').Router()
-const User = require('../models/User.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const User = require('../models/User.js');
+const sendError = require('../lib/sendError');
 
 // This route used to set new password given a passwordResetId
 router.post('/api/password-reset/:passwordResetId', function(req, res) {
   return User.findOneByPasswordResetId(req.params.passwordResetId)
     .then(user => {
       if (!user) {
-        return sendError(res, null, 'Password reset permissions not found')
+        return sendError(res, null, 'Password reset permissions not found');
       }
       if (req.body.email !== user.email) {
-        return sendError(res, null, 'Incorrect email address')
+        return sendError(res, null, 'Incorrect email address');
       }
       if (req.body.password !== req.body.passwordConfirmation) {
-        return sendError(res, null, 'Passwords do not match')
+        return sendError(res, null, 'Passwords do not match');
       }
-      user.password = req.body.password
-      user.passwordResetId = ''
-      return user.save().then(() => res.json({}))
+      user.password = req.body.password;
+      user.passwordResetId = '';
+      return user.save().then(() => res.json({}));
     })
-    .catch(error => sendError(res, error, 'Problem querying user database'))
-})
+    .catch(error => sendError(res, error, 'Problem querying user database'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -1,8 +1,8 @@
-const router = require('express').Router()
-const Query = require('../models/Query.js')
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const mustBeAuthenticatedOrChartLink = require('../middleware/must-be-authenticated-or-chart-link-noauth.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const Query = require('../models/Query.js');
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const mustBeAuthenticatedOrChartLink = require('../middleware/must-be-authenticated-or-chart-link-noauth.js');
+const sendError = require('../lib/sendError');
 
 /*  render page routes
 ============================================================================= */
@@ -13,15 +13,15 @@ router.get('/queries/:_id', mustBeAuthenticatedOrChartLink, function(
   res,
   next
 ) {
-  const { config, query, params } = req
-  const { format } = query
+  const { config, query, params } = req;
+  const { format } = query;
   if (format === 'table') {
-    return res.redirect(config.get('baseUrl') + '/query-table/' + params._id)
+    return res.redirect(config.get('baseUrl') + '/query-table/' + params._id);
   } else if (format === 'chart') {
-    return res.redirect(config.get('baseUrl') + '/query-chart/' + params._id)
+    return res.redirect(config.get('baseUrl') + '/query-chart/' + params._id);
   }
-  next()
-})
+  next();
+});
 
 /*  API routes
 ============================================================================= */
@@ -29,14 +29,14 @@ router.get('/queries/:_id', mustBeAuthenticatedOrChartLink, function(
 router.delete('/api/queries/:_id', mustBeAuthenticated, function(req, res) {
   return Query.removeOneById(req.params._id)
     .then(() => res.json({}))
-    .catch(error => sendError(res, error, 'Problem deleting query'))
-})
+    .catch(error => sendError(res, error, 'Problem deleting query'));
+});
 
 router.get('/api/queries', mustBeAuthenticated, function(req, res) {
   return Query.findAll()
     .then(queries => res.json({ queries }))
-    .catch(error => sendError(res, error, 'Problem querying query database'))
-})
+    .catch(error => sendError(res, error, 'Problem querying query database'));
+});
 
 router.get('/api/queries/:_id', mustBeAuthenticatedOrChartLink, function(
   req,
@@ -47,12 +47,12 @@ router.get('/api/queries/:_id', mustBeAuthenticatedOrChartLink, function(
       if (!query) {
         return res.json({
           query: {}
-        })
+        });
       }
-      return res.json({ query })
+      return res.json({ query });
     })
-    .catch(error => sendError('Problem getting query'))
-})
+    .catch(error => sendError('Problem getting query'));
+});
 
 // create new
 router.post('/api/queries', mustBeAuthenticated, function(req, res) {
@@ -64,36 +64,36 @@ router.post('/api/queries', mustBeAuthenticated, function(req, res) {
     chartConfiguration: req.body.chartConfiguration,
     createdBy: req.user.email,
     modifiedBy: req.user.email
-  })
+  });
   return query
     .save()
     .then(newQuery => {
       // This is async, but save operation doesn't care about when/if finished
-      newQuery.pushQueryToSlackIfSetup()
+      newQuery.pushQueryToSlackIfSetup();
       return res.json({
         query: newQuery
-      })
+      });
     })
-    .catch(error => sendError(res, error, 'Problem saving query'))
-})
+    .catch(error => sendError(res, error, 'Problem saving query'));
+});
 
 router.put('/api/queries/:_id', mustBeAuthenticated, function(req, res) {
   return Query.findOneById(req.params._id)
     .then(query => {
       if (!query) {
-        return sendError(res, null, 'Query not found')
+        return sendError(res, null, 'Query not found');
       }
 
-      query.name = req.body.name || ''
-      query.tags = req.body.tags
-      query.connectionId = req.body.connectionId
-      query.queryText = req.body.queryText
-      query.chartConfiguration = req.body.chartConfiguration
-      query.modifiedBy = req.user.email
+      query.name = req.body.name || '';
+      query.tags = req.body.tags;
+      query.connectionId = req.body.connectionId;
+      query.queryText = req.body.queryText;
+      query.chartConfiguration = req.body.chartConfiguration;
+      query.modifiedBy = req.user.email;
 
-      return query.save().then(newQuery => res.json({ query: newQuery }))
+      return query.save().then(newQuery => res.json({ query: newQuery }));
     })
-    .catch(error => sendError(res, error, 'Problem saving query'))
-})
+    .catch(error => sendError(res, error, 'Problem saving query'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/query-result.js
+++ b/server/routes/query-result.js
@@ -1,13 +1,13 @@
-const sanitize = require('sanitize-filename')
-const moment = require('moment')
-const router = require('express').Router()
-const { runQuery } = require('../drivers/index')
-const connections = require('../models/connections.js')
-const Cache = require('../models/Cache.js')
-const Query = require('../models/Query.js')
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const mustBeAuthenticatedOrChartLink = require('../middleware/must-be-authenticated-or-chart-link-noauth.js')
-const sendError = require('../lib/sendError')
+const sanitize = require('sanitize-filename');
+const moment = require('moment');
+const router = require('express').Router();
+const { runQuery } = require('../drivers/index');
+const connections = require('../models/connections.js');
+const Cache = require('../models/Cache.js');
+const Query = require('../models/Query.js');
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const mustBeAuthenticatedOrChartLink = require('../middleware/must-be-authenticated-or-chart-link-noauth.js');
+const sendError = require('../lib/sendError');
 
 // This allows executing a query relying on the saved query text
 // Instead of relying on an open endpoint that executes arbitrary sql
@@ -18,7 +18,7 @@ router.get(
     return Query.findOneById(req.params._queryId)
       .then(query => {
         if (!query) {
-          return sendError(res, null, 'Query not found (save query first)')
+          return sendError(res, null, 'Query not found (save query first)');
         }
         const data = {
           connectionId: query.connectionId,
@@ -26,15 +26,15 @@ router.get(
           queryName: query.name,
           queryText: query.queryText,
           config: req.config
-        }
+        };
         // NOTE: Sends actual error here since it might have info on why the query is bad
         return getQueryResult(data)
           .then(queryResult => res.send({ queryResult }))
-          .catch(error => sendError(res, error))
+          .catch(error => sendError(res, error));
       })
-      .catch(error => sendError(res, error, 'Problem querying query database'))
+      .catch(error => sendError(res, error, 'Problem querying query database'));
   }
-)
+);
 
 // Accepts raw inputs from client
 // Used during query editing
@@ -46,59 +46,59 @@ router.post('/api/query-result', mustBeAuthenticated, function(req, res) {
     queryName: req.body.queryName,
     queryText: req.body.queryText,
     user: req.user
-  }
+  };
 
   return getQueryResult(data)
     .then(queryResult => res.send({ queryResult }))
-    .catch(error => sendError(res, error))
-})
+    .catch(error => sendError(res, error));
+});
 
 function getQueryResult(data) {
   return connections
     .findOneById(data.connectionId)
     .then(connection => {
       if (!connection) {
-        throw new Error('Please choose a connection')
+        throw new Error('Please choose a connection');
       }
-      connection.maxRows = Number(data.config.get('queryResultMaxRows'))
-      data.connection = connection
-      return Cache.findOneByCacheKey(data.cacheKey)
+      connection.maxRows = Number(data.config.get('queryResultMaxRows'));
+      data.connection = connection;
+      return Cache.findOneByCacheKey(data.cacheKey);
     })
     .then(cache => {
       if (!cache) {
-        cache = new Cache({ cacheKey: data.cacheKey })
+        cache = new Cache({ cacheKey: data.cacheKey });
       }
       cache.queryName = sanitize(
         (data.queryName || 'SQLPad Query Results') +
           ' ' +
           moment().format('YYYY-MM-DD')
-      )
+      );
       // Expire cache in 8 hours
-      const now = new Date()
-      cache.expiration = new Date(now.getTime() + 1000 * 60 * 60 * 8)
-      return cache.save()
+      const now = new Date();
+      cache.expiration = new Date(now.getTime() + 1000 * 60 * 60 * 8);
+      return cache.save();
     })
     .then(newCache => {
-      data.cache = newCache
+      data.cache = newCache;
       return runQuery(data.queryText, data.connection, data.user).then(
         queryResult => {
-          data.queryResult = queryResult
-          data.queryResult.cacheKey = data.cacheKey
+          data.queryResult = queryResult;
+          data.queryResult.cacheKey = data.cacheKey;
         }
-      )
+      );
     })
     .then(() => {
       if (data.config.get('allowCsvDownload')) {
-        const queryResult = data.queryResult
-        const cache = data.cache
+        const queryResult = data.queryResult;
+        const cache = data.cache;
         return cache
           .writeXlsx(queryResult)
-          .then(() => cache.writeCsv(queryResult))
+          .then(() => cache.writeCsv(queryResult));
       }
     })
     .then(() => {
-      return data && data.queryResult ? data.queryResult : null
-    })
+      return data && data.queryResult ? data.queryResult : null;
+    });
 }
 
-module.exports = router
+module.exports = router;

--- a/server/routes/schema-info.js
+++ b/server/routes/schema-info.js
@@ -1,57 +1,57 @@
-const router = require('express').Router()
-const connections = require('../models/connections')
-const Cache = require('../models/Cache.js')
-const driver = require('../drivers')
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const connections = require('../models/connections');
+const Cache = require('../models/Cache.js');
+const driver = require('../drivers');
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const sendError = require('../lib/sendError');
 
 router.get('/api/schema-info/:connectionId', mustBeAuthenticated, function(
   req,
   res
 ) {
-  const reload = req.query.reload === 'true'
-  const cacheKey = 'schemaCache:' + req.params.connectionId
+  const reload = req.query.reload === 'true';
+  const cacheKey = 'schemaCache:' + req.params.connectionId;
   return Promise.all([
     connections.findOneById(req.params.connectionId),
     // This has problems in TravisCI for some reason...
     Cache.findOneByCacheKey(cacheKey)
   ])
     .then(results => {
-      let [conn, cache] = results
+      let [conn, cache] = results;
 
       if (!conn) {
-        throw new Error('Connection not found')
+        throw new Error('Connection not found');
       }
 
       if (cache && !reload) {
         const schemaInfo =
           typeof cache.schema === 'string'
             ? JSON.parse(cache.schema)
-            : cache.schema
+            : cache.schema;
 
-        return res.json({ schemaInfo })
+        return res.json({ schemaInfo });
       }
 
       if (!cache) {
-        cache = new Cache({ cacheKey })
+        cache = new Cache({ cacheKey });
       }
 
       return driver.getSchema(conn).then(schemaInfo => {
         if (Object.keys(schemaInfo).length) {
           // Schema needs to be stringified as JSON
           // Column names could have dots in name (incompatible with nedb)
-          cache.schema = JSON.stringify(schemaInfo)
-          cache.save().catch(error => console.log(error))
+          cache.schema = JSON.stringify(schemaInfo);
+          cache.save().catch(error => console.log(error));
         }
-        return res.json({ schemaInfo })
-      })
+        return res.json({ schemaInfo });
+      });
     })
     .catch(error => {
       if (error.message === 'Connection not found') {
-        return sendError(res, error)
+        return sendError(res, error);
       }
-      sendError(res, error, 'Problem getting schema info')
-    })
-})
+      sendError(res, error, 'Problem getting schema info');
+    });
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/signup-signin-signout.js
+++ b/server/routes/signup-signin-signout.js
@@ -1,34 +1,34 @@
-const passport = require('passport')
-const router = require('express').Router()
-const checkWhitelist = require('../lib/check-whitelist')
-const User = require('../models/User.js')
-const sendError = require('../lib/sendError')
+const passport = require('passport');
+const router = require('express').Router();
+const checkWhitelist = require('../lib/check-whitelist');
+const User = require('../models/User.js');
+const sendError = require('../lib/sendError');
 
 // NOTE: getting config here during module init is okay
 // since these configs are set via env or cli
-const { disableUserpassAuth } = require('../lib/config').getPreDbConfig()
+const { disableUserpassAuth } = require('../lib/config').getPreDbConfig();
 
 /*  Some routes should only exist if userpath auth is enabled
 ============================================================================= */
 if (!disableUserpassAuth) {
   router.post('/api/signup', function(req, res) {
-    const whitelistedDomains = req.config.get('whitelistedDomains')
+    const whitelistedDomains = req.config.get('whitelistedDomains');
 
     if (req.body.password !== req.body.passwordConfirmation) {
-      return sendError(res, null, 'Passwords do not match')
+      return sendError(res, null, 'Passwords do not match');
     }
     return Promise.all([
       User.findOneByEmail(req.body.email),
       User.adminRegistrationOpen()
     ])
       .then(data => {
-        let [user, adminRegistrationOpen] = data
+        let [user, adminRegistrationOpen] = data;
         if (user && user.passhash) {
-          return sendError(res, null, 'User already signed up')
+          return sendError(res, null, 'User already signed up');
         }
         if (user) {
-          user.password = req.body.password
-          user.signupDate = new Date()
+          user.password = req.body.password;
+          user.signupDate = new Date();
         }
         if (!user) {
           // if open admin registration or whitelisted email create user
@@ -42,37 +42,37 @@ if (!disableUserpassAuth) {
               password: req.body.password,
               role: adminRegistrationOpen ? 'admin' : 'editor',
               signupDate: new Date()
-            })
+            });
           } else {
-            return sendError(res, null, 'Email address not whitelisted')
+            return sendError(res, null, 'Email address not whitelisted');
           }
         }
-        return user.save().then(newUser => res.json({}))
+        return user.save().then(newUser => res.json({}));
       })
-      .catch(error => sendError(res, error, 'Error saving user'))
-  })
+      .catch(error => sendError(res, error, 'Error saving user'));
+  });
 
   router.post('/api/signin', passport.authenticate('local'), function(
     req,
     res
   ) {
     // if it makes it here, the authentication succeded
-    res.json({})
-  })
+    res.json({});
+  });
 }
 
 /*  These auth routes should always exist regardless of strategy
 ============================================================================= */
 router.get('/api/signout', function(req, res) {
   if (!req.session) {
-    return res.json({})
+    return res.json({});
   }
   req.session.destroy(function(err) {
     if (err) {
-      console.error(err)
+      console.error(err);
     }
-    res.json({})
-  })
-})
+    res.json({});
+  });
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -1,21 +1,21 @@
-const _ = require('lodash')
-const router = require('express').Router()
-const Query = require('../models/Query.js')
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const sendError = require('../lib/sendError')
+const _ = require('lodash');
+const router = require('express').Router();
+const Query = require('../models/Query.js');
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const sendError = require('../lib/sendError');
 
 router.get('/api/tags', mustBeAuthenticated, function(req, res) {
   return Query.findAll()
     .then(queries => {
       const tags = _.uniq(_.flatten(_.map(queries, 'tags')))
         .sort()
-        .filter(t => t)
+        .filter(t => t);
 
       return res.json({
         tags: tags
-      })
+      });
     })
-    .catch(error => sendError(res, error, 'Problem getting tags'))
-})
+    .catch(error => sendError(res, error, 'Problem getting tags'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/test-connection.js
+++ b/server/routes/test-connection.js
@@ -1,16 +1,16 @@
-const router = require('express').Router()
-const { testConnection } = require('../drivers/index')
-const mustBeAdmin = require('../middleware/must-be-admin.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const { testConnection } = require('../drivers/index');
+const mustBeAdmin = require('../middleware/must-be-admin.js');
+const sendError = require('../lib/sendError');
 
 /**
  * A non-error response is considered a success or valid connection config
  */
 router.post('/api/test-connection', mustBeAdmin, function(req, res) {
-  const { body } = req
+  const { body } = req;
   return testConnection(body)
     .then(queryResult => res.send({ success: true }))
-    .catch(error => sendError(res, error))
-})
+    .catch(error => sendError(res, error));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,68 +1,68 @@
-const router = require('express').Router()
-const User = require('../models/User.js')
-const email = require('../lib/email')
-const mustBeAdmin = require('../middleware/must-be-admin.js')
-const mustBeAuthenticated = require('../middleware/must-be-authenticated.js')
-const sendError = require('../lib/sendError')
+const router = require('express').Router();
+const User = require('../models/User.js');
+const email = require('../lib/email');
+const mustBeAdmin = require('../middleware/must-be-admin.js');
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const sendError = require('../lib/sendError');
 
 router.get('/api/users', mustBeAuthenticated, function(req, res) {
   return User.findAll()
     .then(users => res.json({ users }))
-    .catch(error => sendError(res, error, 'Problem getting uers'))
-})
+    .catch(error => sendError(res, error, 'Problem getting uers'));
+});
 
 // create/whitelist/invite user
 router.post('/api/users', mustBeAdmin, function(req, res) {
-  const { config } = req
+  const { config } = req;
   return User.findOneByEmail(req.body.email)
     .then(user => {
       if (user) {
-        return sendError(res, null, 'User already exists')
+        return sendError(res, null, 'User already exists');
       }
       const newUser = new User({
         email: req.body.email.toLowerCase(),
         role: req.body.role
-      })
+      });
       return newUser.save().then(user => {
         if (config.smtpConfigured()) {
-          email.sendInvite(req.body.email).catch(error => console.error(error))
+          email.sendInvite(req.body.email).catch(error => console.error(error));
         }
-        return res.json({ user })
-      })
+        return res.json({ user });
+      });
     })
-    .catch(error => sendError(res, error, 'Problem saving user'))
-})
+    .catch(error => sendError(res, error, 'Problem saving user'));
+});
 
 router.put('/api/users/:_id', mustBeAdmin, function(req, res) {
-  const { params, body, user } = req
+  const { params, body, user } = req;
   if (user._id === params._id && user.role === 'admin' && body.role != null) {
-    return sendError(res, null, "You can't unadmin yourself")
+    return sendError(res, null, "You can't unadmin yourself");
   }
   return User.findOneById(params._id)
     .then(user => {
       if (!user) {
-        return sendError(res, null, 'user not found')
+        return sendError(res, null, 'user not found');
       }
       // this route could handle potentially different kinds of updates
       // only update user properties that are explicitly provided in body
       if (body.role != null) {
-        user.role = body.role
+        user.role = body.role;
       }
       if (body.passwordResetId != null) {
-        user.passwordResetId = body.passwordResetId
+        user.passwordResetId = body.passwordResetId;
       }
-      return user.save().then(() => res.json({ user }))
+      return user.save().then(() => res.json({ user }));
     })
-    .catch(error => sendError(res, error, 'Problem saving user'))
-})
+    .catch(error => sendError(res, error, 'Problem saving user'));
+});
 
 router.delete('/api/users/:_id', mustBeAdmin, function(req, res) {
   if (req.user._id === req.params._id) {
-    return sendError(res, null, "You can't delete yourself")
+    return sendError(res, null, "You can't delete yourself");
   }
   return User.removeOneById(req.params._id)
     .then(() => res.json({}))
-    .catch(error => sendError(res, error, 'Problem deleting user'))
-})
+    .catch(error => sendError(res, error, 'Problem deleting user'));
+});
 
-module.exports = router
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-const fs = require('fs')
-const http = require('http')
-const https = require('https')
-const detectPort = require('detect-port')
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const detectPort = require('detect-port');
 
 // Parse command line flags to see if anything special needs to happen
-require('./lib/cli-flow.js')
+require('./lib/cli-flow.js');
 
-const app = require('./app')
+const app = require('./app');
 const {
   baseUrl,
   ip,
@@ -18,11 +18,11 @@ const {
   keyPath,
   certPath,
   systemdSocket
-} = require('./lib/config').getPreDbConfig()
-const db = require('./lib/db')
+} = require('./lib/config').getPreDbConfig();
+const db = require('./lib/db');
 
 function isFdObject(ob) {
-  return ob && typeof ob.fd === 'number'
+  return ob && typeof ob.fd === 'number';
 }
 
 // When --systemd-socket is passed we will try to acquire the bound socket
@@ -35,31 +35,31 @@ function isFdObject(ob) {
 // https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
 function detectPortOrSystemd(port) {
   if (systemdSocket) {
-    const passedSocketCount = parseInt(process.env.LISTEN_FDS, 10) || 0
+    const passedSocketCount = parseInt(process.env.LISTEN_FDS, 10) || 0;
 
     // LISTEN_FDS contains number of sockets passed by Systemd. At least one
     // must be passed. The sockets are set to file descriptors starting from 3.
     // We just crab the first socket from fd 3 since sqlpad binds only one
     // port.
     if (passedSocketCount > 0) {
-      console.log('Using port from Systemd')
-      return Promise.resolve({ fd: 3 })
+      console.log('Using port from Systemd');
+      return Promise.resolve({ fd: 3 });
     } else {
       console.error(
         'Warning: Systemd socket asked but not found. Trying to bind port ' +
           port +
           ' manually'
-      )
+      );
     }
   }
 
-  return detectPort(port)
+  return detectPort(port);
 }
 
 /*  Start the Server
 ============================================================================= */
 db.onLoad(function(err) {
-  if (err) throw err
+  if (err) throw err;
 
   // determine if key pair exists for certs
   if (keyPath && certPath) {
@@ -70,25 +70,25 @@ db.onLoad(function(err) {
           '\nPort %d already occupied. Using port %d instead.',
           httpsPort,
           _port
-        )
+        );
         // TODO FIXME XXX  Persist the new port to the in-memory store.
         // config.set('httpsPort', _port)
       }
 
-      const privateKey = fs.readFileSync(keyPath, 'utf8')
-      const certificate = fs.readFileSync(certPath, 'utf8')
+      const privateKey = fs.readFileSync(keyPath, 'utf8');
+      const certificate = fs.readFileSync(certPath, 'utf8');
       const httpsOptions = {
         key: privateKey,
         cert: certificate,
         passphrase: certPassphrase
-      }
+      };
 
       https.createServer(httpsOptions, app).listen(_port, ip, function() {
-        const hostIp = ip === '0.0.0.0' ? 'localhost' : ip
-        const url = `https://${hostIp}:${_port}${baseUrl}`
-        console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`)
-      })
-    })
+        const hostIp = ip === '0.0.0.0' ? 'localhost' : ip;
+        const url = `https://${hostIp}:${_port}${baseUrl}`;
+        console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`);
+      });
+    });
   } else {
     // http only
     detectPortOrSystemd(port).then(function(_port) {
@@ -97,15 +97,15 @@ db.onLoad(function(err) {
           '\nPort %d already occupied. Using port %d instead.',
           port,
           _port
-        )
+        );
         // TODO FIXME XXX  Persist the new port to the in-memory store.
         // config.set('port', _port)
       }
       http.createServer(app).listen(_port, ip, function() {
-        const hostIp = ip === '0.0.0.0' ? 'localhost' : ip
-        const url = `http://${hostIp}:${_port}${baseUrl}`
-        console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`)
-      })
-    })
+        const hostIp = ip === '0.0.0.0' ? 'localhost' : ip;
+        const url = `http://${hostIp}:${_port}${baseUrl}`;
+        console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`);
+      });
+    });
   }
-})
+});

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 const expectedKeys = [
   'adminRegistrationOpen',
@@ -8,7 +8,7 @@ const expectedKeys = [
   'googleAuthConfigured',
   'version',
   'passport'
-]
+];
 
 const expectedConfigKeys = [
   'baseUrl',
@@ -17,24 +17,24 @@ const expectedConfigKeys = [
   'queryResultMaxRows',
   'showSchemaCopyButton',
   'publicUrl'
-]
+];
 
 describe('api/app', function() {
   it('returns expected values', function() {
     return utils.get(null, '/api/app').then(body => {
-      utils.expectKeys(body, expectedKeys)
-      utils.expectKeys(body.config, expectedConfigKeys)
+      utils.expectKeys(body, expectedKeys);
+      utils.expectKeys(body.config, expectedConfigKeys);
       assert.equal(
         Object.keys(body.config).length,
         expectedConfigKeys.length,
         'config should only have keys specified'
-      )
-    })
-  })
+      );
+    });
+  });
 
   it('handles unknown baseUrl', function() {
     return utils
       .get(null, '/literally/any/path/api/app')
-      .then(body => utils.expectKeys(body, expectedKeys))
-  })
-})
+      .then(body => utils.expectKeys(body, expectedKeys));
+  });
+});

--- a/server/test/api/config-values.js
+++ b/server/test/api/config-values.js
@@ -1,38 +1,38 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api config-item & config-values', function() {
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('GET api/config-items (check default)', function() {
     return utils.get('admin', '/api/config-items').then(body => {
-      const { configItems, error } = body
-      assert(!error, 'Expect no error')
-      const item = configItems.find(i => i.key === 'allowCsvDownload')
+      const { configItems, error } = body;
+      assert(!error, 'Expect no error');
+      const item = configItems.find(i => i.key === 'allowCsvDownload');
       assert.equal(
         item.default,
         item.effectiveValue,
         'default is effectiveValue'
-      )
-    })
-  })
+      );
+    });
+  });
 
   it('POST api/config-values (change value)', function() {
     return utils
       .post('admin', '/api/config-values/allowCsvDownload', {
         value: false
       })
-      .then(body => assert(!body.error, 'Expect no error'))
-  })
+      .then(body => assert(!body.error, 'Expect no error'));
+  });
 
   it('GET api/config-items (validate change)', function() {
     return utils.get('admin', '/api/config-items').then(body => {
-      const { configItems, error } = body
-      assert(!error, 'Expect no error')
-      const item = configItems.find(i => i.key === 'allowCsvDownload')
-      assert.equal(item.effectiveValue, false, 'default is effectiveValue')
-    })
-  })
-})
+      const { configItems, error } = body;
+      assert(!error, 'Expect no error');
+      const item = configItems.find(i => i.key === 'allowCsvDownload');
+      assert.equal(item.effectiveValue, false, 'default is effectiveValue');
+    });
+  });
+});

--- a/server/test/api/connections.js
+++ b/server/test/api/connections.js
@@ -1,20 +1,20 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/connections', function() {
-  let connection
+  let connection;
 
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('Returns empty array', function() {
     return utils.get('admin', '/api/connections').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.connections), 'connections is an array')
-      assert.equal(body.connections.length, 0, '0 length')
-    })
-  })
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.connections), 'connections is an array');
+      assert.equal(body.connections.length, 0, '0 length');
+    });
+  });
 
   it('Creates connection', function() {
     return utils
@@ -27,19 +27,19 @@ describe('api/connections', function() {
         password: 'password'
       })
       .then(body => {
-        assert(!body.error, 'no error')
-        assert(body.connection._id, 'has _id')
-        assert.equal(body.connection.driver, 'postgres')
-        assert.equal(body.connection.username, 'username')
-        connection = body.connection
-      })
-  })
+        assert(!body.error, 'no error');
+        assert(body.connection._id, 'has _id');
+        assert.equal(body.connection.driver, 'postgres');
+        assert.equal(body.connection.username, 'username');
+        connection = body.connection;
+      });
+  });
 
   it('Gets array of 1', function() {
     return utils
       .get('admin', '/api/connections')
-      .then(body => assert.equal(body.connections.length, 1, '0 length'))
-  })
+      .then(body => assert.equal(body.connections.length, 1, '0 length'));
+  });
 
   it('Updates connection', function() {
     return utils
@@ -52,26 +52,26 @@ describe('api/connections', function() {
         password: 'password'
       })
       .then(body => {
-        assert(!body.error, 'no error')
-        assert(body.connection._id, 'has _id')
-        assert.equal(body.connection.name, 'test connection update')
-        assert.equal(body.connection.driver, 'postgres')
-        assert.equal(body.connection.username, 'username')
-      })
-  })
+        assert(!body.error, 'no error');
+        assert(body.connection._id, 'has _id');
+        assert.equal(body.connection.name, 'test connection update');
+        assert.equal(body.connection.driver, 'postgres');
+        assert.equal(body.connection.username, 'username');
+      });
+  });
 
   it('Gets updated connection', function() {
     return utils
       .get('admin', `/api/connections/${connection._id}`)
       .then(body => {
-        assert(!body.error, 'no error')
-        assert.equal(body.connection.name, 'test connection update')
-      })
-  })
+        assert(!body.error, 'no error');
+        assert.equal(body.connection.name, 'test connection update');
+      });
+  });
 
   it('Requires authentication', function() {
-    return utils.get(null, `/api/connections/${connection._id}`, 302)
-  })
+    return utils.get(null, `/api/connections/${connection._id}`, 302);
+  });
 
   it('Create requires admin', function() {
     return utils.post(
@@ -86,20 +86,20 @@ describe('api/connections', function() {
         password: 'password'
       },
       403
-    )
-  })
+    );
+  });
 
   it('Deletes connection', function() {
     return utils
       .del('admin', `/api/connections/${connection._id}`)
-      .then(body => assert(!body.error, 'no error'))
-  })
+      .then(body => assert(!body.error, 'no error'));
+  });
 
   it('Returns empty array', function() {
     return utils.get('admin', '/api/connections').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.connections), 'connections is an array')
-      assert.equal(body.connections.length, 0, '0 length')
-    })
-  })
-})
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.connections), 'connections is an array');
+      assert.equal(body.connections.length, 0, '0 length');
+    });
+  });
+});

--- a/server/test/api/drivers.js
+++ b/server/test/api/drivers.js
@@ -1,16 +1,16 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/drivers', function() {
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('gets drivers', function() {
     return utils.get('editor', '/api/drivers').then(body => {
-      const { drivers, error } = body
-      assert(!error, 'Expect no error')
-      assert(drivers.find(i => i.id === 'postgres'), 'has postgres')
-    })
-  })
-})
+      const { drivers, error } = body;
+      assert(!error, 'Expect no error');
+      assert(drivers.find(i => i.id === 'postgres'), 'has postgres');
+    });
+  });
+});

--- a/server/test/api/password-reset.js
+++ b/server/test/api/password-reset.js
@@ -1,20 +1,20 @@
-const assert = require('assert')
-const utils = require('../utils')
-const uuid = require('uuid')
-const User = require('../../models/User')
+const assert = require('assert');
+const utils = require('../utils');
+const uuid = require('uuid');
+const User = require('../../models/User');
 
 function setReset() {
   return User.findOneByEmail('admin@test.com').then(user => {
-    const passwordResetId = uuid.v4()
-    user.passwordResetId = passwordResetId
-    return user.save().then(() => passwordResetId)
-  })
+    const passwordResetId = uuid.v4();
+    user.passwordResetId = passwordResetId;
+    return user.save().then(() => passwordResetId);
+  });
 }
 
 describe('api/password-reset', function() {
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('Allows resetting password', function() {
     return setReset().then(passwordResetId => {
@@ -24,9 +24,9 @@ describe('api/password-reset', function() {
           password: 'admin',
           passwordConfirmation: 'admin'
         })
-        .then(body => assert(!body.error, 'Expect no error'))
-    })
-  })
+        .then(body => assert(!body.error, 'Expect no error'));
+    });
+  });
 
   it('Errors for wrong passwordResetId', function() {
     return setReset().then(passwordResetId => {
@@ -36,9 +36,9 @@ describe('api/password-reset', function() {
           password: 'admin',
           passwordConfirmation: 'admin'
         })
-        .then(body => assert(body.error, 'Expect error'))
-    })
-  })
+        .then(body => assert(body.error, 'Expect error'));
+    });
+  });
 
   it('Errors for wrong email', function() {
     return setReset().then(passwordResetId => {
@@ -48,9 +48,9 @@ describe('api/password-reset', function() {
           password: 'admin',
           passwordConfirmation: 'admin'
         })
-        .then(body => assert(body.error, 'Expect error'))
-    })
-  })
+        .then(body => assert(body.error, 'Expect error'));
+    });
+  });
 
   it('Errors for mismatched passwords', function() {
     return setReset().then(passwordResetId => {
@@ -60,7 +60,7 @@ describe('api/password-reset', function() {
           password: 'admin2',
           passwordConfirmation: 'admin'
         })
-        .then(body => assert(body.error, 'Expect error'))
-    })
-  })
-})
+        .then(body => assert(body.error, 'Expect error'));
+    });
+  });
+});

--- a/server/test/api/queries.js
+++ b/server/test/api/queries.js
@@ -1,20 +1,20 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/queries', function() {
-  let query
+  let query;
 
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('Returns empty array', function() {
     return utils.get('admin', '/api/queries').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.queries), 'queries is an array')
-      assert.equal(body.queries.length, 0, '0 length')
-    })
-  })
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.queries), 'queries is an array');
+      assert.equal(body.queries.length, 0, '0 length');
+    });
+  });
 
   it('Creates query', function() {
     return utils
@@ -32,18 +32,18 @@ describe('api/queries', function() {
         }
       })
       .then(body => {
-        assert(!body.error, 'no error')
-        assert(body.query._id, 'has _id')
-        assert.equal(body.query.name, 'test query')
-        query = body.query
-      })
-  })
+        assert(!body.error, 'no error');
+        assert(body.query._id, 'has _id');
+        assert.equal(body.query.name, 'test query');
+        query = body.query;
+      });
+  });
 
   it('Gets array of 1', function() {
     return utils.get('admin', '/api/queries').then(body => {
-      assert.equal(body.queries.length, 1, '1 length')
-    })
-  })
+      assert.equal(body.queries.length, 1, '1 length');
+    });
+  });
 
   it('Updates query', function() {
     return utils
@@ -53,34 +53,34 @@ describe('api/queries', function() {
         connectionId: 'TODO'
       })
       .then(body => {
-        assert(!body.error, 'no error')
-        assert(body.query._id, 'has _id')
-        assert.equal(body.query.name, 'test query2')
-      })
-  })
+        assert(!body.error, 'no error');
+        assert(body.query._id, 'has _id');
+        assert.equal(body.query.name, 'test query2');
+      });
+  });
 
   it('Gets updated connection', function() {
     return utils.get('admin', `/api/queries/${query._id}`).then(body => {
-      assert(!body.error, 'no error')
-      assert.equal(body.query.name, 'test query2')
-    })
-  })
+      assert(!body.error, 'no error');
+      assert.equal(body.query.name, 'test query2');
+    });
+  });
 
   it('Requires authentication', function() {
-    return utils.get(null, `/api/queries/${query._id}`, 302)
-  })
+    return utils.get(null, `/api/queries/${query._id}`, 302);
+  });
 
   it('Deletes query', function() {
     return utils.del('admin', `/api/queries/${query._id}`).then(body => {
-      assert(!body.error, 'no error')
-    })
-  })
+      assert(!body.error, 'no error');
+    });
+  });
 
   it('Returns empty array', function() {
     return utils.get('admin', '/api/queries').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.queries), 'queries is an array')
-      assert.equal(body.queries.length, 0, '0 length')
-    })
-  })
-})
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.queries), 'queries is an array');
+      assert.equal(body.queries.length, 0, '0 length');
+    });
+  });
+});

--- a/server/test/api/query-result.js
+++ b/server/test/api/query-result.js
@@ -1,31 +1,31 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 const queryText = `
   -- dimensions = department 10, orderdate 10
   -- measures = cost, revenue, profit
   -- orderby = department desc, orderdate asc
   -- limit = 100
-`
+`;
 
 function validateQueryResult(queryResult) {
-  assert(queryResult.id, 'id')
-  assert(queryResult.cacheKey, 'cacheKey')
-  assert(queryResult.startTime, 'startTime')
-  assert(queryResult.stopTime, 'stopTime')
-  assert(queryResult.queryRunTime >= 0, 'queryRunTime')
-  assert(Array.isArray(queryResult.fields), 'fields')
-  assert.equal(queryResult.fields.length, 5, 'fields length')
-  assert.equal(queryResult.fields[0], 'department', 'field department')
-  assert.equal(queryResult.incomplete, false, 'incomplete')
-  assert(queryResult.meta, 'meta')
-  assert(queryResult.meta.department, 'meta.department')
-  assert(Array.isArray(queryResult.rows), 'rows is array')
-  assert.equal(queryResult.rows.length, 100, 'rows length')
+  assert(queryResult.id, 'id');
+  assert(queryResult.cacheKey, 'cacheKey');
+  assert(queryResult.startTime, 'startTime');
+  assert(queryResult.stopTime, 'stopTime');
+  assert(queryResult.queryRunTime >= 0, 'queryRunTime');
+  assert(Array.isArray(queryResult.fields), 'fields');
+  assert.equal(queryResult.fields.length, 5, 'fields length');
+  assert.equal(queryResult.fields[0], 'department', 'field department');
+  assert.equal(queryResult.incomplete, false, 'incomplete');
+  assert(queryResult.meta, 'meta');
+  assert(queryResult.meta.department, 'meta.department');
+  assert(Array.isArray(queryResult.rows), 'rows is array');
+  assert.equal(queryResult.rows.length, 100, 'rows length');
 }
 
 describe('api/query-result', function() {
-  let query, connection
+  let query, connection;
 
   before(function() {
     return utils
@@ -41,8 +41,8 @@ describe('api/query-result', function() {
             password: 'sqlpad'
           })
           .then(body => {
-            connection = body.connection
-          })
+            connection = body.connection;
+          });
       })
       .then(() => {
         return utils
@@ -53,17 +53,17 @@ describe('api/query-result', function() {
             queryText
           })
           .then(body => {
-            query = body.query
-          })
-      })
-  })
+            query = body.query;
+          });
+      });
+  });
 
   it('GET /api/query-result/:queryId', function() {
     return utils.get('admin', `/api/query-result/${query._id}`).then(body => {
-      assert(!body.error, 'Expect no error')
-      validateQueryResult(body.queryResult)
-    })
-  })
+      assert(!body.error, 'Expect no error');
+      validateQueryResult(body.queryResult);
+    });
+  });
 
   it('POST /api/query-result', function() {
     return utils
@@ -74,8 +74,8 @@ describe('api/query-result', function() {
         queryText
       })
       .then(body => {
-        assert(!body.error, 'Expect no error')
-        validateQueryResult(body.queryResult)
-      })
-  })
-})
+        assert(!body.error, 'Expect no error');
+        validateQueryResult(body.queryResult);
+      });
+  });
+});

--- a/server/test/api/schema-info.js
+++ b/server/test/api/schema-info.js
@@ -1,8 +1,8 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/schema-info', function() {
-  let connection
+  let connection;
 
   before(function() {
     return utils.resetWithUser().then(() => {
@@ -16,18 +16,18 @@ describe('api/schema-info', function() {
           password: 'sqlpad'
         })
         .then(body => {
-          assert(!body.error, 'no error')
-          connection = body.connection
-        })
-    })
-  })
+          assert(!body.error, 'no error');
+          connection = body.connection;
+        });
+    });
+  });
 
   it('Gets schema-info', function() {
     return utils
       .get('admin', `/api/schema-info/${connection._id}`)
       .then(body => {
-        assert(!body.error, 'Expect no error')
-        assert(body.schemaInfo, 'body.schemaInfo')
-      })
-  })
-})
+        assert(!body.error, 'Expect no error');
+        assert(body.schemaInfo, 'body.schemaInfo');
+      });
+  });
+});

--- a/server/test/api/signup-signin.js
+++ b/server/test/api/signup-signin.js
@@ -1,10 +1,10 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/signup', function() {
   before(function() {
-    return utils.reset()
-  })
+    return utils.reset();
+  });
 
   it('allows new user signup', function() {
     return utils
@@ -13,8 +13,8 @@ describe('api/signup', function() {
         passwordConfirmation: 'admin',
         email: 'admin@test.com'
       })
-      .then(body => assert(!body.error, 'Expect no error'))
-  })
+      .then(body => assert(!body.error, 'Expect no error'));
+  });
 
   it('prevents duplicate signups', function() {
     return utils
@@ -23,8 +23,8 @@ describe('api/signup', function() {
         passwordConfirmation: 'admin',
         email: 'admin@test.com'
       })
-      .then(body => assert(body.error, 'Expect error user already signed up'))
-  })
+      .then(body => assert(body.error, 'Expect error user already signed up'));
+  });
 
   it('prevents open signups', function() {
     return utils
@@ -33,8 +33,8 @@ describe('api/signup', function() {
         passwordConfirmation: 'notwhitelisted',
         email: 'notwhitelisted@test.com'
       })
-      .then(body => assert(body.error, 'Expect error needing whitelist'))
-  })
+      .then(body => assert(body.error, 'Expect error needing whitelist'));
+  });
 
   it('supports case insensitive login', function() {
     return utils
@@ -43,27 +43,27 @@ describe('api/signup', function() {
         role: 'editor'
       })
       .then(body => {
-        assert(!body.error, 'no error')
+        assert(!body.error, 'no error');
         return utils.post(null, '/api/signup', {
           password: 'password',
           passwordConfirmation: 'password',
           email: 'Usercase@test.com'
-        })
+        });
       })
-      .then(body => assert(!body.error, 'Expect no error'))
-  })
-})
+      .then(body => assert(!body.error, 'Expect no error'));
+  });
+});
 
 describe('api/signin', function() {
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
   it('signs in user', function() {
     return utils
       .post(null, '/api/signin', {
         password: 'admin',
         email: 'admin@test.com'
       })
-      .then(body => assert(!body.error, 'Expect no error'))
-  })
-})
+      .then(body => assert(!body.error, 'Expect no error'));
+  });
+});

--- a/server/test/api/tags.js
+++ b/server/test/api/tags.js
@@ -1,18 +1,18 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/tags', function() {
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('Returns empty array', function() {
     return utils.get('admin', '/api/tags').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.tags), 'tags is an array')
-      assert.equal(body.tags.length, 0, '0 length')
-    })
-  })
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.tags), 'tags is an array');
+      assert.equal(body.tags.length, 0, '0 length');
+    });
+  });
 
   it('Returns expected array', function() {
     return Promise.all([
@@ -34,9 +34,9 @@ describe('api/tags', function() {
         .then(body => assert(!body.error, 'no error'))
     ]).then(() =>
       utils.get('admin', '/api/tags').then(body => {
-        assert(!body.error, 'Expect no error')
-        assert.equal(body.tags.length, 3, '3 length')
+        assert(!body.error, 'Expect no error');
+        assert.equal(body.tags.length, 3, '3 length');
       })
-    )
-  })
-})
+    );
+  });
+});

--- a/server/test/api/test-connection.js
+++ b/server/test/api/test-connection.js
@@ -1,10 +1,10 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/test-connection', function() {
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('tests connection', function() {
     return utils
@@ -16,6 +16,6 @@ describe('api/test-connection', function() {
         username: 'sqlpad',
         password: 'sqlpad'
       })
-      .then(body => assert(!body.error, 'Expect no error'))
-  })
-})
+      .then(body => assert(!body.error, 'Expect no error'));
+  });
+});

--- a/server/test/api/users.js
+++ b/server/test/api/users.js
@@ -1,20 +1,20 @@
-const assert = require('assert')
-const utils = require('../utils')
+const assert = require('assert');
+const utils = require('../utils');
 
 describe('api/users', function() {
-  let user
+  let user;
 
   before(function() {
-    return utils.resetWithUser()
-  })
+    return utils.resetWithUser();
+  });
 
   it('Returns initial array', function() {
     return utils.get('admin', '/api/users').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.users), 'users is an array')
-      assert.equal(body.users.length, 2, '2 length')
-    })
-  })
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.users), 'users is an array');
+      assert.equal(body.users.length, 2, '2 length');
+    });
+  });
 
   it('Creates user', function() {
     return utils
@@ -23,18 +23,18 @@ describe('api/users', function() {
         role: 'editor'
       })
       .then(body => {
-        assert(!body.error, 'no error')
-        assert(body.user._id, 'has _id')
-        assert.equal(body.user.email, 'user1@test.com')
-        user = body.user
-      })
-  })
+        assert(!body.error, 'no error');
+        assert(body.user._id, 'has _id');
+        assert.equal(body.user.email, 'user1@test.com');
+        user = body.user;
+      });
+  });
 
   it('Gets list of users', function() {
     return utils
       .get('admin', '/api/users')
-      .then(body => assert.equal(body.users.length, 3, '3 length'))
-  })
+      .then(body => assert.equal(body.users.length, 3, '3 length'));
+  });
 
   it('Updates user', function() {
     return utils
@@ -42,14 +42,14 @@ describe('api/users', function() {
         role: 'admin'
       })
       .then(body => {
-        assert(!body.error, 'no error')
-        assert.equal(body.user.role, 'admin')
-      })
-  })
+        assert(!body.error, 'no error');
+        assert.equal(body.user.role, 'admin');
+      });
+  });
 
   it('Requires authentication', function() {
-    return utils.get(null, `/api/users`, 302)
-  })
+    return utils.get(null, `/api/users`, 302);
+  });
 
   it('Create requires admin', function() {
     return utils.post(
@@ -60,20 +60,20 @@ describe('api/users', function() {
         role: 'editor'
       },
       403
-    )
-  })
+    );
+  });
 
   it('Deletes user', function() {
     return utils
       .del('admin', `/api/users/${user._id}`)
-      .then(body => assert(!body.error, 'no error'))
-  })
+      .then(body => assert(!body.error, 'no error'));
+  });
 
   it('Returns expected list', function() {
     return utils.get('admin', '/api/users').then(body => {
-      assert(!body.error, 'Expect no error')
-      assert(Array.isArray(body.users), 'users is an array')
-      assert.equal(body.users.length, 2, '2 length')
-    })
-  })
-})
+      assert(!body.error, 'Expect no error');
+      assert(Array.isArray(body.users), 'users is an array');
+      assert.equal(body.users.length, 2, '2 length');
+    });
+  });
+});

--- a/server/test/drivers.js
+++ b/server/test/drivers.js
@@ -1,39 +1,39 @@
-const assert = require('assert')
-const drivers = require('../drivers')
+const assert = require('assert');
+const drivers = require('../drivers');
 
 describe('drivers', function() {
   it('loads and exposes api', function() {
     // This test doesn't test much will expand later
-    assert(drivers)
-    assert(typeof drivers.getSchema === 'function')
-    assert(typeof drivers.runQuery === 'function')
-    assert(typeof drivers.testConnection === 'function')
-  })
+    assert(drivers);
+    assert(typeof drivers.getSchema === 'function');
+    assert(typeof drivers.runQuery === 'function');
+    assert(typeof drivers.testConnection === 'function');
+  });
 
   it('getDrivers()', function() {
-    const driverItems = drivers.getDrivers()
-    assert(Array.isArray(driverItems), 'driverItems is array')
-    assert(driverItems.find(item => item.id === 'crate'))
-    assert(driverItems.find(item => item.id === 'hdb'))
-    assert(driverItems.find(item => item.id === 'mysql'))
-    assert(driverItems.find(item => item.id === 'postgres'))
-    assert(driverItems.find(item => item.id === 'presto'))
-    assert(driverItems.find(item => item.id === 'sqlserver'))
-    assert(driverItems.find(item => item.id === 'vertica'))
+    const driverItems = drivers.getDrivers();
+    assert(Array.isArray(driverItems), 'driverItems is array');
+    assert(driverItems.find(item => item.id === 'crate'));
+    assert(driverItems.find(item => item.id === 'hdb'));
+    assert(driverItems.find(item => item.id === 'mysql'));
+    assert(driverItems.find(item => item.id === 'postgres'));
+    assert(driverItems.find(item => item.id === 'presto'));
+    assert(driverItems.find(item => item.id === 'sqlserver'));
+    assert(driverItems.find(item => item.id === 'vertica'));
 
-    const postgres = driverItems.find(item => item.id === 'postgres')
-    assert.equal(postgres.id, 'postgres')
-    assert.equal(postgres.name, 'Postgres')
-    assert(Array.isArray(postgres.fields))
+    const postgres = driverItems.find(item => item.id === 'postgres');
+    assert.equal(postgres.id, 'postgres');
+    assert.equal(postgres.name, 'Postgres');
+    assert(Array.isArray(postgres.fields));
     assert(
       postgres.fields.find(field => field.key === 'postgresSsl'),
       'has postgres specific field'
-    )
+    );
     assert(
       !postgres.fields.find(field => field.key === 'sqlserverEncrypt'),
       'Does not have a SQL Server field'
-    )
-  })
+    );
+  });
 
   it('validateConnection()', function() {
     const validPostgres = drivers.validateConnection({
@@ -43,32 +43,32 @@ describe('drivers', function() {
       port: 'port',
       postgresSsl: true,
       somethingStripped: 'shouldnotmakeit'
-    })
-    assert.equal(Object.keys(validPostgres).length, 5, 'only 5 keys valid')
-    assert.equal(validPostgres.name, 'testname')
-    assert.equal(validPostgres.driver, 'postgres')
-    assert.equal(validPostgres.host, 'host')
-    assert.equal(validPostgres.port, 'port')
-    assert.equal(validPostgres.postgresSsl, true)
+    });
+    assert.equal(Object.keys(validPostgres).length, 5, 'only 5 keys valid');
+    assert.equal(validPostgres.name, 'testname');
+    assert.equal(validPostgres.driver, 'postgres');
+    assert.equal(validPostgres.host, 'host');
+    assert.equal(validPostgres.port, 'port');
+    assert.equal(validPostgres.postgresSsl, true);
 
     assert.throws(() => {
-      drivers.validateConnection({ name: 'name' })
-    }, 'missing driver throws error')
+      drivers.validateConnection({ name: 'name' });
+    }, 'missing driver throws error');
 
     assert.throws(() => {
-      drivers.validateConnection({ driver: 'postgres' })
-    }, 'missing name throws error')
+      drivers.validateConnection({ driver: 'postgres' });
+    }, 'missing name throws error');
 
     assert.throws(() => {
-      drivers.validateConnection({ name: 'name', driver: 'not exist' })
-    }, 'missing driver imp throws error')
+      drivers.validateConnection({ name: 'name', driver: 'not exist' });
+    }, 'missing driver imp throws error');
 
     assert.throws(() => {
       drivers.validateConnection({
         name: 'name',
         driver: 'postgres',
         postgresSsl: 'notboolean'
-      })
-    }, 'boolean not convertable throws error')
-  })
-})
+      });
+    }, 'boolean not convertable throws error');
+  });
+});

--- a/server/test/lib/config.js
+++ b/server/test/lib/config.js
@@ -1,40 +1,40 @@
-const assert = require('assert')
-const configUtil = require('../../lib/config')
-const db = require('../../lib/db')
+const assert = require('assert');
+const configUtil = require('../../lib/config');
+const db = require('../../lib/db');
 
-const configItems = require('../../lib/config/configItems')
-const fromDefault = require('../../lib/config/fromDefault')
-const fromEnv = require('../../lib/config/fromEnv')
-const fromCli = require('../../lib/config/fromCli')
-const nonUiConfig = require('../../lib/config').getPreDbConfig()
+const configItems = require('../../lib/config/configItems');
+const fromDefault = require('../../lib/config/fromDefault');
+const fromEnv = require('../../lib/config/fromEnv');
+const fromCli = require('../../lib/config/fromCli');
+const nonUiConfig = require('../../lib/config').getPreDbConfig();
 
 describe('config', function() {
   it('default', function() {
-    const conf = fromDefault()
-    assert.equal(conf.port, 80, 'default port')
-    assert(conf.dbPath !== '$HOME/sqlpad/db', 'dbPath should change')
-  })
+    const conf = fromDefault();
+    assert.equal(conf.port, 80, 'default port');
+    assert(conf.dbPath !== '$HOME/sqlpad/db', 'dbPath should change');
+  });
 
   it('env', function() {
-    const conf = fromEnv({ SQLPAD_PORT: 8000 })
-    assert.equal(conf.port, 8000, 'conf.port')
-  })
+    const conf = fromEnv({ SQLPAD_PORT: 8000 });
+    assert.equal(conf.port, 8000, 'conf.port');
+  });
 
   it('cli', function() {
     const conf = fromCli({
       'key-path': 'key/path',
       cert: 'cert/path',
       admin: 'admin@email.com'
-    })
-    assert.equal(conf.keyPath, 'key/path', 'keyPath')
-    assert.equal(conf.certPath, 'cert/path', 'certPath')
-    assert.equal(conf.admin, 'admin@email.com', 'admin')
-  })
+    });
+    assert.equal(conf.keyPath, 'key/path', 'keyPath');
+    assert.equal(conf.certPath, 'cert/path', 'certPath');
+    assert.equal(conf.admin, 'admin@email.com', 'admin');
+  });
 
   it('nonUI', function() {
-    assert.equal(Object.keys(nonUiConfig).length, configItems.length)
-  })
-})
+    assert.equal(Object.keys(nonUiConfig).length, configItems.length);
+  });
+});
 
 describe('lib/config', function() {
   // TODO test when control is inverted/dependencies injected
@@ -48,12 +48,12 @@ describe('lib/config', function() {
   // Loading a config should likely be explicit
   it('.get() should get a value provided by default', function() {
     return configUtil.getHelper(db).then(config => {
-      assert.equal(config.get('httpsPort'), 443, 'httpsPort=443')
-    })
-  })
+      assert.equal(config.get('httpsPort'), 443, 'httpsPort=443');
+    });
+  });
   it('.get() should only accept key in config items', function() {
     return configUtil.getHelper(db).then(config => {
-      assert.throws(() => config.get('non-existent-key'), Error)
-    })
-  })
-})
+      assert.throws(() => config.get('non-existent-key'), Error);
+    });
+  });
+});

--- a/server/test/lib/email.js
+++ b/server/test/lib/email.js
@@ -1,30 +1,30 @@
-const email = require('../../lib/email.js')
-const configUtil = require('../../lib/config')
-const db = require('../../lib/db')
+const email = require('../../lib/email.js');
+const configUtil = require('../../lib/config');
+const db = require('../../lib/db');
 
 describe('lib/email.js', function() {
   return configUtil.getHelper(db).then(config => {
     if (config.smtpConfigured() && process.env.SQLPAD_TEST_EMAIL) {
       it('should send invites', function() {
-        return email.sendInvite(process.env.SQLPAD_TEST_EMAIL)
-      })
+        return email.sendInvite(process.env.SQLPAD_TEST_EMAIL);
+      });
       it('should send forgot passwords', function() {
         return email.sendForgotPassword(
           process.env.SQLPAD_TEST_EMAIL,
           '/password-resset/id'
-        )
-      })
+        );
+      });
     } else {
       describe('Set env vars to enable:', function() {
-        it.skip('SQLPAD_SMTP_HOST')
-        it.skip('SQLPAD_SMTP_PORT')
-        it.skip('SQLPAD_SMTP_USER')
-        it.skip('SQLPAD_SMTP_PASSWORD')
-        it.skip('SQLPAD_SMTP_FROM')
-        it.skip('PUBLIC_URL')
-        it.skip('SQLPAD_TEST_EMAIL')
-        it.skip('SQLPAD_SMTP_SECURE (opt. probably to false)')
-      })
+        it.skip('SQLPAD_SMTP_HOST');
+        it.skip('SQLPAD_SMTP_PORT');
+        it.skip('SQLPAD_SMTP_USER');
+        it.skip('SQLPAD_SMTP_PASSWORD');
+        it.skip('SQLPAD_SMTP_FROM');
+        it.skip('PUBLIC_URL');
+        it.skip('SQLPAD_TEST_EMAIL');
+        it.skip('SQLPAD_SMTP_SECURE (opt. probably to false)');
+      });
     }
-  })
-})
+  });
+});

--- a/server/test/lib/getMeta.js
+++ b/server/test/lib/getMeta.js
@@ -1,8 +1,8 @@
-const assert = require('assert')
-const getMeta = require('../../lib/getMeta.js')
+const assert = require('assert');
+const getMeta = require('../../lib/getMeta.js');
 
-const d1 = new Date()
-const d2 = new Date(new Date().getTime() + 60000)
+const d1 = new Date();
+const d2 = new Date(new Date().getTime() + 60000);
 
 describe('lib/getMeta.js', function() {
   it('returns expected results', function() {
@@ -44,36 +44,36 @@ describe('lib/getMeta.js', function() {
         date: null,
         numberString: null
       }
-    ]
+    ];
 
-    const meta = getMeta(rows)
+    const meta = getMeta(rows);
 
-    assert.equal(meta.alwaysNull.datatype, null, 'null')
+    assert.equal(meta.alwaysNull.datatype, null, 'null');
 
-    assert.equal(meta.accountNumber.datatype, 'string', 'accountNumber')
+    assert.equal(meta.accountNumber.datatype, 'string', 'accountNumber');
     assert.equal(
       meta.accountNumber.maxValueLength,
       6,
       'accountNumber.maxValueLength'
-    )
+    );
 
-    assert.equal(meta.decimalString.datatype, 'number', 'decimalString')
-    assert.equal(meta.decimalString.max, 0.999, 'decimalString.max')
-    assert.equal(meta.decimalString.min, 0.111, 'decimalString.min')
+    assert.equal(meta.decimalString.datatype, 'number', 'decimalString');
+    assert.equal(meta.decimalString.max, 0.999, 'decimalString.max');
+    assert.equal(meta.decimalString.min, 0.111, 'decimalString.min');
 
-    assert.equal(meta.number.datatype, 'number', 'number.datatype')
-    assert.equal(meta.number.max, 30, 'number.max')
-    assert.equal(meta.number.min, 0, 'number.min')
+    assert.equal(meta.number.datatype, 'number', 'number.datatype');
+    assert.equal(meta.number.max, 30, 'number.max');
+    assert.equal(meta.number.min, 0, 'number.min');
 
-    assert.equal(meta.string.datatype, 'string', 'string.datatype')
-    assert.equal(meta.string.maxValueLength, 7, 'string.maxValueLength')
+    assert.equal(meta.string.datatype, 'string', 'string.datatype');
+    assert.equal(meta.string.maxValueLength, 7, 'string.maxValueLength');
 
-    assert.equal(meta.date.datatype, 'date', 'date.datatype')
-    assert.equal(meta.date.max.getTime(), d2.getTime(), 'date.max')
-    assert.equal(meta.date.min.getTime(), d1.getTime(), 'date.min')
+    assert.equal(meta.date.datatype, 'date', 'date.datatype');
+    assert.equal(meta.date.max.getTime(), d2.getTime(), 'date.max');
+    assert.equal(meta.date.min.getTime(), d1.getTime(), 'date.min');
 
-    assert.equal(meta.numberString.datatype, 'number', 'numberString.datatype')
-    assert.equal(meta.numberString.max, 100, 'numberString.max')
-    assert.equal(meta.numberString.min, 0, 'numberString.min')
-  })
-})
+    assert.equal(meta.numberString.datatype, 'number', 'numberString.datatype');
+    assert.equal(meta.numberString.max, 100, 'numberString.max');
+    assert.equal(meta.numberString.min, 0, 'numberString.min');
+  });
+});

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -1,8 +1,8 @@
-const assert = require('assert')
-const request = require('supertest')
-const User = require('../models/User')
-const db = require('../lib/db')
-const app = require('../app')
+const assert = require('assert');
+const request = require('supertest');
+const User = require('../models/User');
+const db = require('../lib/db');
+const app = require('../app');
 
 const users = {
   admin: {
@@ -15,12 +15,12 @@ const users = {
     password: 'editor',
     role: 'editor'
   }
-}
+};
 
 function expectKeys(data, expectedKeys) {
   Object.keys(data).forEach(key =>
     assert(expectedKeys.includes(key), `expected key ${key}`)
-  )
+  );
 }
 
 function reset() {
@@ -29,56 +29,56 @@ function reset() {
     db.queries.remove({}, { multi: true }),
     db.connections.remove({}, { multi: true }),
     db.config.remove({}, { multi: true })
-  ])
+  ]);
 }
 
 function resetWithUser() {
   return reset().then(() => {
     const saves = Object.keys(users).map(key => {
-      const user = new User(users[key])
-      return user.save()
-    })
-    return Promise.all(saves)
-  })
+      const user = new User(users[key]);
+      return user.save();
+    });
+    return Promise.all(saves);
+  });
 }
 
 function addAuth(req, role) {
   if (users[role]) {
-    const username = users[role].email
-    const password = users[role].password
-    return req.auth(username, password)
+    const username = users[role].email;
+    const password = users[role].password;
+    return req.auth(username, password);
   }
-  return req
+  return req;
 }
 
 function del(role, url, statusCode = 200) {
-  let req = request(app).delete(url)
-  req = addAuth(req, role)
-  return req.expect(statusCode).then(response => response.body)
+  let req = request(app).delete(url);
+  req = addAuth(req, role);
+  return req.expect(statusCode).then(response => response.body);
 }
 
 function get(role, url, statusCode = 200) {
-  let req = request(app).get(url)
-  req = addAuth(req, role)
-  return req.expect(statusCode).then(response => response.body)
+  let req = request(app).get(url);
+  req = addAuth(req, role);
+  return req.expect(statusCode).then(response => response.body);
 }
 
 function post(role, url, body, statusCode = 200) {
-  let req = request(app).post(url)
-  req = addAuth(req, role)
+  let req = request(app).post(url);
+  req = addAuth(req, role);
   return req
     .send(body)
     .expect(statusCode)
-    .then(response => response.body)
+    .then(response => response.body);
 }
 
 function put(role, url, body, statusCode = 200) {
-  let req = request(app).put(url)
-  req = addAuth(req, role)
+  let req = request(app).put(url);
+  req = addAuth(req, role);
   return req
     .send(body)
     .expect(statusCode)
-    .then(response => response.body)
+    .then(response => response.body);
 }
 
 module.exports = {
@@ -89,4 +89,4 @@ module.exports = {
   put,
   reset,
   resetWithUser
-}
+};


### PR DESCRIPTION
RIP meaningful file updated dates, git blame, etc. Sorry if you've been maintaining a fork of SQLPad (kinda). 

I ditched the semicolon in this project 2.5 years ago. I don't know that I had a preference for or against it, but instead I liked the standardjs tooling in that it handled formatting and eslint all together. It was opinionated in some areas, but not too much in others, and at the time it seemed like a good fit. 

Shortly after that decision I got a job as a JavaScript developer. There we eventually adopted Prettier when it became a thing. We used semicolons. 

Switching back and forth between codebases with and without semicolons has been a struggle to be honest. It always take a bit to adjust. 

At this point I don't care what the code format is, I'd just like it to be consistent.

And I figure it'll be the most consistent if I use the most popular formats (which I assume must be the prettier defaults?)

So semicolons are back. 