### PR TITLE
Sql format via server API

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11950,14 +11950,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "sql-formatter": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-2.3.2.tgz",
-      "integrity": "sha512-cffwWdNzQAvzf/JlAv7fnCAR2//ZvmN2e9FWyWI6GCHYvn0U2UrmCOwBr0GO8HPaEm7Bks+a3rQDc+0Z43bhJg==",
-      "requires": {
-        "lodash": "^4.16.0"
-      }
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,6 @@
     "react-split-pane": "^0.1.87",
     "react-switch": "^5.0.0",
     "react-window": "^1.8.1",
-    "sql-formatter": "^2.3.2",
     "taucharts": "^2.7.2",
     "unistore": "^3.4.1",
     "whatwg-fetch": "^3.0.0"

--- a/client/src/stores/unistoreStore.js
+++ b/client/src/stores/unistoreStore.js
@@ -1,5 +1,4 @@
 import sortBy from 'lodash/sortBy';
-import sqlFormatter from 'sql-formatter';
 import createStore from 'unistore';
 import uuid from 'uuid';
 import message from '../common/message';
@@ -214,10 +213,20 @@ export const actions = store => ({
   },
 
   // QUERY
-  formatQuery(state) {
+  async formatQuery(state) {
     const { query } = state;
+
+    const json = await fetchJson('POST', '/api/format-sql', {
+      query: query.queryText
+    });
+
+    if (json.error) {
+      message.error(json.error);
+      return;
+    }
+
     return {
-      query: { ...query, queryText: sqlFormatter.format(query.queryText) },
+      query: { ...query, queryText: json.query },
       unsavedChanges: true
     };
   },

--- a/server/app.js
+++ b/server/app.js
@@ -118,6 +118,7 @@ const routers = [
   require('./routes/config-items.js'),
   require('./routes/config-values.js'),
   require('./routes/tags.js'),
+  require('./routes/format-sql.js'),
   require('./routes/signup-signin-signout.js')
 ];
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3445,6 +3445,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
+    "sql-formatter": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-2.3.2.tgz",
+      "integrity": "sha512-cffwWdNzQAvzf/JlAv7fnCAR2//ZvmN2e9FWyWI6GCHYvn0U2UrmCOwBr0GO8HPaEm7Bks+a3rQDc+0Z43bhJg==",
+      "requires": {
+        "lodash": "^4.16.0"
+      }
+    },
     "sqlstring": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -72,6 +72,7 @@
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.2.0",
     "socksjs": "^0.5.0",
+    "sql-formatter": "^2.3.2",
     "uuid": "^3.3.2",
     "vertica": "^0.5.5"
   },

--- a/server/routes/format-sql.js
+++ b/server/routes/format-sql.js
@@ -1,0 +1,18 @@
+const sqlFormatter = require('sql-formatter');
+const router = require('express').Router();
+const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
+const sendError = require('../lib/sendError');
+
+/**
+ * Returns formatted query in same object format it was sent
+ */
+router.post('/api/format-sql', mustBeAuthenticated, function(req, res) {
+  const { body } = req;
+  if (!body.query) {
+    return sendError(res, null, 'query property must be provided');
+  }
+  body.query = sqlFormatter.format(body.query);
+  res.send(body);
+});
+
+module.exports = router;

--- a/server/test/api/format-sql.js
+++ b/server/test/api/format-sql.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const utils = require('../utils');
+
+describe('api/format-sql', function() {
+  before(function() {
+    return utils.resetWithUser();
+  });
+
+  it('format sql query', function() {
+    return utils
+      .post('admin', '/api/format-sql', {
+        query: 'SELECT column_one, column_two FROM sometable'
+      })
+      .then(body => {
+        console.log(body);
+        assert.equal(
+          body.query,
+          'SELECT\n  column_one,\n  column_two\nFROM\n  sometable'
+        );
+        assert(!body.error, 'Expect no error');
+      });
+  });
+});


### PR DESCRIPTION
Removes sql-formatter from the front-end to replace it with an API call that formats the SQL and returns it. Cuts a dependency from the front end. Eventually a more flexible/advanced formatter could potentially be introduced. 