### PR TITLE
Query list improvements (react-window, sorting)

### DIFF
--- a/client/src/common/DeleteConfirmButton.js
+++ b/client/src/common/DeleteConfirmButton.js
@@ -1,7 +1,9 @@
 import { Dialog } from '@reach/dialog';
+import DeleteIcon from 'mdi-react/DeleteIcon';
 import React, { useRef, useState } from 'react';
 import base from './base.module.css';
 import Button from './Button';
+import IconButton from './IconButton';
 
 const dialogStyle = {
   width: '500px',
@@ -9,20 +11,31 @@ const dialogStyle = {
 };
 
 const DeleteConfirmButton = React.forwardRef(
-  ({ children, confirmMessage, onConfirm, className, ...rest }, ref) => {
+  ({ children, confirmMessage, onConfirm, className, icon, ...rest }, ref) => {
     const [visible, setVisible] = useState(false);
     const cancelEl = useRef(null);
 
     return (
       <>
-        <Button
-          onClick={() => setVisible(true)}
-          ref={ref}
-          type="danger"
-          {...rest}
-        >
-          {children}
-        </Button>
+        {icon ? (
+          <IconButton
+            onClick={() => setVisible(true)}
+            ref={ref}
+            type="danger"
+            {...rest}
+          >
+            <DeleteIcon />
+          </IconButton>
+        ) : (
+          <Button
+            onClick={() => setVisible(true)}
+            ref={ref}
+            type="danger"
+            {...rest}
+          >
+            {children}
+          </Button>
+        )}
         {visible && (
           <Dialog
             onDismiss={() => setVisible(false)}

--- a/client/src/common/IconButton.js
+++ b/client/src/common/IconButton.js
@@ -6,11 +6,18 @@ import Tooltip from './Tooltip';
 const ICON_SIZE = 18;
 
 const IconButton = React.forwardRef(
-  ({ children, to, icon, tooltip, disabled, className, ...rest }, ref) => {
+  (
+    { children, type, to, icon, tooltip, disabled, className, ...rest },
+    ref
+  ) => {
     const classNames = [styles.btn];
 
     if (className) {
       classNames.push(className);
+    }
+
+    if (type === 'danger') {
+      classNames.push(styles.danger);
     }
 
     let button;

--- a/client/src/common/IconButton.module.css
+++ b/client/src/common/IconButton.module.css
@@ -46,3 +46,12 @@
   color: rgba(0, 0, 0, 0.25);
   background-color: #eee;
 }
+
+.danger:hover,
+.danger:focus {
+  color: #fb30ac;
+}
+
+.danger:active {
+  color: #ff009d;
+}

--- a/client/src/common/MultiSelect.js
+++ b/client/src/common/MultiSelect.js
@@ -9,7 +9,7 @@ import Tag from './Tag';
  * A lot of that example was changed and reduced down to what this is here.
  * If anyone out there more familiar with downshift wants to clean this up by all means feel free
  */
-function MultiSelect({ selectedItems = [], options, onChange }) {
+function MultiSelect({ selectedItems = [], options, onChange, placeholder }) {
   const input = useRef();
 
   const itemToString = item => (item ? item.name : '');
@@ -96,6 +96,7 @@ function MultiSelect({ selectedItems = [], options, onChange }) {
               : null}
             <input
               className={styles.input}
+              placeholder={placeholder}
               {...getInputProps({
                 ref: input,
                 onKeyDown(event) {

--- a/client/src/common/SqlEditor.js
+++ b/client/src/common/SqlEditor.js
@@ -47,7 +47,7 @@ function SqlEditor({ config, onChange, readOnly, value, onSelectionChange }) {
       {({ measureRef }) => (
         <div ref={measureRef} className="h-100 w-100">
           <AceEditor
-            focus={true}
+            focus={!readOnly}
             editorProps={{ $blockScrolling: Infinity }}
             enableBasicAutocompletion
             enableLiveAutocompletion

--- a/client/src/common/Text.js
+++ b/client/src/common/Text.js
@@ -4,7 +4,7 @@ const Text = ({ children, type, style, ...rest }) => {
   const s = Object.assign({}, style);
 
   if (type === 'secondary') {
-    s.color = 'rgba(0,0,0,0.45)';
+    s.color = 'rgba(0,0,0,0.4)';
   } else if (type === 'danger') {
     s.color = '#cf1322';
   }

--- a/client/src/queries/QueryList.module.css
+++ b/client/src/queries/QueryList.module.css
@@ -1,10 +1,54 @@
+/* Padding of 2 added to show link outline when focused */
+.ListItem {
+  padding: 2px;
+}
+
 .ListItem:hover {
   background-color: #f4f4f4;
   transition: background-color 0.15s ease-in-out;
 }
 
-.outlined:hover,
-.outlined:active,
-.outlined:focus {
-  outline: 1px solid #40a9ff;
+.listItemActions {
+  position: absolute;
+  right: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.queryLink {
+  flex-grow: 1;
+  padding: 8px;
+}
+
+.queryName {
+  display: inline-block;
+  width: 240px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.connectionName {
+  margin-left: 16px;
+  display: inline-block;
+  width: 132px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview {
+  position: fixed;
+  left: 640px;
+  top: 40px;
+  right: 40px;
+  bottom: 40px;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+}
+
+.previewQueryName {
+  font-size: 1.25rem;
 }

--- a/client/src/queries/QueryList.module.css
+++ b/client/src/queries/QueryList.module.css
@@ -16,25 +16,8 @@
 }
 
 .queryLink {
-  flex-grow: 1;
+  width: 100%;
   padding: 8px;
-}
-
-.queryName {
-  display: inline-block;
-  width: 240px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.connectionName {
-  margin-left: 16px;
-  display: inline-block;
-  width: 132px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .preview {
@@ -51,4 +34,9 @@
 
 .previewQueryName {
   font-size: 1.25rem;
+}
+
+.newWindowLink {
+  display: inline-flex;
+  align-items: center;
 }

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -107,6 +107,7 @@ function QueryListDrawer({
         <ChartIcon />
       </IconButton>,
       <DeleteConfirmButton
+        icon
         key="del"
         confirmMessage={`Delete ${query.name}`}
         onConfirm={e => deleteQuery(query._id)}

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -1,14 +1,14 @@
-import ChartIcon from 'mdi-react/FinanceIcon';
-import TableIcon from 'mdi-react/TableIcon';
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
+import Measure from 'react-measure';
 import { Link } from 'react-router-dom';
+import { FixedSizeList as List } from 'react-window';
 import { connect } from 'unistore/react';
 import base from '../common/base.module.css';
 import DeleteConfirmButton from '../common/DeleteConfirmButton';
 import Divider from '../common/Divider';
 import Drawer from '../common/Drawer';
-import IconButton from '../common/IconButton';
 import ListItem from '../common/ListItem';
 import MultiSelect from '../common/MultiSelect';
 import SqlEditor from '../common/SqlEditor';
@@ -18,8 +18,6 @@ import { deleteQuery, loadQueries } from '../stores/queries';
 import getAvailableSearchTags from './getAvailableSearchTags';
 import getDecoratedQueries from './getDecoratedQueries';
 import styles from './QueryList.module.css';
-import { FixedSizeList as List } from 'react-window';
-import Measure from 'react-measure';
 
 function QueryListDrawer({
   queries,
@@ -87,34 +85,8 @@ function QueryListDrawer({
     const chartUrl = `/query-chart/${query._id}`;
     const queryUrl = `/queries/${query._id}`;
 
-    const actions = [
-      <IconButton
-        key="table"
-        to={tableUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        tooltip="Open results in new window"
-      >
-        <TableIcon />
-      </IconButton>,
-      <IconButton
-        key="chart"
-        to={chartUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        tooltip="Open chart in new window"
-      >
-        <ChartIcon />
-      </IconButton>,
-      <DeleteConfirmButton
-        icon
-        key="del"
-        confirmMessage={`Delete ${query.name}`}
-        onConfirm={e => deleteQuery(query._id)}
-      >
-        Delete
-      </DeleteConfirmButton>
-    ];
+    const hasChart =
+      query && query.chartConfiguration && query.chartConfiguration.chartType;
 
     return (
       <ListItem
@@ -125,12 +97,38 @@ function QueryListDrawer({
         style={style}
       >
         <Link className={styles.queryLink} to={queryUrl} onClick={onClose}>
-          <Text className={styles.queryName}>{query.name}</Text>
-          <Text className={styles.connectionName} type="secondary">
-            {query.connectionName}
-          </Text>
+          {query.name}
+          <br />
+          <Text type="secondary">{query.connectionName}</Text>
         </Link>
-        <div className={styles.listItemActions}>{actions}</div>
+        <div className={styles.listItemActions}>
+          <Link
+            className={styles.newWindowLink}
+            to={tableUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            table <OpenInNewIcon size={16} />
+          </Link>
+          <div style={{ width: 8 }} />
+          <Link
+            className={styles.newWindowLink}
+            to={chartUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            disabled={!Boolean(hasChart)}
+          >
+            chart <OpenInNewIcon size={16} />
+          </Link>
+          <DeleteConfirmButton
+            icon
+            key="del"
+            confirmMessage={`Delete ${query.name}`}
+            onConfirm={e => deleteQuery(query._id)}
+          >
+            Delete
+          </DeleteConfirmButton>
+        </div>
       </ListItem>
     );
   };
@@ -160,43 +158,40 @@ function QueryListDrawer({
             placeholder="search queries"
           />
         </div>
+        <div>
+          <Divider />
+        </div>
 
-        <Divider />
-
-        <div
-          style={{
-            display: 'flex',
-            flexGrow: 1
+        <Measure
+          bounds
+          onResize={contentRect => {
+            setDimensions(contentRect.bounds);
           }}
         >
-          <Measure
-            bounds
-            onResize={contentRect => {
-              setDimensions(contentRect.bounds);
-            }}
-          >
-            {({ measureRef }) => (
-              <div
-                ref={measureRef}
-                style={{
-                  display: 'flex',
-                  width: '100%',
-                  height: '100%'
-                }}
+          {({ measureRef }) => (
+            <div
+              ref={measureRef}
+              style={{
+                display: 'flex',
+                width: '100%',
+                height: '100%'
+              }}
+            >
+              <List
+                // position absolute takes list out of flow,
+                // preventing some weird react-measure behavior in FireFox
+                style={{ position: 'absolute' }}
+                height={dimensions.height}
+                itemCount={filteredQueries.length}
+                itemSize={60}
+                width={dimensions.width}
+                overscanCount={2}
               >
-                <List
-                  height={dimensions.height}
-                  itemCount={filteredQueries.length}
-                  itemSize={48}
-                  width={dimensions.width}
-                  overscanCount={2}
-                >
-                  {Row}
-                </List>
-              </div>
-            )}
-          </Measure>
-        </div>
+                {Row}
+              </List>
+            </div>
+          )}
+        </Measure>
       </div>
 
       {preview && (

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -135,37 +135,37 @@ function QueryListDrawer({
       onClose={onClose}
       placement="left"
     >
-      <Measure
-        bounds
-        onResize={contentRect => {
-          setDimensions(contentRect.bounds);
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%'
         }}
       >
-        {({ measureRef }) => (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: '100%'
+        <div>
+          <MultiSelect
+            selectedItems={searches}
+            options={availableSearches}
+            onChange={items => setSearches(items)}
+            placeholder="search queries"
+          />
+        </div>
+
+        <Divider />
+
+        <div
+          style={{
+            display: 'flex',
+            flexGrow: 1
+          }}
+        >
+          <Measure
+            bounds
+            onResize={contentRect => {
+              setDimensions(contentRect.bounds);
             }}
           >
-            <div>
-              <MultiSelect
-                selectedItems={searches}
-                options={availableSearches}
-                onChange={items => setSearches(items)}
-                placeholder="search queries"
-              />
-            </div>
-
-            <Divider />
-
-            <div
-              style={{
-                display: 'flex',
-                flexGrow: 1
-              }}
-            >
+            {({ measureRef }) => (
               <div
                 ref={measureRef}
                 style={{
@@ -184,10 +184,10 @@ function QueryListDrawer({
                   {Row}
                 </List>
               </div>
-            </div>
-          </div>
-        )}
-      </Measure>
+            )}
+          </Measure>
+        </div>
+      </div>
 
       {preview && (
         <div className={`${base.shadow2} ${styles.preview}`}>

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -72,6 +72,15 @@ function QueryListDrawer({
     });
   }
 
+  // For now sort by last modified
+  filteredQueries = filteredQueries.sort((a, b) => {
+    const aDate = a.modifiedDate || a.createdDate;
+    const bDate = b.modifiedDate || b.createdDate;
+    if (aDate < bDate) return 1;
+    if (bDate < aDate) return -1;
+    return 0;
+  });
+
   const Row = ({ index, style }) => {
     const query = filteredQueries[index];
     const tableUrl = `/query-table/${query._id}`;


### PR DESCRIPTION
* Uses react-window to render query list. Today all queries are fetched and rendered in this list, and we don't want to bother rendering all of them. (switching this over to paginated/load-more fetching is future work)
* Adds sorting of queries back, defaulting to last modified. Still deciding on how to display this, or what to add to allow user to toggle how things are sorted.
* Delete confirmation button has been changed to an icon
* Table/chart link buttons changed to just plain links. reach-tooltip does not play well when tooltips are triggered and re-rendered... or something. Not sure how to reproduce the behavior exactly. This is okay though, as the icons previously used are not clear to the user.

Overall I'm struggling with how to expand on this query list and have a lot of questions
* Is the preview mechanic useful or distracting?
* Is connection name worth showing in this list?
* Is the tagged-search concept nice or should there instead be a few separate search inputs (author, connection, tag, general search?)

<img width="1080" alt="Screen Shot 2019-06-02 at 11 49 50 PM" src="https://user-images.githubusercontent.com/303966/58774854-8a62e580-8591-11e9-8d1b-fda139aa5ae0.png">
