### PR TITLE
Query list: separate author, connection, sort inputs

### DIFF
--- a/client/src/queries/QueryList.module.css
+++ b/client/src/queries/QueryList.module.css
@@ -1,5 +1,6 @@
 /* Padding of 2 added to show link outline when focused */
 .ListItem {
+  margin-top: 2px;
   padding: 2px;
 }
 
@@ -19,10 +20,11 @@
   border-bottom: var(--border);
   background-color: rgba(0, 0, 0, 0.03);
   padding: 16px;
-  margin-left: -16px;
-  margin-top: -16px;
-  margin-right: -16px;
-  margin-bottom: 16px;
+  /* 
+    Negative margins in place to compensate for padding in Drawer 
+    Should probably update Drawer implementation to have a subheader/actions section
+  */
+  margin: -16px -16px 16px -16px;
 }
 
 .filterRow {

--- a/client/src/queries/QueryList.module.css
+++ b/client/src/queries/QueryList.module.css
@@ -15,26 +15,24 @@
   align-items: center;
 }
 
+.filterContainer {
+  border-bottom: var(--border);
+  background-color: rgba(0, 0, 0, 0.03);
+  padding: 16px;
+  margin-left: -16px;
+  margin-top: -16px;
+  margin-right: -16px;
+  margin-bottom: 16px;
+}
+
+.filterRow {
+  display: flex;
+  margin-bottom: 8px;
+}
+
 .queryLink {
   width: 100%;
   padding: 8px;
-}
-
-.preview {
-  position: fixed;
-  left: 640px;
-  top: 40px;
-  right: 40px;
-  bottom: 40px;
-  background-color: white;
-  display: flex;
-  flex-direction: column;
-  padding: 16px;
-  box-shadow: var(--box-shadow-2);
-}
-
-.previewQueryName {
-  font-size: 1.25rem;
 }
 
 .newWindowLink {

--- a/client/src/queries/QueryPreview.js
+++ b/client/src/queries/QueryPreview.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Divider from '../common/Divider';
+import SqlEditor from '../common/SqlEditor';
+import Tag from '../common/Tag';
+import styles from './QueryPreview.module.css';
+
+function QueryPreview({ query }) {
+  if (!query) {
+    return null;
+  }
+  return (
+    <div className={styles.preview}>
+      <div className={styles.previewQueryName}>{query.name}</div>
+      <div>Connection {query.connectionName}</div>
+      <div>By {query.createdBy}</div>
+      <div>
+        {query.tags && query.tags.map(tag => <Tag key={tag}>{tag}</Tag>)}
+      </div>
+
+      <Divider />
+
+      {/* 
+            This style necessary to get proper sizing on SqlEditor.
+            It has height 100%, which looks to height of nearest containing BLOCK,
+            which apparently looks past this flex container. This causes weirdness
+          */}
+      <div
+        style={{
+          flexGrow: 1,
+          display: 'flex'
+        }}
+      >
+        <SqlEditor readOnly value={query.queryText} />
+      </div>
+    </div>
+  );
+}
+
+QueryPreview.propTypes = {
+  query: PropTypes.object
+};
+
+export default React.memo(QueryPreview);

--- a/client/src/queries/QueryPreview.module.css
+++ b/client/src/queries/QueryPreview.module.css
@@ -1,0 +1,16 @@
+.preview {
+  position: fixed;
+  left: 640px;
+  top: 40px;
+  right: 40px;
+  bottom: 40px;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  box-shadow: var(--box-shadow-2);
+}
+
+.previewQueryName {
+  font-size: 1.25rem;
+}

--- a/client/src/queries/getAvailableSearchTags.js
+++ b/client/src/queries/getAvailableSearchTags.js
@@ -1,14 +1,8 @@
 import uniq from 'lodash/uniq';
+import TagIcon from 'mdi-react/TagIcon';
+import React from 'react';
 
-export default function getAvailableSearchTags(queries, connections) {
-  const createdBys = uniq(queries.map(q => q.createdBy)).map(createdBy => {
-    return {
-      id: `createdBy=${createdBy}`,
-      name: `createdBy=${createdBy}`,
-      createdBy
-    };
-  });
-
+export default function getAvailableSearchTags(queries) {
   const tags = uniq(
     queries
       .map(q => q.tags)
@@ -16,22 +10,16 @@ export default function getAvailableSearchTags(queries, connections) {
       .filter(tag => Boolean(tag))
   ).map(tag => {
     return {
-      id: `tag=${tag}`,
-      name: `tag=${tag}`,
+      id: `# ${tag}`,
+      name: (
+        <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+          <TagIcon size={14} style={{ marginRight: 4 }} />
+          <span>{tag}</span>
+        </span>
+      ),
       tag
     };
   });
 
-  const connectionOptions = connections.map(connection => {
-    return {
-      id: `connection=${connection._id}`,
-      name: `connections=${connection.name}`,
-      connectionId: connection._id
-    };
-  });
-
-  return createdBys
-    .concat(tags)
-    .concat(connectionOptions)
-    .sort();
+  return tags.sort();
 }


### PR DESCRIPTION
Breaks author and connection inputs out of the main search/tag input. The single input wasn't really sitting right with me and I think the explicit inputs are better. 

This also allows for another dropdown to be added for query listing order. 

The inputs lack labels to keep the section compact. Open for input on what is useful here and what isn't, as my use case would require a single search box...

<img width="1042" alt="Screen Shot 2019-06-09 at 11 30 20 PM" src="https://user-images.githubusercontent.com/303966/59170879-93fac900-8b0e-11e9-9135-a4c2663481ee.png">
