### PR TITLE
Allow restore of unsaved query

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6468,6 +6468,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "immer": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
@@ -8187,6 +8192,14 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -8267,6 +8280,14 @@
             "minimist": "^1.2.0"
           }
         }
+      }
+    },
+    "localforage": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
+      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "d3": "^5.9.2",
     "downshift": "^3.2.10",
     "keymaster": "^1.6.2",
+    "localforage": "^1.7.3",
     "lodash": "^4.17.11",
     "match-sorter": "^3.1.1",
     "mdi-react": "^5.4.0",

--- a/client/src/common/Modal.js
+++ b/client/src/common/Modal.js
@@ -16,9 +16,11 @@ function Modal({ title, visible, onClose, width, children }) {
       >
         <div className={styles.titleWrapper}>
           <span>{title}</span>
-          <IconButton onClick={onClose}>
-            <CloseIcon />
-          </IconButton>
+          {onClose && (
+            <IconButton onClick={onClose}>
+              <CloseIcon />
+            </IconButton>
+          )}
         </div>
         <div className={styles.dialogBody}>{children}</div>
       </Dialog>

--- a/client/src/common/SqlDiff.js
+++ b/client/src/common/SqlDiff.js
@@ -1,0 +1,49 @@
+// NOTE this import 'brace' must occur before the importing of brace extensions
+import 'brace';
+import 'brace/mode/sql';
+import 'brace/theme/sqlserver';
+
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import Measure from 'react-measure';
+import { diff as DiffEditor } from 'react-ace';
+
+function SqlDiff({ value }) {
+  const [dimensions, setDimensions] = useState({ width: -1, height: -1 });
+  const { width, height } = dimensions;
+
+  // DiffEditor isn't responding to size changes or initial measure
+  // As a workaround, setting the key based on size will ensure React re-renders it
+  const key = `${width}${height}`;
+
+  return (
+    <Measure bounds onResize={contentRect => setDimensions(contentRect.bounds)}>
+      {({ measureRef }) => (
+        <div ref={measureRef} className="h-100 w-100">
+          <DiffEditor
+            key={key}
+            focus={false}
+            editorProps={{ $blockScrolling: Infinity }}
+            height={`${height}px`}
+            mode="sql"
+            name="query-diff-ace-editor"
+            theme="sqlserver"
+            readOnly={true}
+            value={value}
+            width={`${width}px`}
+          />
+        </div>
+      )}
+    </Measure>
+  );
+}
+
+SqlDiff.propTypes = {
+  value: PropTypes.arrayOf(PropTypes.string)
+};
+
+SqlDiff.defaultProps = {
+  value: ['', '']
+};
+
+export default SqlDiff;

--- a/client/src/css/vendorOverrides.css
+++ b/client/src/css/vendorOverrides.css
@@ -43,3 +43,10 @@
   justify-content: center;
   align-items: center;
 }
+
+/* Missing Ace diff editor style for highlighting code changes */
+.codeMarker {
+  background: #fff677;
+  position: absolute;
+  z-index: 20;
+}

--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -7,23 +7,21 @@ import { connect } from 'unistore/react';
 import { resizeChart } from '../common/tauChartRef';
 import SchemaSidebar from '../schema/SchemaSidebar.js';
 import { loadConnections } from '../stores/connections';
-import { loadTags } from '../stores/tags';
 import {
   formatQuery,
   loadQuery,
+  resetNewQuery,
   runQuery,
-  saveQuery,
-  resetNewQuery
+  saveQuery
 } from '../stores/queries';
+import { loadTags } from '../stores/tags';
 import QueryEditorChart from './QueryEditorChart';
+import QueryEditorChartToolbar from './QueryEditorChartToolbar';
 import QueryEditorResult from './QueryEditorResult';
 import QueryEditorSqlEditor from './QueryEditorSqlEditor';
 import QueryResultHeader from './QueryResultHeader.js';
 import Toolbar from './toolbar/Toolbar';
-import QueryEditorChartToolbar from './QueryEditorChartToolbar';
-
-// TODO FIXME XXX capture unsaved state to local storage
-// Prompt is removed. It doesn't always work anyways
+import UnsavedQuerySelector from './UnsavedQuerySelector';
 
 class QueryEditor extends React.Component {
   componentDidUpdate(prevProps) {
@@ -88,7 +86,7 @@ class QueryEditor extends React.Component {
   }, 700);
 
   render() {
-    const { chartType, queryName, showSchema } = this.props;
+    const { queryId, chartType, queryName, showSchema } = this.props;
 
     document.title = queryName;
 
@@ -168,6 +166,7 @@ class QueryEditor extends React.Component {
       >
         <Toolbar />
         <div style={{ position: 'relative', flexGrow: 1 }}>{sqlTabPane}</div>
+        <UnsavedQuerySelector queryId={queryId} />
       </div>
     );
   }

--- a/client/src/queryEditor/UnsavedQuerySelector.js
+++ b/client/src/queryEditor/UnsavedQuerySelector.js
@@ -24,7 +24,7 @@ function UnsavedQuerySelector({ queryId, queryText, setQueryState }) {
 
   const value = [queryText, unsavedQueryText];
   return (
-    <Modal title="Found an unsaved changes" visible={showModal} width="90vw">
+    <Modal title="Found unsaved query" visible={showModal} width="90vw">
       <div
         style={{ display: 'flex', margin: 8, justifyContent: 'space-around' }}
       >

--- a/client/src/queryEditor/UnsavedQuerySelector.js
+++ b/client/src/queryEditor/UnsavedQuerySelector.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'unistore/react';
+import { setQueryState } from '../stores/queries';
+import {
+  getLocalQueryText,
+  removeLocalQueryText
+} from '../utilities/localQueryText';
+import Modal from '../common/Modal';
+import SqlDiff from '../common/SqlDiff';
+import Button from '../common/Button';
+
+function UnsavedQuerySelector({ queryId, queryText, setQueryState }) {
+  const [showModal, setShowModal] = useState(false);
+  const [unsavedQueryText, setUnsavedQueryText] = useState('');
+
+  useEffect(() => {
+    getLocalQueryText(queryId).then(localQueryText => {
+      if (typeof localQueryText === 'string' && localQueryText.trim() !== '') {
+        setShowModal(true);
+        setUnsavedQueryText(localQueryText);
+      }
+    });
+  }, [queryId]);
+
+  const value = [queryText, unsavedQueryText];
+  return (
+    <Modal title="Found an unsaved changes" visible={showModal} width="90vw">
+      <div
+        style={{ display: 'flex', margin: 8, justifyContent: 'space-around' }}
+      >
+        <Button
+          onClick={() => {
+            setShowModal(false);
+          }}
+        >
+          Use saved
+        </Button>
+        <Button
+          onClick={() => {
+            setShowModal(false);
+            removeLocalQueryText(queryId);
+            setQueryState('queryText', unsavedQueryText);
+          }}
+        >
+          Use unsaved
+        </Button>
+      </div>
+      <div style={{ width: '100%', height: '60vh' }}>
+        <SqlDiff key={JSON.stringify(value)} value={value} />
+      </div>
+    </Modal>
+  );
+}
+
+function mapStateToProps(state, props) {
+  return {
+    queryText: state.query && state.query.queryText
+  };
+}
+
+const Connected = connect(
+  mapStateToProps,
+  { setQueryState }
+)(UnsavedQuerySelector);
+
+export default Connected;

--- a/client/src/stores/queries.js
+++ b/client/src/stores/queries.js
@@ -1,6 +1,10 @@
 import uuid from 'uuid';
 import message from '../common/message';
 import fetchJson from '../utilities/fetch-json.js';
+import {
+  setLocalQueryText,
+  removeLocalQueryText
+} from '../utilities/localQueryText';
 
 const ONE_HOUR_MS = 1000 * 60 * 60;
 
@@ -41,6 +45,8 @@ export const formatQuery = async state => {
     message.error(json.error);
     return;
   }
+
+  setLocalQueryText(query._id, json.query);
 
   return {
     query: { ...query, queryText: json.query },
@@ -143,6 +149,7 @@ export const saveQuery = store => async state => {
         return;
       }
       message.success('Query Saved');
+      removeLocalQueryText(query._id);
       const updatedQueries = queries.map(q => {
         return q._id === query._id ? query : q;
       });
@@ -168,6 +175,7 @@ export const saveQuery = store => async state => {
         `${window.BASE_URL}/queries/${query._id}`
       );
       message.success('Query Saved');
+      removeLocalQueryText(query._id);
       store.setState({
         isSaving: false,
         unsavedChanges: false,
@@ -197,6 +205,9 @@ export const resetNewQuery = state => {
 
 export const setQueryState = (state, field, value) => {
   const { query } = state;
+  if (field === 'queryText') {
+    setLocalQueryText(query._id, value);
+  }
   return { query: { ...query, [field]: value }, unsavedChanges: true };
 };
 

--- a/client/src/utilities/localQueryText.js
+++ b/client/src/utilities/localQueryText.js
@@ -1,0 +1,25 @@
+import localforage from 'localforage';
+
+export function setLocalQueryText(queryId, queryText) {
+  return localforage
+    .setItem(`queryText:${queryId}`, queryText)
+    .catch(error => console.error(error));
+}
+
+export function getLocalQueryText(queryId) {
+  return localforage
+    .getItem(`queryText:${queryId}`)
+    .catch(error => console.error(error));
+}
+
+export function removeLocalQueryText(queryId) {
+  return localforage
+    .removeItem(`queryText:${queryId}`)
+    .catch(error => console.error(error));
+}
+
+export default {
+  setLocalQueryText,
+  getLocalQueryText,
+  removeLocalQueryText
+};


### PR DESCRIPTION
Ever lose your query because you scrolled too far left in the result grid and Mac OS decided to navigation away from the page? Or maybe the session timed out?

Well now with this PR unsaved changes to a query will be saved to browser local storage, and you'll be prompted on reloading that query. 

<img width="984" alt="Screen Shot 2019-06-23 at 11 06 46 PM" src="https://user-images.githubusercontent.com/303966/59989075-9a5b6b80-960b-11e9-973e-b4d4916f1584.png">

This only happens for previously saved queries. This could be enhanced to support unsaved queries, but I'm not sure if that'd get to be annoying or not.