### PR TITLE
Use v4 UUID instead of v1 for query cacheKey

### DIFF
--- a/client/src/stores/queries.js
+++ b/client/src/stores/queries.js
@@ -21,7 +21,7 @@ export const NEW_QUERY = {
 };
 
 export const initialState = {
-  cacheKey: uuid.v1(),
+  cacheKey: uuid.v4(),
   isRunning: false,
   isSaving: false,
   queries: [],


### PR DESCRIPTION
I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of sqlpad.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found one occurrence where v1 UUIDs were being used instead of v4 UUIDs and I was wondering if this case really requires the semantically much more complex v1 UUIDs or whether we could live equally well with purely random v4 UUIDs?

I'd be really curious to understand the motivation for choosing v1 over v4 UUIDs in the first place, so any feedback on this would be highly appreciated!

@rickbergfalk, as far as I can tell from the git history you introduced this in https://github.com/rickbergfalk/sqlpad/commit/84aae812da4bfdcb30e5ce7103f2f8b9a2afd1af, I'd be really curious about your feedback!