### PR TITLE
Turn URLs in table columns into links

### DIFF
--- a/client/src/common/QueryResultDataTable.js
+++ b/client/src/common/QueryResultDataTable.js
@@ -18,6 +18,12 @@ const renderValue = (input, fieldMeta) => {
     return input.substring(0, 10);
   } else if (typeof input === 'object') {
     return JSON.stringify(input, null, 2);
+  } else if (typeof input === 'string' && input.match('^https?://')) {
+    return (
+      <a target="_blank" rel="noopener noreferrer" href={input}>
+        {input}
+      </a>
+    );
   } else {
     return input;
   }


### PR DESCRIPTION
This allows for easy linking to database entries in a different web interface.

FYI: We're running a [public SQLPad instance](https://vndb.org/d18) at VNDB.org with this patch applied. [Example of a common use case](https://query.vndb.org/query-table/bim26nb17M1UwjwR)