### PR TITLE
Define connections from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Env var: `WHITELISTED_DOMAINS`
 
 ### Connection configuration
 
-As of 3.2.0 (Work-in-progress) connections may be defined via application configuration.
+As of 3.2.0 connections may be defined via application configuration.
 
 Every connection defined should provide a `name` and `driver` value, with driver equaling the value in header parentheses below. `name` will be the label used in the UI to label the connection.
 

--- a/README.md
+++ b/README.md
@@ -263,15 +263,15 @@ How connections are defined in configuration depends on the source of the config
 
 #### Environment variable
 
-When using environment variables, connection field values must be provided using an environment variable with the convention `SQLPAD_CONNECTION__<connectionId>__<fieldName>`. Note double underscores between `SQLPAD_CONNECTION`, `<connectionId>`, and `<fieldName>`. Both connection ID and field name values are case sensitive. Boolean values should be the value `true` or `false`.
+When using environment variables, connection field values must be provided using an environment variable with the convention `SQLPAD_CONNECTIONS__<connectionId>__<fieldName>`. Note double underscores between `SQLPAD_CONNECTIONS`, `<connectionId>`, and `<fieldName>`. Both connection ID and field name values are case sensitive. Boolean values should be the value `true` or `false`.
 
 Example for a MySQL connection with id `prod123`.
 
 ```sh
-SQLPAD_CONNECTION__prod123__name="Production 123"
-SQLPAD_CONNECTION__prod123__driver=mysql
-SQLPAD_CONNECTION__prod123__host=localhost
-SQLPAD_CONNECTION__prod123__mysqlInsecureAuth=true
+SQLPAD_CONNECTIONS__prod123__name="Production 123"
+SQLPAD_CONNECTIONS__prod123__driver=mysql
+SQLPAD_CONNECTIONS__prod123__host=localhost
+SQLPAD_CONNECTIONS__prod123__mysqlInsecureAuth=true
 ```
 
 #### INI file

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Env var: `WHITELISTED_DOMAINS`
 
 ### Connection configuration
 
-As of 3.2.0 connections may be defined via application configuration.
+As of 3.2.0 (Work-in-progress) connections may be defined via application configuration.
 
 Every connection defined should provide a `name` and `driver` value, with driver equaling the value in header parentheses below. `name` will be the label used in the UI to label the connection.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ sqlpad --dbPath ../db --port 3010
 
 A docker image may be built using the Dockerfile located in `server` directory. See `docker-publish.sh` for example docker build command.
 
+## Development
+
+[Developer guide](DEVELOPER-GUIDE.md)
+
 ## Configuration
 
 SQLPad may be configured via environment variables, config file, or command line flags.
@@ -245,9 +249,242 @@ Default: `true`
 Allows pre-approval of email domains. Delimit multiple domains by empty space.  
 Env var: `WHITELISTED_DOMAINS`
 
-## Development
+### Connection configuration
 
-[Developer guide](DEVELOPER-GUIDE.md)
+As of 3.2.0 connections may be defined via application configuration.
+
+Every connection defined should provide a `name` and `driver` value, with driver equaling the value in header parentheses below. `name` will be the label used in the UI to label the connection.
+
+How connections are defined in configuration depends on the source of the configuration.
+
+#### Environment variable
+
+For all connections, the connection id value used can be any alphanumeric value, and is case-sensitive. This can be a randomly generated value like SQLPad's underlying embedded database uses, or it can be a more human-friendly name, or an id used from another source.
+
+When using environment variables, connection field values must be provided using an environment variable with the convention `SQLPAD_CONNECTION__<connectionId>__<fieldName>`. Note double underscores between `SQLPAD_CONNECTION`, `<connectionId>`, and `<fieldName>`. `<connectionId>` is case sensitive, and can be any alphanumeric value. `<fieldName>` is also case sensitive. Boolean values should be the string value `true` or `false`. For example, to set `mysqlInsecureAuth` for connection with an ID `prod123`, the environment variable would be `SQLPAD_CONNECTION__prod123__mysqlInsecureAuth=true`.
+
+#### INI file
+
+When defining a connection in an INI file, use section header with the value `connections.<connectionId>`.
+
+```ini
+[connections.prod123]
+host = localhost
+mysqlInsecureAuth = true
+```
+
+#### JSON file
+
+When using JSON file, provide `<connectionId>` as a key under `connections`.
+
+```json
+{
+  "connections": {
+    "prod123": {
+      "host": "localhost",
+      "mysqlInsecureAuth": true
+    }
+  }
+}
+```
+
+#### CrateDB (crate)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>crate</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+  </tbody>
+</table>
+
+#### Apache Drill (drill)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>drill</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>password</td><td>Database Password</td><td>text</td></tr>
+    <tr><td>drillDefaultSchema</td><td>Default Schema</td><td>text</td></tr>
+    <tr><td>ssl</td><td>Use SSL to connect to Drill</td><td>boolean</td></tr>
+  </tbody>
+</table>
+
+#### SAP Hana (hdb)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>hdb</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>hanaport</td><td>Port (e.g. 39015)</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>password</td><td>Database Password</td><td>text</td></tr>
+    <tr><td>hanadatabase</td><td>Tenant</td><td>text</td></tr>
+    <tr><td>hanaSchema</td><td>Schema (optional)</td><td>text</td></tr>
+  </tbody>
+</table>
+
+#### MySQL (mysql)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>mysql</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+    <tr><td>database</td><td>Database</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>password</td><td>Database Password</td><td>text</td></tr>
+    <tr><td>mysqlInsecureAuth</td><td>Use old/insecure pre 4.1 Auth System</td><td>boolean</td></tr>
+  </tbody>
+</table>
+
+#### PostgreSQL (postgres)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>postgres</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+    <tr><td>database</td><td>Database</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>password</td><td>Database Password</td><td>text</td></tr>
+    <tr><td>postgresSsl</td><td>Use SSL</td><td>boolean</td></tr>
+    <tr><td>postgresCert</td><td>Database Certificate Path</td><td>text</td></tr>
+    <tr><td>postgresKey</td><td>Database Key Path</td><td>text</td></tr>
+    <tr><td>postgresCA</td><td>Database CA Path</td><td>text</td></tr>
+    <tr><td>useSocks</td><td>Connect through SOCKS proxy</td><td>boolean</td></tr>
+    <tr><td>socksHost</td><td>Proxy hostname</td><td>text</td></tr>
+    <tr><td>socksPort</td><td>Proxy port</td><td>text</td></tr>
+    <tr><td>socksUsername</td><td>Username for socks proxy</td><td>text</td></tr>
+    <tr><td>socksPassword</td><td>Password for socks proxy</td><td>text</td></tr>
+  </tbody>
+</table>
+
+#### PrestoDB (presto)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>presto</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>prestoCatalog</td><td>Catalog</td><td>text</td></tr>
+    <tr><td>prestoSchema</td><td>Schema</td><td>text</td></tr>
+  </tbody>
+</table>
+
+#### MS SQL Server (sqlserver)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>sqlserver</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+    <tr><td>database</td><td>Database</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>password</td><td>Database Password</td><td>text</td></tr>
+    <tr><td>domain</td><td>Domain</td><td>text</td></tr>
+    <tr><td>sqlserverEncrypt</td><td>Encrypt (necessary for Azure)</td><td>boolean</td></tr>
+  </tbody>
+</table>
+
+#### Vertica (vertica)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>vertica</code></td><td>text</td></tr>
+    <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
+    <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
+    <tr><td>database</td><td>Database</td><td>text</td></tr>
+    <tr><td>username</td><td>Database Username</td><td>text</td></tr>
+    <tr><td>password</td><td>Database Password</td><td>text</td></tr>
+  </tbody>
+</table>
+
+#### Cassandra (cassandra)
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>data type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
+    <tr><td>driver</td><td>Must be <code>cassandra</code></td><td>text</td></tr>
+    <tr><td>contactPoints</td><td>Contact points (comma delimited)</td><td>text</td></tr>
+    <tr><td>localDataCenter</td><td>Local data center</td><td>text</td></tr>
+    <tr><td>keyspace</td><td>Keyspace</td><td>text</td></tr>
+  </tbody>
+</table>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -255,13 +255,24 @@ As of 3.2.0 (Work-in-progress) connections may be defined via application config
 
 Every connection defined should provide a `name` and `driver` value, with driver equaling the value in header parentheses below. `name` will be the label used in the UI to label the connection.
 
+Field names and values are case sensitive.
+
+The connection ID value used can be any alphanumeric value, and is case-sensitive. This can be a randomly generated value like SQLPad's underlying embedded database uses, or it can be a more human-friendly name, or an id used from another source.
+
 How connections are defined in configuration depends on the source of the configuration.
 
 #### Environment variable
 
-For all connections, the connection id value used can be any alphanumeric value, and is case-sensitive. This can be a randomly generated value like SQLPad's underlying embedded database uses, or it can be a more human-friendly name, or an id used from another source.
+When using environment variables, connection field values must be provided using an environment variable with the convention `SQLPAD_CONNECTION__<connectionId>__<fieldName>`. Note double underscores between `SQLPAD_CONNECTION`, `<connectionId>`, and `<fieldName>`. Both connection ID and field name values are case sensitive. Boolean values should be the value `true` or `false`.
 
-When using environment variables, connection field values must be provided using an environment variable with the convention `SQLPAD_CONNECTION__<connectionId>__<fieldName>`. Note double underscores between `SQLPAD_CONNECTION`, `<connectionId>`, and `<fieldName>`. `<connectionId>` is case sensitive, and can be any alphanumeric value. `<fieldName>` is also case sensitive. Boolean values should be the string value `true` or `false`. For example, to set `mysqlInsecureAuth` for connection with an ID `prod123`, the environment variable would be `SQLPAD_CONNECTION__prod123__mysqlInsecureAuth=true`.
+Example for a MySQL connection with id `prod123`.
+
+```sh
+SQLPAD_CONNECTION__prod123__name="Production 123"
+SQLPAD_CONNECTION__prod123__driver=mysql
+SQLPAD_CONNECTION__prod123__host=localhost
+SQLPAD_CONNECTION__prod123__mysqlInsecureAuth=true
+```
 
 #### INI file
 
@@ -269,6 +280,8 @@ When defining a connection in an INI file, use section header with the value `co
 
 ```ini
 [connections.prod123]
+name = Production 123
+driver = mysql
 host = localhost
 mysqlInsecureAuth = true
 ```
@@ -281,6 +294,8 @@ When using JSON file, provide `<connectionId>` as a key under `connections`.
 {
   "connections": {
     "prod123": {
+      "name": "Production 123",
+      "driver": "mysql",
       "host": "localhost",
       "mysqlInsecureAuth": true
     }

--- a/client/src/connections/ConnectionList.js
+++ b/client/src/connections/ConnectionList.js
@@ -101,6 +101,7 @@ function ConnectionList({
           actions.push(
             <Button
               key="edit"
+              disabled={!item.editable}
               style={{ marginLeft: 8 }}
               onClick={() => editConnection(item)}
             >
@@ -110,6 +111,7 @@ function ConnectionList({
           actions.push(
             <DeleteConfirmButton
               key="delete"
+              disabled={!item.editable}
               confirmMessage="Delete connection?"
               onConfirm={e => deleteConnection(item._id)}
               style={{ marginLeft: 8 }}

--- a/client/src/connections/ConnectionList.js
+++ b/client/src/connections/ConnectionList.js
@@ -97,11 +97,10 @@ function ConnectionList({
 
         const actions = [];
 
-        if (currentUser.role === 'admin') {
+        if (currentUser.role === 'admin' && item.editable) {
           actions.push(
             <Button
               key="edit"
-              disabled={!item.editable}
               style={{ marginLeft: 8 }}
               onClick={() => editConnection(item)}
             >
@@ -111,7 +110,6 @@ function ConnectionList({
           actions.push(
             <DeleteConfirmButton
               key="delete"
-              disabled={!item.editable}
               confirmMessage="Delete connection?"
               onConfirm={e => deleteConnection(item._id)}
               style={{ marginLeft: 8 }}

--- a/server/config.dev.ini
+++ b/server/config.dev.ini
@@ -1,0 +1,7 @@
+; INI config file that defines some connections for development purposes
+
+[connections.devdbdriverid123]
+driver = mock
+name = mock connection from ini
+host = mock-host
+useSsl = true

--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -6,11 +6,10 @@ const fromFile = require('./fromFile');
 const getOldConfigWarning = require('./getOldConfigWarning');
 
 const argv = minimist(process.argv.slice(2));
-const configFilePath = argv.config || process.env.SQLPAD_CONFIG;
 
 const defaultConfig = fromDefault();
 const envConfig = fromEnv();
-const [fileConfig, warnings] = fromFile(configFilePath);
+const [fileConfig, warnings] = fromFile();
 const cliConfig = fromCli(argv);
 
 // Old files might have some values no longer recognized

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -88,14 +88,13 @@ function decipherConnection(connection) {
 
 async function findAll() {
   let connectionsFromDb = await db.connections.find({});
-  connectionsFromDb = _.sortBy(connectionsFromDb, c => c.name.toLowerCase())
-    .map(conn => decipherConnection(conn))
-    .map(conn => {
-      conn.editable = true;
-      return conn;
-    });
+  connectionsFromDb = connectionsFromDb.map(conn => {
+    conn.editable = true;
+    return decipherConnection(conn);
+  });
 
-  return connectionsFromDb.concat(getConnectionsFromConfig());
+  const allConnections = connectionsFromDb.concat(getConnectionsFromConfig());
+  return _.sortBy(allConnections, c => c.name.toLowerCase());
 }
 
 async function findOneById(id) {

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -22,7 +22,7 @@ const decipher = require('../lib/decipher');
  * @param {object} env
  * @returns {array<object>} arrayOfConnections
  */
-function getConnectionsFromEnv(env = process.env) {
+function getConnectionsFromConfig(env = process.env) {
   const connectionMap = Object.keys(env)
     .filter(key => key.startsWith('SQLPAD_CONNECTION__'))
     .reduce((connectionsMap, envVar) => {
@@ -72,7 +72,7 @@ async function findAll() {
       return conn;
     });
 
-  return connectionsFromDb.concat(getConnectionsFromEnv());
+  return connectionsFromDb.concat(getConnectionsFromConfig());
 }
 
 async function findOneById(id) {
@@ -83,7 +83,7 @@ async function findOneById(id) {
   }
 
   // If connection was not found in db try env
-  const connectionFromEnv = getConnectionsFromEnv().find(
+  const connectionFromEnv = getConnectionsFromConfig().find(
     connection => connection._id === id
   );
 
@@ -123,5 +123,5 @@ module.exports = {
   findOneById,
   removeOneById,
   save,
-  getConnectionsFromEnv
+  getConnectionsFromConfig
 };

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -12,7 +12,7 @@ const [configFromFile] = getConfigFromFile() || {};
  *
  * For environment variables:
  * connection env vars must follow the format:
- * SQLPAD_CONNECTION__<connectionId>__<connectionFieldName>
+ * SQLPAD_CONNECTIONS__<connectionId>__<connectionFieldName>
  *
  * <connectionId> can be any value to associate a grouping a fields to a connection instance
  * If supplying a connection that was previously defined in the nedb database,
@@ -23,7 +23,7 @@ const [configFromFile] = getConfigFromFile() || {};
  * To define connections via envvars, `driver` field should be supplied.
  * _id field is not required, as it is defined in second env var fragment.
  *
- * Example: SQLPAD_CONNECTION__ab123__sqlserverEncrypt=""
+ * Example: SQLPAD_CONNECTIONS__ab123__sqlserverEncrypt=""
  *
  * From file, resulting parsed configuration from file is expected to follow format `connections.<id>.<fieldname>`
  * {
@@ -40,7 +40,7 @@ const [configFromFile] = getConfigFromFile() || {};
 function getConnectionsFromConfig(env = process.env) {
   // Create a map of connections from parsing environment variable
   const connectionsMapFromEnv = Object.keys(env)
-    .filter(key => key.startsWith('SQLPAD_CONNECTION__'))
+    .filter(key => key.startsWith('SQLPAD_CONNECTIONS__'))
     .reduce((connectionsMap, envVar) => {
       // eslint-disable-next-line no-unused-vars
       const [prefix, id, field] = envVar.split('__');

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -5,7 +5,7 @@ const cipher = require('../lib/cipher.js');
 const decipher = require('../lib/decipher');
 const getConfigFromFile = require('../lib/config/fromFile.js');
 
-const configFromFile = getConfigFromFile() || {};
+const [configFromFile] = getConfigFromFile() || {};
 
 /**
  * Get connections from config.

--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "prepublishOnly": "cd .. && ./scripts/build.sh",
-    "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad",
+    "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini'",
     "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_TEST='true' mocha test --timeout 10000 --recursive --exit",
     "fixlint": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"

--- a/server/test/models/connections.js
+++ b/server/test/models/connections.js
@@ -1,14 +1,14 @@
 const assert = require('assert');
 const connections = require('../../models/connections.js');
 
-describe('getConnectionsFromEnv', function() {
+describe('getConnectionsFromConfig', function() {
   it('handles empty object', function() {
-    const cs = connections.getConnectionsFromEnv({});
+    const cs = connections.getConnectionsFromConfig({});
     assert(Array.isArray(cs));
   });
 
   it('skips partial connections', function() {
-    const cs = connections.getConnectionsFromEnv({
+    const cs = connections.getConnectionsFromConfig({
       SQLPAD_CONNECTION__abc__driver: 'postgres'
     });
     assert(Array.isArray(cs));
@@ -16,7 +16,7 @@ describe('getConnectionsFromEnv', function() {
   });
 
   it('parses connection properly', function() {
-    const cs = connections.getConnectionsFromEnv({
+    const cs = connections.getConnectionsFromConfig({
       SQLPAD_CONNECTION__abc__driver: 'postgres',
       SQLPAD_CONNECTION__abc__name: 'env-postgres',
       SQLPAD_CONNECTION__abc__host: 'localhost',

--- a/server/test/models/connections.js
+++ b/server/test/models/connections.js
@@ -1,0 +1,74 @@
+const assert = require('assert');
+const connections = require('../../models/connections.js');
+
+describe('getConnectionsFromEnv', function() {
+  it('handles empty object', function() {
+    const cs = connections.getConnectionsFromEnv({});
+    assert(Array.isArray(cs));
+  });
+
+  it('skips partial connections', function() {
+    const cs = connections.getConnectionsFromEnv({
+      SQLPAD_CONNECTION__abc__driver: 'postgres'
+    });
+    assert(Array.isArray(cs));
+    assert.equal(cs.length, 0, 'c should be empty');
+  });
+
+  it('parses connection properly', function() {
+    const cs = connections.getConnectionsFromEnv({
+      SQLPAD_CONNECTION__abc__driver: 'postgres',
+      SQLPAD_CONNECTION__abc__name: 'env-postgres',
+      SQLPAD_CONNECTION__abc__host: 'localhost',
+      SQLPAD_CONNECTION__abc__port: '5432',
+      SQLPAD_CONNECTION__abc__postgresSsl: 'true'
+    });
+    assert(Array.isArray(cs));
+    assert.equal(cs.length, 1, 'cs should have 1');
+    const connection = cs[0];
+    assert.strictEqual(connection.editable, false, 'connection.editable');
+    assert.strictEqual(connection._id, 'abc', 'connection._id');
+    assert.strictEqual(connection.driver, 'postgres', 'connection.driver');
+    assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
+    assert.strictEqual(connection.host, 'localhost', 'connection.host');
+    assert.strictEqual(connection.port, '5432', 'connection.port');
+    assert.strictEqual(connection.postgresSsl, true, 'connection.postgresSsl');
+  });
+
+  it('includes env connection in all connections', async function() {
+    process.env.SQLPAD_CONNECTION__abc__driver = 'postgres';
+    process.env.SQLPAD_CONNECTION__abc__name = 'env-postgres';
+    process.env.SQLPAD_CONNECTION__abc__host = 'localhost';
+    process.env.SQLPAD_CONNECTION__abc__port = '5432';
+    process.env.SQLPAD_CONNECTION__abc__postgresSsl = 'true';
+
+    const allConnections = await connections.findAll();
+    const connection = allConnections.find(c => c._id === 'abc');
+    assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
+    assert.strictEqual(connection.editable, false, 'connection.editable');
+
+    delete process.env.SQLPAD_CONNECTION__abc__driver;
+    delete process.env.SQLPAD_CONNECTION__abc__name;
+    delete process.env.SQLPAD_CONNECTION__abc__host;
+    delete process.env.SQLPAD_CONNECTION__abc__port;
+    delete process.env.SQLPAD_CONNECTION__abc__postgresSsl;
+  });
+
+  it('includes env connection by id', async function() {
+    process.env.SQLPAD_CONNECTION__abc__driver = 'postgres';
+    process.env.SQLPAD_CONNECTION__abc__name = 'env-postgres';
+    process.env.SQLPAD_CONNECTION__abc__host = 'localhost';
+    process.env.SQLPAD_CONNECTION__abc__port = '5432';
+    process.env.SQLPAD_CONNECTION__abc__postgresSsl = 'true';
+
+    const connection = await connections.findOneById('abc');
+    assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
+    assert.strictEqual(connection.editable, false, 'connection.editable');
+
+    delete process.env.SQLPAD_CONNECTION__abc__driver;
+    delete process.env.SQLPAD_CONNECTION__abc__name;
+    delete process.env.SQLPAD_CONNECTION__abc__host;
+    delete process.env.SQLPAD_CONNECTION__abc__port;
+    delete process.env.SQLPAD_CONNECTION__abc__postgresSsl;
+  });
+});

--- a/server/test/models/connections.js
+++ b/server/test/models/connections.js
@@ -9,7 +9,7 @@ describe('getConnectionsFromConfig', function() {
 
   it('skips partial connections', function() {
     const cs = connections.getConnectionsFromConfig({
-      SQLPAD_CONNECTION__abc__driver: 'postgres'
+      SQLPAD_CONNECTIONS__abc__driver: 'postgres'
     });
     assert(Array.isArray(cs));
     assert.equal(cs.length, 0, 'c should be empty');
@@ -17,11 +17,11 @@ describe('getConnectionsFromConfig', function() {
 
   it('parses connection properly', function() {
     const cs = connections.getConnectionsFromConfig({
-      SQLPAD_CONNECTION__abc__driver: 'postgres',
-      SQLPAD_CONNECTION__abc__name: 'env-postgres',
-      SQLPAD_CONNECTION__abc__host: 'localhost',
-      SQLPAD_CONNECTION__abc__port: '5432',
-      SQLPAD_CONNECTION__abc__postgresSsl: 'true'
+      SQLPAD_CONNECTIONS__abc__driver: 'postgres',
+      SQLPAD_CONNECTIONS__abc__name: 'env-postgres',
+      SQLPAD_CONNECTIONS__abc__host: 'localhost',
+      SQLPAD_CONNECTIONS__abc__port: '5432',
+      SQLPAD_CONNECTIONS__abc__postgresSsl: 'true'
     });
     assert(Array.isArray(cs));
     assert.equal(cs.length, 1, 'cs should have 1');
@@ -36,39 +36,39 @@ describe('getConnectionsFromConfig', function() {
   });
 
   it('includes env connection in all connections', async function() {
-    process.env.SQLPAD_CONNECTION__abc__driver = 'postgres';
-    process.env.SQLPAD_CONNECTION__abc__name = 'env-postgres';
-    process.env.SQLPAD_CONNECTION__abc__host = 'localhost';
-    process.env.SQLPAD_CONNECTION__abc__port = '5432';
-    process.env.SQLPAD_CONNECTION__abc__postgresSsl = 'true';
+    process.env.SQLPAD_CONNECTIONS__abc__driver = 'postgres';
+    process.env.SQLPAD_CONNECTIONS__abc__name = 'env-postgres';
+    process.env.SQLPAD_CONNECTIONS__abc__host = 'localhost';
+    process.env.SQLPAD_CONNECTIONS__abc__port = '5432';
+    process.env.SQLPAD_CONNECTIONS__abc__postgresSsl = 'true';
 
     const allConnections = await connections.findAll();
     const connection = allConnections.find(c => c._id === 'abc');
     assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
     assert.strictEqual(connection.editable, false, 'connection.editable');
 
-    delete process.env.SQLPAD_CONNECTION__abc__driver;
-    delete process.env.SQLPAD_CONNECTION__abc__name;
-    delete process.env.SQLPAD_CONNECTION__abc__host;
-    delete process.env.SQLPAD_CONNECTION__abc__port;
-    delete process.env.SQLPAD_CONNECTION__abc__postgresSsl;
+    delete process.env.SQLPAD_CONNECTIONS__abc__driver;
+    delete process.env.SQLPAD_CONNECTIONS__abc__name;
+    delete process.env.SQLPAD_CONNECTIONS__abc__host;
+    delete process.env.SQLPAD_CONNECTIONS__abc__port;
+    delete process.env.SQLPAD_CONNECTIONS__abc__postgresSsl;
   });
 
   it('includes env connection by id', async function() {
-    process.env.SQLPAD_CONNECTION__abc__driver = 'postgres';
-    process.env.SQLPAD_CONNECTION__abc__name = 'env-postgres';
-    process.env.SQLPAD_CONNECTION__abc__host = 'localhost';
-    process.env.SQLPAD_CONNECTION__abc__port = '5432';
-    process.env.SQLPAD_CONNECTION__abc__postgresSsl = 'true';
+    process.env.SQLPAD_CONNECTIONS__abc__driver = 'postgres';
+    process.env.SQLPAD_CONNECTIONS__abc__name = 'env-postgres';
+    process.env.SQLPAD_CONNECTIONS__abc__host = 'localhost';
+    process.env.SQLPAD_CONNECTIONS__abc__port = '5432';
+    process.env.SQLPAD_CONNECTIONS__abc__postgresSsl = 'true';
 
     const connection = await connections.findOneById('abc');
     assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
     assert.strictEqual(connection.editable, false, 'connection.editable');
 
-    delete process.env.SQLPAD_CONNECTION__abc__driver;
-    delete process.env.SQLPAD_CONNECTION__abc__name;
-    delete process.env.SQLPAD_CONNECTION__abc__host;
-    delete process.env.SQLPAD_CONNECTION__abc__port;
-    delete process.env.SQLPAD_CONNECTION__abc__postgresSsl;
+    delete process.env.SQLPAD_CONNECTIONS__abc__driver;
+    delete process.env.SQLPAD_CONNECTIONS__abc__name;
+    delete process.env.SQLPAD_CONNECTIONS__abc__host;
+    delete process.env.SQLPAD_CONNECTIONS__abc__port;
+    delete process.env.SQLPAD_CONNECTIONS__abc__postgresSsl;
   });
 });


### PR DESCRIPTION
Adds support for defining connections via configuration. Supported configuration methods include env var, ini, or json file. 