### PR TITLE
Add server timeout seconds setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ When false, table and chart result links will be operational without login.
 Env var: `SQLPAD_TABLE_CHART_LINKS_REQUIRE_AUTH`  
 Default: `true`
 
+**timeoutSeconds**  
+HTTP server timeout as number of seconds. Extend as necessary for long running queries.
+Env var: `SQLPAD_TIMEOUT_SECONDS`  
+Default: `300`
+
 **whitelistedDomains**  
 Allows pre-approval of email domains. Delimit multiple domains by empty space.  
 Env var: `WHITELISTED_DOMAINS`

--- a/config-example.ini
+++ b/config-example.ini
@@ -106,6 +106,9 @@ systemdSocket="false"
 ; When false, table and chart result links will be operational without login.
 tableChartLinksRequireAuth="true"
 
+; HTTP server timeout as number of seconds. Extend as necessary for long running queries
+timeoutSeconds=300
+
 ; Allows pre-approval of email domains. Delimit multiple domains by empty space.
 whitelistedDomains=""
 

--- a/config-example.json
+++ b/config-example.json
@@ -35,5 +35,6 @@
   "smtpUser": "",
   "systemdSocket": false,
   "tableChartLinksRequireAuth": true,
+  "timeoutSeconds": 300,
   "whitelistedDomains": ""
 }

--- a/server/lib/config/configItems.js
+++ b/server/lib/config/configItems.js
@@ -20,6 +20,11 @@ const configItems = [
     default: 60
   },
   {
+    key: 'timeoutSeconds',
+    envVar: 'SQLPAD_TIMEOUT_SECONDS',
+    default: 300
+  },
+  {
     key: 'ip',
     envVar: 'SQLPAD_IP',
     default: '0.0.0.0'

--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,7 @@ const certPassphrase = config.get('certPassphrase');
 const keyPath = config.get('keyPath');
 const certPath = config.get('certPath');
 const systemdSocket = config.get('systemdSocket');
+const timeoutSeconds = config.get('timeoutSeconds');
 
 const db = require('./lib/db');
 
@@ -110,6 +111,7 @@ async function startServer() {
       console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`);
     });
   }
+  server.setTimeout(timeoutSeconds * 1000);
 }
 
 db.loadPromise.then(startServer).catch(error => {


### PR DESCRIPTION
Adds configuration option to extend http timeout for node.js http server, which defaults to 2 minutes. The new configuration option sets the default to 5 minutes. 

This can be extended to a larger amount to support longer-running queries.

Fixes #155 in that it provides a configurable timeout. Cancellation would be a much better option but that would require significant changes to the driver APIs.