### PR TITLE
Adding MultiSubnetFailover option for SQL Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ When using JSON file, provide `<connectionId>` as a key under `connections`.
     <tr><td>password</td><td>Database Password</td><td>text</td></tr>
     <tr><td>domain</td><td>Domain</td><td>text</td></tr>
     <tr><td>sqlserverEncrypt</td><td>Encrypt (necessary for Azure)</td><td>boolean</td></tr>
+    <tr><td>sqlserverMultiSubnetFailover</td><td>MultiSubnetFailover</td><td>boolean</td></tr>
   </tbody>
 </table>
 

--- a/server/drivers/sqlserver/index.js
+++ b/server/drivers/sqlserver/index.js
@@ -39,7 +39,8 @@ function runQuery(query, connection) {
     requestTimeout: 1000 * 60 * 60,
     options: {
       appName: 'SQLPad',
-      encrypt: Boolean(connection.sqlserverEncrypt)
+      encrypt: Boolean(connection.sqlserverEncrypt),
+      multiSubnetFailover: connection.sqlserverMultiSubnetFailover
     },
     pool: {
       max: 1,
@@ -158,6 +159,11 @@ const fields = [
     key: 'sqlserverEncrypt',
     formType: 'CHECKBOX',
     label: 'Encrypt (necessary for Azure)'
+  },
+  {
+    key: 'sqlserverMultiSubnetFailover',
+    formType: 'CHECKBOX',
+    label: 'MultiSubnetFailover'
   }
 ];
 


### PR DESCRIPTION
This adds support for the MultiSubnetFailover connection option that allows connections to an AlwaysOn SQL Server cluster.