### PR TITLE
Wait for admin password to get hashed before persist it to db

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -59,7 +59,7 @@ async function ensureAdmin() {
     if (user) {
       const changes = { role: 'admin' };
       if (adminPassword) {
-        changes.passhash = passhash.getPasshash(adminPassword);
+        changes.passhash = await passhash.getPasshash(adminPassword);
       }
       await db.users.update({ _id: user._id }, { $set: changes }, {});
       console.log(adminEmail + ' should now have admin access.');


### PR DESCRIPTION
Good afternoon,

When configuring the setup of an admin user for the first time using `SQLPAD_ADMIN` and `SQLPAD_ADMIN_PASSWORD`, it was not working for me. After some debugging I realised the password was never getting to db; the method `passhash.getPasshash` is a Promise and was not resolved in time for me before persisting the new admin user to db. Here is a fix that works fine for me... I find it very rare that was even working for anybody.

Happy to contribute and thanks for the project!

Regards,
Javi