### PR TITLE
Remove whitespace at start of lines, add type hint

### DIFF
--- a/server/lib/pushQueryToSlack.js
+++ b/server/lib/pushQueryToSlack.js
@@ -13,10 +13,10 @@ function pushQueryToSlack(query) {
         text: `New Query <${PUBLIC_URL}${BASE_URL}/queries/${query._id}|${
           query.name
         }> 
-            saved by ${query.modifiedBy} on SQLPad 
-            ${'```'}
-            ${query.queryText}
-            ${'```'}`
+saved by ${query.modifiedBy} on SQLPad 
+${'```sql'}
+${query.queryText}
+${'```'}`
       },
       json: true,
       url: SLACK_WEBHOOK


### PR DESCRIPTION
When posting to anything else than Slack (haven't actually tested Slack), e.g. Mattermost, the leading whitespace makes output render funkily. Also, allow highlighting by specifying language. Minor cosmetic fix, but major usability improvement.