### PR TITLE
Wait for admin password to get hashed before persist (new admin)

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -71,7 +71,7 @@ async function ensureAdmin() {
       role: 'admin'
     };
     if (adminPassword) {
-      newAdmin.passhash = passhash.getPasshash(adminPassword);
+      newAdmin.passhash = await passhash.getPasshash(adminPassword);
     }
     await db.users.insert(newAdmin);
     console.log(`\n${adminEmail} has been whitelisted with admin access.`);


### PR DESCRIPTION
Similar to #487 `await` is also needed a few lines below where default admin password is hashed for a new admin.