### PR TITLE
Set shell script interpreter to bash instead of sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 SQLPAD_CLIENT_DIR=$(pwd)/client
 SQLPAD_SERVER_DIR=$(pwd)/server
 SCRIPTS_DIR=$(pwd)/scripts

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH" != "master" ]]; then


### PR DESCRIPTION
On many systems sh points to bash. In that case the scripts work fine. However, double square brackets won't necessarily work when sh does not point to bash but to a POSIX sh. This commit changes the interpreter to bash. Alternatively, one can change the double square brackets to single square brackets to achieve portability.

Fixes #495.