### PR TITLE
Fixed issue when mysql query returns zero row

### DIFF
--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -61,11 +61,11 @@ function runQuery(query, connection) {
   }
 
   return new Promise((resolve, reject) => {
-    const connection = mysql.createConnection(myConfig);
+    const myConnection = mysql.createConnection(myConfig);
     let incomplete = false;
     const rows = [];
 
-    connection.connect(err => {
+    myConnection.connect(err => {
       if (err) {
         return reject(err);
       }
@@ -82,7 +82,7 @@ function runQuery(query, connection) {
         }
       }
 
-      const myQuery = connection.query(query);
+      const myQuery = myConnection.query(query);
       myQuery
         .on('error', function(err) {
           // Handle error,
@@ -100,11 +100,11 @@ function runQuery(query, connection) {
           incomplete = true;
 
           // Stop the query stream
-          connection.pause();
+          myConnection.pause();
 
           // Destroy the underlying connection
           // Calling end() will wait and eventually time out
-          connection.destroy();
+          myConnection.destroy();
           continueOn();
         })
         .on('end', function() {
@@ -112,7 +112,7 @@ function runQuery(query, connection) {
           // This will not fire if we end the connection early
           // myConnection.end()
           // myConnection.destroy()
-          connection.end(error => {
+          myConnection.end(error => {
             if (error) {
               console.error('Error ending MySQL connection', error);
             }


### PR DESCRIPTION
**Problem**

MySQL/MariaDB queries return zero rows since SSL support added to the driver by https://github.com/rickbergfalk/sqlpad/commit/370daf6b57fc9735b00a56b1aa1e80b1f898ca27

This PR fixing it.

**Reason**

The SqlPad connection object overwritten by the MySQL connection object [here](https://github.com/rickbergfalk/sqlpad/blob/a9982c772c840cdc35af512d5f278c3f8d54afc8/server/drivers/mysql/index.js#L64) but both object required to run queries. The code [here](https://github.com/rickbergfalk/sqlpad/blob/a9982c772c840cdc35af512d5f278c3f8d54afc8/server/drivers/mysql/index.js#L95) requires the SqlPad `connection` object but it's referring to the MySQL `connection` object where `connection.maxRows` is undefined so no rows added to the results array.

```
if (rows.length < connection.maxRows) {
  return rows.push(row);
}
```
