### PR TITLE
Let decipher errors bubble up

### DIFF
--- a/server/lib/decipher.js
+++ b/server/lib/decipher.js
@@ -8,13 +8,6 @@ const passphrase = config.get('passphrase');
  * @returns {string} deciphered value
  */
 module.exports = function decipher(gibberish) {
-  let returnValue = '';
-  try {
-    const myDecipher = crypto.createDecipher(algorithm, passphrase);
-    returnValue =
-      myDecipher.update(gibberish, 'hex', 'utf8') + myDecipher.final('utf8');
-  } catch (e) {
-    console.error(e);
-  }
-  return returnValue;
+  const myDecipher = crypto.createDecipher(algorithm, passphrase);
+  return myDecipher.update(gibberish, 'hex', 'utf8') + myDecipher.final('utf8');
 };


### PR DESCRIPTION
Today decipher attempts to decrypt the encrypted value, and if a failure occurs for some reason, returns empty string. 

This is problematic in that it covers up a potential configuration issue, disguising it as something else (like potentially #475)