### PR TITLE
Fix connection and user invite forms

### DIFF
--- a/client/src/common/Button.js
+++ b/client/src/common/Button.js
@@ -21,6 +21,7 @@ const Button = React.forwardRef(
       classNames.push(className);
     }
 
+    // TODO change type prop to variant, htmlType to type
     const button = (
       <button
         ref={ref}

--- a/client/src/common/message.module.css
+++ b/client/src/common/message.module.css
@@ -8,6 +8,7 @@
   top: 16px;
   right: 16px;
   width: 200px;
+  z-index: 9001 !important;
 }
 
 .error {

--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -64,7 +64,10 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
     setTestSuccess(json.error ? false : true);
   };
 
-  const saveConnection = async () => {
+  const saveConnection = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (saving) {
       return;
     }
@@ -146,7 +149,7 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
                   setConnectionValue(e.target.name, e.target.checked)
                 }
               />
-              <label for={field.key} style={{ marginLeft: 8 }}>
+              <label htmlFor={field.key} style={{ marginLeft: 8 }}>
                 {field.label}
               </label>
             </HorizontalFormItem>
@@ -182,6 +185,7 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
   return (
     <div style={{ height: '100%' }}>
       <form
+        onSubmit={saveConnection}
         autoComplete="off"
         style={{
           display: 'flex',
@@ -221,6 +225,7 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
           }}
         >
           <Button
+            htmlType="submit"
             style={{ width: 120 }}
             type="primary"
             onClick={saveConnection}

--- a/client/src/users/InviteUserForm.js
+++ b/client/src/users/InviteUserForm.js
@@ -13,7 +13,9 @@ function InviteUserForm({ onInvited }) {
   const [role, setRole] = useState(null);
   const [isInviting, setIsInviting] = useState(null);
 
-  const onInviteClick = async e => {
+  const onInviteClick = async event => {
+    event.preventDefault();
+    event.stopPropagation();
     const user = {
       email,
       role
@@ -22,7 +24,8 @@ function InviteUserForm({ onInvited }) {
     const json = await fetchJson('POST', '/api/users', user);
     setIsInviting(false);
     if (json.error) {
-      return message.error('Whitelist failed: ' + json.error.toString());
+      message.error('Add user failed: ' + json.error.toString());
+      return false;
     }
     setEmail(null);
     setRole(null);
@@ -36,7 +39,7 @@ function InviteUserForm({ onInvited }) {
         them to continue the sign-up process on the{' '}
         <Link to={'/signup'}>signup page</Link>.
       </p>
-      <form>
+      <form onSubmit={onInviteClick}>
         <label>
           Email
           <Input
@@ -69,6 +72,7 @@ function InviteUserForm({ onInvited }) {
         <Spacer size={3} />
         <div>
           <Button
+            htmlType="submit"
             className="w-100"
             type="primary"
             onClick={onInviteClick}


### PR DESCRIPTION
The connection and invite user forms are wrapped in a `form` element without an `onSubmit` handler or `submit` button. This causes issues in some browsers. 

This PR adds onSubmit handlers and submit buttons to address the behaviors.

This PR also fixes the toast message z-index. On user add error the message is hidden behind the drawer/overlay.

Fixes #503 #486 