### PR TITLE
Add Pre-query statements options to MySQL driver

### DIFF
--- a/client/src/common/TextArea.js
+++ b/client/src/common/TextArea.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from './TextArea.module.css';
+
+export default function TextArea({ children, error, className, ...rest }) {
+  const classNames = [styles.textarea];
+
+  if (error) {
+    classNames.push(styles.danger);
+  }
+
+  if (className) {
+    classNames.push(className);
+  }
+
+  return (
+    <textarea className={classNames.join(' ')} {...rest}>
+      {children}
+    </textarea>
+  );
+}

--- a/client/src/common/TextArea.module.css
+++ b/client/src/common/TextArea.module.css
@@ -1,0 +1,57 @@
+.textarea {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-variant: tabular-nums;
+  list-style: none;
+  font-feature-settings: 'tnum';
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  height: 10em;
+  padding: 4px 11px;
+  color: rgba(0, 0, 0, 0.65);
+  font-size: 14px;
+  line-height: 1.5;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #d9d9d9;
+  border-radius: 2px;
+}
+
+.textarea:focus {
+  border: 2px solid var(--primary-color);
+  /* padding adjustment prevents added border from shifting text */
+  padding-left: 10px;
+  padding-right: 10px;
+  outline: 0;
+}
+
+.textarea:hover {
+  border: 2px solid var(--primary-color);
+  /* padding adjustment prevents added border from shifting text */
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.textarea::placeholder {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.danger {
+  border-color: var(--secondary-color);
+  box-shadow: inset 0 1px 1px var(--secondary-color-30);
+}
+
+.danger:focus {
+  border: 2px solid var(--secondary-color);
+  outline: 0;
+}
+
+.danger:hover {
+  border-color: var(--secondary-color);
+}
+
+.danger::placeholder {
+  color: var(--secondary-color);
+}

--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import Button from '../common/Button';
 import HorizontalFormItem from '../common/HorizontalFormItem.js';
 import Input from '../common/Input';
+import TextArea from '../common/TextArea';
 import message from '../common/message';
 import Select from '../common/Select';
 import fetchJson from '../utilities/fetch-json.js';
@@ -11,6 +12,7 @@ import fetchJson from '../utilities/fetch-json.js';
 const TEXT = 'TEXT';
 const PASSWORD = 'PASSWORD';
 const CHECKBOX = 'CHECKBOX';
+const TEXTAREA = 'TEXTAREA';
 
 function ConnectionForm({ connectionId, onConnectionSaved }) {
   const [connectionEdits, setConnectionEdits] = useState({});
@@ -152,6 +154,21 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
               <label htmlFor={field.key} style={{ marginLeft: 8 }}>
                 {field.label}
               </label>
+            </HorizontalFormItem>
+          );
+        } else if (field.formType === TEXTAREA) {
+          const value = connectionEdits[field.key] || '';
+          return (
+            <HorizontalFormItem key={field.key} label={field.label}>
+              <TextArea
+                name={field.key}
+                value={value}
+                cols={45}
+                placeholder={field.placeholder}
+                onChange={e =>
+                  setConnectionValue(e.target.name, e.target.value)
+                }
+              />
             </HorizontalFormItem>
           );
         }


### PR DESCRIPTION
**Summary**

This PR adds optional **Pre-query statements** option to MySQL driver. This is one ore more SQL queries that run before the actual query but in the same session.  This is useful to enforce some session variables whenever it's required. Typical use-case is to avoid long running queries from SQLPad by setting session variables (ie. `SET max_statement_time = x`) before running the queries. 

Additionally added **Deny multiple statements queries** option to avoid to overwrite pre-query statements by running multi-statements queries from the UI. 

**Connection form with new items**
<img width="545" alt="Screenshot 2020-01-04 at 14 30 36" src="https://user-images.githubusercontent.com/643687/71767017-d8acde00-2efe-11ea-8a21-05aaf9ad3b5e.png">
