### PR TITLE
Add snowflake driver

### DIFF
--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -96,6 +96,7 @@ requireValidate('../drivers/sqlserver');
 requireValidate('../drivers/unixodbc', true);
 requireValidate('../drivers/vertica');
 requireValidate('../drivers/cassandra');
+requireValidate('../drivers/snowflake');
 
 if (debug || process.env.SQLPAD_TEST === 'true') {
   requireValidate('../drivers/mock');

--- a/server/drivers/snowflake/index.js
+++ b/server/drivers/snowflake/index.js
@@ -1,0 +1,225 @@
+const snowflake = require('snowflake-sdk');
+const { formatSchemaQueryResults } = require('../utils');
+
+const id = 'snowflake';
+const name = 'Snowflake';
+
+function getSchemaSql(schema) {
+  const whereSql = schema
+    ? `WHERE t.table_schema = UPPER('${schema}')`
+    : `WHERE t.table_schema NOT IN (
+        'information_schema'
+      )`;
+  return `
+    SELECT 
+      t.table_schema, 
+      t.table_name, 
+      c.column_name, 
+      c.data_type
+    FROM 
+      INFORMATION_SCHEMA.TABLES t 
+      JOIN INFORMATION_SCHEMA.COLUMNS c
+        ON t.table_catalog = c.table_catalog AND t.table_schema = c.table_schema AND t.table_name = c.table_name 
+    ${whereSql}
+    ORDER BY 
+      t.table_schema, 
+      t.table_name, 
+      c.ordinal_position
+  `;
+}
+
+/**
+ * Run query for connection
+ * Should return { rows, incomplete }
+ * @param {string} query
+ * @param {object} connection
+ */
+function runQuery(query, connection) {
+  const sfConfig = {
+    account: connection.account,
+    username: connection.username,
+    password: connection.password,
+    warehouse: connection.warehouse,
+    database: connection.database,
+    schema: connection.schema,
+    preQueryStatements: connection.preQueryStatements
+  };
+
+  let incomplete;
+  const rows = [];
+
+  return new Promise((resolve, reject) => {
+    const sfConnection = snowflake.createConnection(sfConfig);
+    let preQueryCompletes = 0;
+
+    sfConnection.connect(err => {
+      if (err) {
+        return reject(err);
+      }
+      let queryError;
+      let resultsSent = false;
+
+      function continueOn(onFinished = () => {}) {
+        if (!resultsSent) {
+          if (queryError) {
+            resultsSent = true;
+            return reject(queryError);
+          }
+          onFinished();
+        }
+      }
+
+      function _runQuery(query, params = {}) {
+        const addRowsToResults = params.hasOwnProperty('addRowsToResults')
+          ? params.addRowsToResults
+          : true;
+        const closeConnection = params.hasOwnProperty('closeConnection')
+          ? params.closeConnection
+          : true;
+        const onCompleted =
+          params.onCompleted ||
+          (() => {
+            return resolve({ rows, incomplete });
+          });
+
+        sfConnection
+          .execute({ sqlText: query })
+          .streamRows()
+          .on('error', function(err) {
+            queryError = err;
+            sfConnection.destroy();
+            continueOn(onCompleted);
+          })
+          .on('data', function(row) {
+            if (addRowsToResults) {
+              // If we haven't hit the max yet add row to results
+              if (rows.length < connection.maxRows) {
+                return rows.push(row);
+              }
+
+              // Too many rows
+              incomplete = true;
+
+              // Destroy the underlying connection
+              if (closeConnection) {
+                sfConnection.destroy();
+              }
+              continueOn(onCompleted);
+            }
+          })
+          .on('end', function() {
+            if (closeConnection) {
+              sfConnection.destroy();
+            }
+            continueOn(onCompleted);
+          });
+      }
+
+      // Run with pre query statements
+      if (sfConfig.preQueryStatements) {
+        // Statements split and filtered by JS because Snowflake driver not supporting multiple SQL statements
+        const preQueries = sfConfig.preQueryStatements
+          .trim()
+          .split(';')
+          .filter(q => {
+            return q;
+          });
+        // Run pre queries in parallel
+        preQueries.forEach(q => {
+          // Don't add rows to results and keep the connection open for the next query
+          _runQuery(q, {
+            addRowsToResults: false,
+            closeConnection: false,
+
+            // Count the number of finished pre query statements
+            onCompleted: () => {
+              preQueryCompletes += 1;
+
+              // Run the actual query only when every pre query statement finished
+              if (preQueryCompletes === preQueries.length) {
+                _runQuery(query);
+              }
+            }
+          });
+        });
+      } else {
+        // No pre query statements, run the actual query immediately
+        _runQuery(query);
+      }
+    });
+  });
+}
+
+/**
+ * Test connectivity of connection
+ * @param {*} connection
+ */
+function testConnection(connection) {
+  const query = "SELECT 'success' AS TestQuery;";
+  return runQuery(query, connection);
+}
+
+/**
+ * Get schema for connection
+ * @param {*} connection
+ */
+function getSchema(connection) {
+  const schemaSql = getSchemaSql(connection.schema);
+  return runQuery(schemaSql, connection).then(queryResult =>
+    formatSchemaQueryResults(queryResult)
+  );
+}
+
+const fields = [
+  {
+    key: 'account',
+    formType: 'TEXT',
+    label: 'Account'
+  },
+  {
+    key: 'username',
+    formType: 'TEXT',
+    label: 'Database Username'
+  },
+  {
+    key: 'password',
+    formType: 'PASSWORD',
+    label: 'Database Password'
+  },
+  {
+    key: 'warehouse',
+    formType: 'TEXT',
+    label: 'Warehouse'
+  },
+  {
+    key: 'database',
+    formType: 'TEXT',
+    label: 'Database'
+  },
+  {
+    key: 'schema',
+    formType: 'TEXT',
+    label: 'Schema'
+  },
+  {
+    key: 'role',
+    formType: 'TEXT',
+    label: 'Role'
+  },
+  {
+    key: 'preQueryStatements',
+    formType: 'TEXTAREA',
+    label: 'Pre-query Statements (Optional)',
+    placeholder:
+      'Use to enforce session parameters like:\n  ALTER SESSION SET statement_timeout_in_seconds = 15;'
+  }
+];
+
+module.exports = {
+  id,
+  name,
+  fields,
+  getSchema,
+  runQuery,
+  testConnection
+};

--- a/server/drivers/snowflake/test.js
+++ b/server/drivers/snowflake/test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const snowflake = require('./index.js');
+
+const connection = {
+  name: 'test snowflake',
+  driver: 'snowflake',
+  account: process.env.SNOWFLAKE_ACCOUNT,
+  username: process.env.SNOWFLAKE_USERNAME,
+  password: process.env.SNOWFLAKE_PASSWORD,
+  warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+  database: process.env.SNOWFLAKE_DATABASE,
+  schema: process.env.SNOWFLAKE_SCHEMA,
+  maxRows: 50000
+};
+
+const dropTable = 'DROP TABLE IF EXISTS test;';
+const createTable = 'CREATE TABLE test (id int);';
+const inserts = 'INSERT INTO test (id) VALUES (1), (2), (3);';
+
+describe('drivers/snowflake', function() {
+  before(function() {
+    this.timeout(10000);
+    return snowflake
+      .runQuery(dropTable, connection)
+      .then(() => snowflake.runQuery(createTable, connection))
+      .then(() => snowflake.runQuery(inserts, connection));
+  });
+
+  it('tests connection', function() {
+    return snowflake.testConnection(connection);
+  });
+
+  it('getSchema()', function() {
+    this.timeout(60000);
+    return snowflake.getSchema(connection).then(schemaInfo => {
+      assert(schemaInfo.SQLPAD, 'SQLPAD');
+      assert(schemaInfo.SQLPAD.TEST, 'SQLPAD.TEST');
+      const columns = schemaInfo.SQLPAD.TEST;
+      assert.equal(columns.length, 1, 'columns.length');
+      assert.equal(columns[0].table_schema, 'SQLPAD', 'TABLE_SCHEMA');
+      assert.equal(columns[0].table_name, 'TEST', 'TABLE_NAME');
+      assert.equal(columns[0].column_name, 'ID', 'COLUMN_NAME');
+      assert(columns[0].hasOwnProperty('data_type'), 'DATA_TYPE');
+    });
+  });
+
+  it('runQuery under limit', function() {
+    return snowflake
+      .runQuery('SELECT id FROM test WHERE id = 1;', connection)
+      .then(results => {
+        assert(!results.incomplete, 'not incomplete');
+        assert.equal(results.rows.length, 1, 'rows length');
+      });
+  });
+
+  it('runQuery over limit', function() {
+    const limitedConnection = { ...connection, maxRows: 2 };
+    return snowflake
+      .runQuery('SELECT * FROM test;', limitedConnection)
+      .then(results => {
+        assert(results.incomplete, 'incomplete');
+        assert.equal(results.rows.length, 2, 'row length');
+      });
+  });
+
+  it('returns descriptive error message', function() {
+    let error;
+    return snowflake
+      .runQuery('SELECT * FROM missing_table;', connection)
+      .catch(e => {
+        error = e;
+      })
+      .then(() => {
+        assert(error);
+        assert(error.toString().indexOf('MISSING_TABLE') > -1);
+      });
+  });
+});

--- a/server/drivers/snowflake/test.sh
+++ b/server/drivers/snowflake/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Running the tests requires a real Snowflake account because Snowflake
+# does not provide a publicly available docker image that we can use for running tests locally
+#
+# To run the tests, update the below environment variables pointing to a real Snowflake account
+export SNOWFLAKE_ACCOUNT=rtXXXXX._region_
+export SNOWFLAKE_USERNAME=_username_
+export SNOWFLAKE_PASSWORD=_password_
+export SNOWFLAKE_WAREHOUSE=_warehouse_
+export SNOWFLAKE_DATABASE=_database_
+export SNOWFLAKE_SCHEMA=SQLPAD
+npx mocha ./test.js

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -137,6 +137,22 @@
         "printj": "~1.1.0"
       }
     },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "requires": {
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        }
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -226,6 +242,33 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "asn1.js": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+      "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "asn1.js-rfc2560": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/asn1.js-rfc2560/-/asn1.js-rfc2560-5.0.1.tgz",
+      "integrity": "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA==",
+      "requires": {
+        "asn1.js-rfc5280": "^3.0.0"
+      }
+    },
+    "asn1.js-rfc5280": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/asn1.js-rfc5280/-/asn1.js-rfc5280-3.0.0.tgz",
+      "integrity": "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg==",
+      "requires": {
+        "asn1.js": "^5.0.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -293,6 +336,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
     "big-number": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/big-number/-/big-number-1.0.0.tgz",
@@ -329,6 +377,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -359,6 +412,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browser-request": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -519,11 +577,19 @@
         }
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -531,8 +597,35 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -734,6 +827,16 @@
         "debug": "^2.6.0"
       }
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -801,10 +904,23 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -845,6 +961,19 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -1200,10 +1329,20 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "feature-policy": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
       "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
       "version": "2.0.0",
@@ -1580,6 +1719,38 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1739,6 +1910,11 @@
         "has": "^1.0.1"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -1875,6 +2051,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1940,6 +2124,25 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      }
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "long": {
@@ -2095,6 +2298,11 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2247,6 +2455,14 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
+      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "morgan": {
       "version": "1.9.1",
@@ -2513,6 +2729,51 @@
         "has": "^1.0.3"
       }
     },
+    "ocsp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ocsp/-/ocsp-1.2.0.tgz",
+      "integrity": "sha1-RpoXdrRX3uZ+sCAUCMGUa6xAdsw=",
+      "requires": {
+        "asn1.js": "^4.8.0",
+        "asn1.js-rfc2560": "^4.0.0",
+        "asn1.js-rfc5280": "^2.0.0",
+        "async": "^1.5.2",
+        "simple-lru-cache": "0.0.2"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+          "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "asn1.js-rfc2560": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/asn1.js-rfc2560/-/asn1.js-rfc2560-4.0.6.tgz",
+          "integrity": "sha512-ysf48ni+f/efNPilq4+ApbifUPcSW/xbDeQAh055I+grr2gXgNRQqHew7kkO70WSMQ2tEOURVwsK+dJqUNjIIg==",
+          "requires": {
+            "asn1.js-rfc5280": "^2.0.0"
+          }
+        },
+        "asn1.js-rfc5280": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js-rfc5280/-/asn1.js-rfc5280-2.0.1.tgz",
+          "integrity": "sha512-1e2ypnvTbYD/GdxWK77tdLBahvo1fZUHlQJqAVUuZWdYj0rdjGcf2CWYUtbsyRYpYUMwMWLZFUtLxog8ZXTrcg==",
+          "requires": {
+            "asn1.js": "^4.5.0"
+          }
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
     "odbc": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/odbc/-/odbc-1.4.6.tgz",
@@ -2543,6 +2804,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
     "onetime": {
       "version": "2.0.1",
@@ -3255,6 +3521,26 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -3270,6 +3556,51 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "snowflake-sdk": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/snowflake-sdk/-/snowflake-sdk-1.5.0.tgz",
+      "integrity": "sha512-s52rGMwe3wxGnetekhdy3BHSjIfRRUNOYtqilfqQkL/PjXTt6xK6tqASVMNd0ZH9+Q6udcExwfJUK35wZfW+OA==",
+      "requires": {
+        "agent-base": "^2.1.1",
+        "asn1.js-rfc2560": "^5.0.0",
+        "asn1.js-rfc5280": "^3.0.0",
+        "big-integer": "^1.6.43",
+        "bignumber.js": "^2.4.0",
+        "browser-request": "^0.3.3",
+        "debug": "^3.2.6",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.23.0",
+        "moment-timezone": "^0.5.15",
+        "ocsp": "^1.2.0",
+        "request": "^2.88.0",
+        "simple-lru-cache": "^0.0.2",
+        "uuid": "^3.3.2",
+        "winston": "^3.1.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
+          "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "socksjs": {
       "version": "0.5.0",
@@ -3367,6 +3698,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
       "version": "1.5.0",
@@ -3555,6 +3891,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3609,6 +3950,11 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -3783,6 +4129,51 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
       }
     },
     "wordwrap": {

--- a/server/package.json
+++ b/server/package.json
@@ -71,6 +71,7 @@
     "sanitize-filename": "^1.6.3",
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.3.0",
+    "snowflake-sdk": "^1.5.0",
     "socksjs": "^0.5.0",
     "sql-formatter": "^2.3.3",
     "uuid": "^3.3.3",


### PR DESCRIPTION
## Summary

This PR adds Snowflake database driver.

**New connection dropdown and form:**
<img width="200" alt="Screenshot 2020-01-25 at 11 46 44" src="https://user-images.githubusercontent.com/643687/73120598-6745d580-3f68-11ea-8c68-9e36577dc186.png">

**Running query on a connected Snowflake database:**
<img width="1849" alt="Screenshot 2020-01-25 at 11 37 18" src="https://user-images.githubusercontent.com/643687/73120523-28fbe680-3f67-11ea-8f39-41eb3e135cdf.png">

## Testing
The PR includes test cases as well, but running them requires a real Snowflake account because Snowflake doesn't provide a docker image that we can use to run tests locally. Tests are still implemented and credentials have to be defined as environment variables in  `server/driver/snowflake/test.sh`. 

I paste here the test output after setting real credentials in the above file:

```
$> ./test.sh 


  drivers/snowflake
    ✓ tests connection (328ms)
    ✓ getSchema() (2946ms)
    ✓ runQuery under limit (460ms)
    ✓ runQuery over limit (354ms)
    ✓ returns descriptive error message (451ms)


  5 passing (7s)

$ >
```
