### PR TITLE
Add proper application and web logs using pino

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,65 @@ When using JSON file, provide `<connectionId>` as a key under `connections`.
   </tbody>
 </table>
 
+## Logging
+
+SQLPad logs json messages using [pino](https://github.com/pinojs/pino), a simple and fast logging library. Log messages are sent to stdout, leaving how to handle the messages up to you. The pino ecosystem supports a variety of transports http://getpino.io/#/docs/transports that should cover most logging setups.
+
+Two categories of messages are logged by SQLPad: "app" messages containing info messages, warnings, and errors relating to application code, and "web" messages relating to the actual http requests handled by SQLPad. The level at which these logs are logged can be configured separately, or even turned off, with the `appLogLevel` and `webLogLevel` settings. This level represents the minimum level to be logged. The value used should be one of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`. Setting the level to `silent` will effectively disable the logger.
+
+In production, log messages will be a single json object per line:
+
+```
+> node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini'
+
+{"level":30,"time":1581974034149,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading users","v":1}
+{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading connections","v":1}
+{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading connectionAccesses","v":1}
+{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading queries","v":1}
+{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading queryHistory","v":1}
+{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading cache","v":1}
+{"level":30,"time":1581974035055,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Creating access on every connection to every user...","v":1}
+{"level":30,"time":1581974035066,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Welcome to SQLPad! Visit http://localhost:3010/sqlpad to get started","v":1}
+{"level":30,"time":1581974050933,"pid":7226,"hostname":"hostname.local","name":"sqlpad-web","req":{"id":2,"method":"GET","url":"/sqlpad/signin"},"res":{"statusCode":200},"responseTime":3,"msg":"request completed","v":1}
+{"level":30,"time":1581974050970,"pid":7226,"hostname":"hostname.local","name":"sqlpad-web","req":{"id":3,"method":"GET","url":"/sqlpad/javascripts/vendor/tauCharts/tauCharts.min.css"},"res":{"statusCode":304},"responseTime":2,"msg":"request completed","v":1}
+```
+
+During development, the logs can be piped to `pino-pretty`, which is used when running `npm start` by default, producing a more human friendly format:
+
+```
+> node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini' | pino-pretty
+
+[1581974767500] INFO  (sqlpad-app/7387 on hostname.local): Loading users
+[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading connections
+[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading connectionAccesses
+[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading queries
+[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading queryHistory
+[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading cache
+[1581974768401] INFO  (sqlpad-app/7387 on hostname.local): Creating access on every connection to every user...
+[1581974768413] INFO  (sqlpad-app/7387 on hostname.local): Welcome to SQLPad! Visit http://localhost:3010/sqlpad to get started
+[1581974774313] INFO  (sqlpad-web/7387 on hostname.local): request completed
+    req: {
+      "id": 1,
+      "method": "GET",
+      "url": "/sqlpad/signin"
+    }
+    res: {
+      "statusCode": 304
+    }
+    responseTime: 8
+[1581974774342] INFO  (sqlpad-web/7387 on hostname.local): request completed
+    req: {
+      "id": 2,
+      "method": "GET",
+      "url": "/sqlpad/javascripts/vendor/tauCharts/tauCharts.min.css"
+    }
+    res: {
+      "statusCode": 304
+    }
+    responseTime: 3
+
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ By default query history results are limited to 1,000 records.
 Env var: `SQLPAD_QUERY_HISTORY_RESULT_MAX_ROWS`  
 Default: `1000`
 
+**appLogLevel**  
+Minimum level for app logs. Should be one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.  
+Env var: `SQLPAD_APP_LOG_LEVEL`  
+Default: `info`
+
+**webLogLevel**  
+Minimum level for web logs. Should be one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.  
+Env var: `SQLPAD_WEB_LOG_LEVEL`  
+Default: `info`
+
 ### Connection configuration
 
 As of 3.2.0 connections may be defined via application configuration.

--- a/config-example.ini
+++ b/config-example.ini
@@ -112,3 +112,8 @@ timeoutSeconds=300
 ; Allows pre-approval of email domains. Delimit multiple domains by empty space.
 whitelistedDomains=""
 
+; Minimum level for app logs. Should be one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.
+appLogLevel="info"
+
+; Minimum level for web logs. Should be one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.
+webLogLevel="info"

--- a/config-example.json
+++ b/config-example.json
@@ -36,5 +36,7 @@
   "systemdSocket": false,
   "tableChartLinksRequireAuth": true,
   "timeoutSeconds": 300,
-  "whitelistedDomains": ""
+  "whitelistedDomains": "",
+  "appLogLevel": "info",
+  "webLogLevel": "info"
 }

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -14,7 +14,6 @@
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",
     "import/order": "off",
-    "no-console": "off",
     "no-else-return": "off",
     "no-multi-assign": "off",
     "no-param-reassign": "off",

--- a/server/app.js
+++ b/server/app.js
@@ -13,18 +13,16 @@ const googleClientSecret = config.get('googleClientSecret');
 const publicUrl = config.get('publicUrl');
 const dbPath = config.get('dbPath');
 const debug = config.get('debug');
-const logLevel = config.get('logLevel');
-const logWeb = config.get('logWeb');
+const webLogLevel = config.get('webLogLevel');
 const cookieName = config.get('cookieName');
 const cookieSecret = config.get('cookieSecret');
 const sessionMinutes = config.get('sessionMinutes');
 
 const expressPino = require('express-pino-logger')({
-  enabled: logWeb,
-  level: debug ? 'debug' : logLevel,
+  level: webLogLevel,
   name: 'sqlpad-web',
   // express-pino-logger logs all the headers by default
-  // This might be too much
+  // Removing these for now but open to adding them back in based on feedback
   redact: {
     paths: [
       'req.headers',

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const helmet = require('helmet');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 const config = require('./lib/config');
+const logger = require('./lib/logger');
 
 const baseUrl = config.get('baseUrl');
 const googleClientId = config.get('googleClientId');
@@ -100,9 +101,7 @@ const routers = [
 ];
 
 if (googleClientId && googleClientSecret && publicUrl) {
-  if (debug) {
-    console.log('Enabling Google authentication Strategy.');
-  }
+  logger.info('Enabling Google authentication Strategy.');
   routers.push(require('./routes/oauth.js'));
 }
 
@@ -113,9 +112,7 @@ if (
   samlCert &&
   samlAuthContext
 ) {
-  if (debug) {
-    console.log('Enabling SAML authentication Strategy.');
-  }
+  logger.info('Enabling SAML authentication Strategy.');
   routers.push(require('./routes/saml.js'));
 }
 
@@ -130,7 +127,7 @@ app.use(require('./routes/app.js'));
 // For any missing api route, return a 404
 // NOTE - this cannot be a general catch-all because it might be a valid non-api route from a front-end perspective
 app.use(baseUrl + '/api/', function(req, res) {
-  console.log('reached catch all api route');
+  logger.debug('reached catch all api route');
   res.sendStatus(404);
 });
 
@@ -155,8 +152,8 @@ if (fs.existsSync(indexTemplatePath)) {
     .replace(/="\/static/g, `="${baseUrl}/static`);
   app.use((req, res) => res.send(baseUrlHtml));
 } else {
-  console.error('\nNO FRONT END TEMPLATE DETECTED');
-  console.error('If not running in dev mode please report this issue.\n');
+  logger.warn('NO FRONT END TEMPLATE DETECTED');
+  logger.warn('If not running in dev mode please report this issue.');
 }
 
 module.exports = app;

--- a/server/drivers/cassandra/index.js
+++ b/server/drivers/cassandra/index.js
@@ -1,4 +1,5 @@
 const cassandra = require('cassandra-driver');
+const logger = require('../../lib/logger');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'cassandra';
@@ -19,11 +20,10 @@ const SCHEMA_SQL = `
  * @param {*} client
  */
 function shutdownClient(client) {
-  client
-    .shutdown()
-    .catch(error =>
-      console.error('Error shutting down cassandra connection', error)
-    );
+  client.shutdown().catch(error => {
+    logger.error('Error shutting down cassandra connection');
+    logger.error(error);
+  });
 }
 
 /**

--- a/server/drivers/drill/drill.js
+++ b/server/drivers/drill/drill.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch');
 let request = require('request');
 let url = require('url');
+const logger = require('../../lib/logger');
 
 exports.version = '1.0';
 
@@ -71,7 +72,7 @@ Client.prototype.query = function(config, query) {
     })
     .catch(function(e) {
       // TODO Send error message to JSON
-      console.log('There was a problem with the request' + e);
+      logger.error(e);
       return e;
     });
 };

--- a/server/drivers/drill/index.js
+++ b/server/drivers/drill/index.js
@@ -1,4 +1,5 @@
 const drill = require('./drill.js');
+const logger = require('../../lib/logger');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'drill';
@@ -49,8 +50,8 @@ function runQuery(query, connection) {
     if (!result) {
       throw new Error('No result returned');
     } else if (result.errorMessage && result.errorMessage.length > 0) {
-      console.log('Error with query: ' + query);
-      console.log(result.errorMessage);
+      logger.info('Error with query: %s', query);
+      logger.info(result.errorMessage);
       throw new Error(result.errorMessage.split('\n')[0]);
     }
     if (result.length > connection.maxRows) {

--- a/server/drivers/hdb/index.js
+++ b/server/drivers/hdb/index.js
@@ -1,4 +1,5 @@
 const hdb = require('hdb');
+const logger = require('../../lib/logger');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'hdb';
@@ -41,13 +42,13 @@ function runQuery(query, connection) {
     });
 
     client.on('error', err => {
-      console.error('Network connection error', err);
+      logger.error(err, 'Network connection error');
       return reject(err);
     });
 
     client.connect(err => {
       if (err) {
-        console.error('Connect error', err);
+        logger.error(err, 'Connect error');
         return reject(err);
       }
       return client.execute(query, function(err, rs) {

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -142,9 +142,10 @@ function runQuery(query, connection, user) {
     const rowCount = rows.length;
     const { startTime, stopTime, queryRunTime } = queryResult;
 
-    logger.debug({
+    logger.info({
       userId: user && user._id,
       userEmail: user && user.email,
+      connectionId: connection._id,
       connectionName,
       startTime,
       stopTime,

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -99,7 +99,9 @@ requireValidate('../drivers/vertica');
 requireValidate('../drivers/cassandra');
 requireValidate('../drivers/snowflake');
 
-if (debug || process.env.SQLPAD_TEST === 'true') {
+// If debug is turned on also add in mock drivers
+// This is used for test cases, and is also useful for end-user debugging
+if (debug) {
   requireValidate('../drivers/mock');
 }
 

--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const mysql = require('mysql');
+const logger = require('../../lib/logger');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'mysql';
@@ -124,7 +125,7 @@ function runQuery(query, connection) {
             if (params.closeConnection) {
               myConnection.end(error => {
                 if (error) {
-                  console.error('Error ending MySQL connection', error);
+                  logger.error(error, 'Error ending MySQL connection');
                 }
                 continueOn();
               });

--- a/server/drivers/postgres/index.js
+++ b/server/drivers/postgres/index.js
@@ -3,6 +3,7 @@ const pg = require('pg');
 const _ = require('lodash');
 const PgCursor = require('pg-cursor');
 const SocksConnection = require('socksjs');
+const logger = require('../../lib/logger');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'postgres';
@@ -135,14 +136,13 @@ function runQuery(query, connection) {
           if (params.closeConnection) {
             cursor.close(err => {
               if (err) {
-                console.log('error closing pg-cursor:');
-                console.log(err);
+                logger.error(err, 'error closing pg-cursor');
               }
               // Calling end() without setImmediate causes error within node-pg
               setImmediate(() => {
                 client.end(error => {
                   if (error) {
-                    console.error(error);
+                    logger.error(error);
                   }
                 });
               });

--- a/server/drivers/unixodbc/index.js
+++ b/server/drivers/unixodbc/index.js
@@ -1,4 +1,5 @@
 const odbc = require('odbc');
+const logger = require('../../lib/logger');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'unixodbc';
@@ -80,7 +81,7 @@ async function runQuery(query, connection) {
 
     return { rows, incomplete };
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     try {
       if (connectionInstance && connectionInstance.close) {
         await connectionInstance.close();
@@ -88,8 +89,7 @@ async function runQuery(query, connection) {
     } catch (error) {
       // Do nothing here.
       // An error already happened we're just trying to ensure it closed okay
-      console.log('error closing connection after error');
-      console.error(error);
+      logger.error(error, 'error closing connection after error');
     }
     throw error;
   }

--- a/server/lib/cli-flow.js
+++ b/server/lib/cli-flow.js
@@ -1,5 +1,6 @@
 const minimist = require('minimist');
 const argv = minimist(process.argv.slice(2));
+const logger = require('./logger');
 const packageJson = require('../package.json');
 const configItems = require('./config/configItems');
 
@@ -26,12 +27,12 @@ ${configItems
 
 // If version is requested show version then exit
 if (argv.v || argv.version) {
-  console.log('SQLPad version ' + packageJson.version);
+  logger.info('SQLPad version %s', packageJson.version);
   process.exit();
 }
 
 // If help is requested show help
 if (argv.h || argv.help) {
-  console.log(helpText);
+  logger.info(helpText);
   process.exit();
 }

--- a/server/lib/config/configItems.js
+++ b/server/lib/config/configItems.js
@@ -208,6 +208,11 @@ const configItems = [
     key: 'queryHistoryResultMaxRows',
     envVar: 'SQLPAD_QUERY_HISTORY_RESULT_MAX_ROWS',
     default: 1000
+  },
+  {
+    key: 'logLevel',
+    envVar: 'SQLPAD_LOG_LEVEL',
+    default: 'info'
   }
 ];
 

--- a/server/lib/config/configItems.js
+++ b/server/lib/config/configItems.js
@@ -213,6 +213,16 @@ const configItems = [
     key: 'logLevel',
     envVar: 'SQLPAD_LOG_LEVEL',
     default: 'info'
+  },
+  {
+    key: 'logApp',
+    envVar: 'SQLPAD_LOG_APP',
+    default: true
+  },
+  {
+    key: 'logWeb',
+    envVar: 'SQLPAD_LOG_WEB',
+    default: true
   }
 ];
 

--- a/server/lib/config/configItems.js
+++ b/server/lib/config/configItems.js
@@ -210,19 +210,14 @@ const configItems = [
     default: 1000
   },
   {
-    key: 'logLevel',
-    envVar: 'SQLPAD_LOG_LEVEL',
+    key: 'appLogLevel',
+    envVar: 'SQLPAD_APP_LOG_LEVEL',
     default: 'info'
   },
   {
-    key: 'logApp',
-    envVar: 'SQLPAD_LOG_APP',
-    default: true
-  },
-  {
-    key: 'logWeb',
-    envVar: 'SQLPAD_LOG_WEB',
-    default: true
+    key: 'webLogLevel',
+    envVar: 'SQLPAD_WEB_LOG_LEVEL',
+    default: 'info'
   }
 ];
 

--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -12,11 +12,6 @@ const envConfig = fromEnv();
 const [fileConfig, warnings] = fromFile();
 const cliConfig = fromCli(argv);
 
-// Old files might have some values no longer recognized
-if (warnings.length) {
-  warnings.forEach(warning => console.warn(warning));
-}
-
 const all = { ...defaultConfig, ...envConfig, ...fileConfig, ...cliConfig };
 
 // Clean string boolean values
@@ -40,12 +35,21 @@ exports.get = function get(key) {
     throw new Error(`config item ${key} not defined in configItems.js`);
   }
 
-  if (key === 'dbPath' && !all.dbPath) {
-    console.error(getOldConfigWarning());
-    throw new Error(`dbPath not defined`);
+  return all[key];
+};
+
+exports.getValidations = () => {
+  const errors = [];
+
+  // By default dbPath will exist as empty string, which is not valid
+  if (all.dbPath === '') {
+    errors.push(getOldConfigWarning());
   }
 
-  return all[key];
+  return {
+    errors,
+    warnings: [...warnings]
+  };
 };
 
 exports.smtpConfigured = () =>

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -1,4 +1,5 @@
 const nodemailer = require('nodemailer');
+const logger = require('./logger');
 const config = require('./config');
 
 /**
@@ -37,7 +38,7 @@ function sendInvite(to) {
 
 async function send(to, subject, text, html) {
   if (!config.smtpConfigured()) {
-    console.error('email.send() called without being configured');
+    logger.error('email.send() called without being configured');
     return;
   }
 
@@ -64,11 +65,9 @@ async function send(to, subject, text, html) {
       html
     };
     transporter.sendMail(mailOptions, function(err, info) {
-      if (config.get('debug')) {
-        console.log('sent email: ' + info);
-      }
+      logger.info('sent email: %s', info);
       if (err) {
-        console.error(err);
+        logger.error(err);
         return reject(err);
       }
       resolve(info);

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,0 +1,12 @@
+const config = require('./config');
+
+// Log levels https://github.com/pinojs/pino/issues/123
+const logLevel = config.get('logLevel');
+
+const logger = require('pino')({
+  name: 'sqlpad-app',
+  enabled: true, // TODO turn off for testing?
+  level: logLevel // default 'info' // or debug
+});
+
+module.exports = logger;

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -2,11 +2,13 @@ const config = require('./config');
 
 // Log levels https://github.com/pinojs/pino/issues/123
 const logLevel = config.get('logLevel');
+const logApp = config.get('logApp');
+const debug = config.get('debug');
 
 const logger = require('pino')({
   name: 'sqlpad-app',
-  enabled: true, // TODO turn off for testing?
-  level: logLevel // default 'info' // or debug
+  enabled: logApp,
+  level: debug ? 'debug' : logLevel
 });
 
 module.exports = logger;

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,14 +1,11 @@
 const config = require('./config');
 
 // Log levels https://github.com/pinojs/pino/issues/123
-const logLevel = config.get('logLevel');
-const logApp = config.get('logApp');
-const debug = config.get('debug');
+const appLogLevel = config.get('appLogLevel');
 
 const logger = require('pino')({
   name: 'sqlpad-app',
-  enabled: logApp,
-  level: debug ? 'debug' : logLevel
+  level: appLogLevel
 });
 
 module.exports = logger;

--- a/server/lib/pushQueryToSlack.js
+++ b/server/lib/pushQueryToSlack.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 const config = require('./config');
 const request = require('request');
 
@@ -23,8 +24,8 @@ ${'```'}`
     };
     request(options, function(err) {
       if (err) {
-        console.error('Something went wrong while sending to Slack.');
-        console.error(err);
+        logger.error('Something went wrong while sending to Slack.');
+        logger.error(err);
       }
     });
   }

--- a/server/lib/sendError.js
+++ b/server/lib/sendError.js
@@ -1,12 +1,14 @@
+const logger = require('./logger');
+
 /**
- * Logs actual error to console and sends standard error response
+ * Logs actual error and sends standard error response
  * @param {*} res
  * @param {Error} [error]
  * @param {string} [message]
  */
 module.exports = function sendError(res, error, message) {
   if (error) {
-    console.error(error);
+    logger.error(error);
   }
   return res.json({
     error: message || (error ? error.toString() : 'Something happened')

--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -5,6 +5,7 @@ const BasicStrategy = require('passport-http').BasicStrategy;
 const SamlStrategy = require('passport-saml').Strategy;
 const usersUtil = require('../models/users.js');
 const config = require('../lib/config');
+const logger = require('../lib/logger');
 const checkWhitelist = require('../lib/check-whitelist.js');
 const passhash = require('../lib/passhash.js');
 
@@ -125,7 +126,7 @@ if (samlEntryPoint) {
             'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'
           ];
         const user = await usersUtil.findOneByEmail(email);
-        console.log(`User logged in with SAML as ${email}`);
+        logger.info('User logged in via SAML %s', email);
         if (!user) {
           return done(null, false);
         }

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -1,4 +1,5 @@
 const db = require('../lib/db.js');
+const logger = require('../lib/logger');
 const _ = require('lodash');
 const drivers = require('../drivers');
 const cipher = require('../lib/cipher.js');
@@ -67,9 +68,10 @@ function getConnectionsFromConfig(env = process.env) {
       connection.editable = false;
       connectionsFromConfig.push(connection);
     } catch (error) {
-      console.log(
-        `Environment connection configuration failed for ${id} %s`,
-        error
+      logger.error(
+        error,
+        'Environment connection configuration failed for %s',
+        id
       );
     }
   });

--- a/server/models/resultCache.js
+++ b/server/models/resultCache.js
@@ -3,6 +3,7 @@ const path = require('path');
 const moment = require('moment');
 const sanitize = require('sanitize-filename');
 const db = require('../lib/db.js');
+const logger = require('../lib/logger');
 const xlsx = require('node-xlsx');
 const { parse } = require('json2csv');
 const config = require('../lib/config');
@@ -66,7 +67,7 @@ function writeXlsx(cacheKey, queryResult) {
       // if there's an error log it but otherwise continue on
       // we can still send results even if download file failed to create
       if (err) {
-        console.log(err);
+        logger.error(err);
       }
       return resolve();
     });
@@ -79,12 +80,12 @@ function writeCsv(cacheKey, queryResult) {
       const csv = parse(queryResult.rows, { fields: queryResult.fields });
       fs.writeFile(csvFilePath(cacheKey), csv, function(err) {
         if (err) {
-          console.log(err);
+          logger.error(err);
         }
         return resolve();
       });
     } catch (error) {
-      console.log(error);
+      logger.error(error);
       return resolve();
     }
   });
@@ -107,12 +108,12 @@ function writeJson(cacheKey, queryResult) {
       const json = JSON.stringify(queryResult.rows);
       fs.writeFile(jsonFilePath(cacheKey), json, function(err) {
         if (err) {
-          console.log(err);
+          logger.error(err);
         }
         return resolve();
       });
     } catch (error) {
-      console.log(error);
+      logger.error(error);
       return resolve();
     }
   });
@@ -135,7 +136,7 @@ async function removeExpired() {
       await db.cache.remove({ _id: doc._id }, {});
     }
   } catch (error) {
-    console.log(error);
+    logger.error(error);
   }
 }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -62,6 +62,12 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
     "@hapi/formula": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
@@ -277,6 +283,26 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
+    },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         }
       }
@@ -1147,6 +1173,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "env-variable": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
@@ -1588,6 +1623,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+    },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
@@ -1692,6 +1732,11 @@
           }
         }
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "2.0.1",
@@ -2269,6 +2314,18 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
+    },
+    "joycon": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2381,6 +2438,12 @@
       "requires": {
         "colornames": "^1.1.1"
       }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -2804,6 +2867,12 @@
         "on-finished": "~2.3.0",
         "on-headers": "~1.0.1"
       }
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -3600,6 +3669,62 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.16.0.tgz",
+      "integrity": "sha512-k9cDzHd9S/oYSQ9B9g9+7RXkfsZX78sQXERC8x4p2XArECZXULx9nqNwZvJHsLj779wPCt+ybN+dG8jFR70p6Q==",
+      "requires": {
+        "fast-redact": "^2.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^2.4.2",
+        "quick-format-unescaped": "^3.0.3",
+        "sonic-boom": "^0.7.5"
+      }
+    },
+    "pino-pretty": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.6.0.tgz",
+      "integrity": "sha512-gTVA+Kx4DoVQl+sXO4/HdLVaNgr281b+NDJWmXzreIoQ+3fd7xVyTg31c0hpzCUbheuW4TpzQOqDg9uOIsbw7Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/bourne": "^1.3.2",
+        "args": "^5.0.1",
+        "chalk": "^2.4.2",
+        "dateformat": "^3.0.3",
+        "fast-safe-stringify": "^2.0.7",
+        "jmespath": "^0.15.0",
+        "joycon": "^2.2.5",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.4.0",
+        "split2": "^3.1.1",
+        "strip-json-comments": "^3.0.1"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
+    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -3677,6 +3802,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
       "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3691,6 +3826,11 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -4148,6 +4288,14 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
+      "integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
+      "requires": {
+        "flatstr": "^1.0.12"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -4186,6 +4334,28 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
         "through": "2"
+      }
+    },
+    "split2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "sprintf-js": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -534,14 +534,6 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "bcrypt-nodejs": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
@@ -1553,6 +1545,14 @@
         "vary": "~1.1.2"
       }
     },
+    "express-pino-logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express-pino-logger/-/express-pino-logger-4.0.0.tgz",
+      "integrity": "sha512-BTJwjQXMSR6tFiyvTOOr6aosJkJOuJpW0mXE+icv3ae/0WXBGnLaumINGHJvWMuDO1RSLHBLfRrJaghMjMhVrg==",
+      "requires": {
+        "pino-http": "^4.0.0"
+      }
+    },
     "express-session": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.0.tgz",
@@ -1632,6 +1632,21 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
     },
     "feature-policy": {
       "version": "0.3.0",
@@ -2856,18 +2871,6 @@
         "moment": ">= 2.9.0"
       }
     },
-    "morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
-      "requires": {
-        "basic-auth": "~2.0.0",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
-      }
-    },
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
@@ -3680,6 +3683,16 @@
         "pino-std-serializers": "^2.4.2",
         "quick-format-unescaped": "^3.0.3",
         "sonic-boom": "^0.7.5"
+      }
+    },
+    "pino-http": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-4.4.0.tgz",
+      "integrity": "sha512-uPGPNGT9WV5GrRydEPR8A1bCXUutmI4M7VIQ6InoJTC1ddjgScQPZt/uxDOQkdTTjP2RJ1dJH5ML+V1f5Q/JKg==",
+      "requires": {
+        "fast-url-parser": "^1.1.3",
+        "pino": "^5.0.0",
+        "pino-std-serializers": "^2.4.0"
       }
     },
     "pino-pretty": {

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "prepublishOnly": "cd .. && ./scripts/build.sh",
     "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini' | pino-pretty",
-    "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_TEST='true' mocha test --timeout 10000 --recursive --exit",
+    "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_DEBUG='true' SQLPAD_LOG_WEB='false' SQLPAD_LOG_APP='false' mocha test --timeout 10000 --recursive --exit",
     "fixlint": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"
   },
@@ -41,6 +41,7 @@
     "detect-port": "^1.3.0",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
+    "express-pino-logger": "^4.0.0",
     "express-session": "^1.17.0",
     "hdb": "^0.17.1",
     "helmet": "^3.21.2",
@@ -50,7 +51,6 @@
     "minimist": "^1.2.0",
     "mkdirp": "^1.0.3",
     "moment": "^2.24.0",
-    "morgan": "^1.9.1",
     "mssql": "^6.0.1",
     "mysql": "^2.18.1",
     "nedb": "^1.8.0",

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "prepublishOnly": "cd .. && ./scripts/build.sh",
     "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini' | pino-pretty",
-    "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_DEBUG='true' SQLPAD_LOG_WEB='false' SQLPAD_LOG_APP='false' mocha test --timeout 10000 --recursive --exit",
+    "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_DEBUG='true' SQLPAD_APP_LOG_LEVEL='silent' SQLPAD_WEB_LOG_LEVEL='silent' mocha test --timeout 10000 --recursive --exit",
     "fixlint": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "prepublishOnly": "cd .. && ./scripts/build.sh",
-    "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini'",
+    "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini' | pino-pretty",
     "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_TEST='true' mocha test --timeout 10000 --recursive --exit",
     "fixlint": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"
@@ -66,6 +66,7 @@
     "passport-saml": "^1.3.2",
     "pg": "^7.18.1",
     "pg-cursor": "^2.1.5",
+    "pino": "^5.16.0",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",
     "sanitize-filename": "^1.6.3",
@@ -92,6 +93,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "mocha": "^7.0.1",
     "node-dev": "^4.0.0",
+    "pino-pretty": "^3.6.0",
     "supertest": "^4.0.2"
   }
 }

--- a/server/routes/download-results.js
+++ b/server/routes/download-results.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const router = require('express').Router();
 const resultCache = require('../models/resultCache.js');
 const config = require('../lib/config');
+const logger = require('../lib/logger');
 
 router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
   const { cacheKey } = req.params;
@@ -22,7 +23,7 @@ router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
       return next(new Error('CSV download disabled'));
     }
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     // TODO figure out what this sends and set manually
     return next(error);
   }
@@ -50,7 +51,7 @@ router.get('/download-results/:cacheKey.xlsx', async function(req, res, next) {
       return next(new Error('XLSX download disabled'));
     }
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     // TODO figure out what this sends and set manually
     return next(error);
   }
@@ -75,7 +76,7 @@ router.get('/download-results/:cacheKey.json', async function(req, res, next) {
       return next(new Error('JSON download disabled'));
     }
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     // TODO figure out what this sends and set manually
     return next(error);
   }

--- a/server/routes/forgot-password.js
+++ b/server/routes/forgot-password.js
@@ -4,6 +4,7 @@ const usersUtil = require('../models/users.js');
 const email = require('../lib/email');
 const sendError = require('../lib/sendError');
 const config = require('../lib/config');
+const logger = require('../lib/logger');
 
 router.post('/api/forgot-password', async function(req, res) {
   if (!req.body.email) {
@@ -30,7 +31,7 @@ router.post('/api/forgot-password', async function(req, res) {
     const resetPath = `/password-reset/${user.passwordResetId}`;
     email
       .sendForgotPassword(req.body.email, resetPath)
-      .catch(error => console.error(error));
+      .catch(error => logger.error(error));
 
     return res.json({});
   } catch (error) {

--- a/server/routes/signup-signin-signout.js
+++ b/server/routes/signup-signin-signout.js
@@ -4,6 +4,7 @@ const checkWhitelist = require('../lib/check-whitelist');
 const usersUtil = require('../models/users.js');
 const sendError = require('../lib/sendError');
 const config = require('../lib/config');
+const logger = require('../lib/logger');
 
 async function handleSignup(req, res, next) {
   try {
@@ -75,7 +76,7 @@ router.get('/api/signout', function(req, res) {
   }
   req.session.destroy(function(err) {
     if (err) {
-      console.error(err);
+      logger.error(err);
     }
     res.json({});
   });

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -5,6 +5,7 @@ const mustBeAdmin = require('../middleware/must-be-admin.js');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const sendError = require('../lib/sendError');
 const config = require('../lib/config');
+const logger = require('../lib/logger');
 
 router.get('/api/users', mustBeAuthenticated, async function(req, res) {
   try {
@@ -28,7 +29,7 @@ router.post('/api/users', mustBeAdmin, async function(req, res) {
     });
 
     if (config.smtpConfigured()) {
-      email.sendInvite(req.body.email).catch(error => console.error(error));
+      email.sendInvite(req.body.email).catch(error => logger.error(error));
     }
     return res.json({ user });
   } catch (error) {

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,15 @@ const detectPort = require('detect-port');
 // Parse command line flags to see if anything special needs to happen
 require('./lib/cli-flow.js');
 
+const logger = require('./lib/logger');
 const config = require('./lib/config');
+
+const configValidations = config.getValidations();
+configValidations.warnings.map(warning => logger.warn(warning));
+if (configValidations.errors.length > 0) {
+  configValidations.errors.forEach(error => logger.error(error));
+  process.exit(1);
+}
 
 const app = require('./app');
 
@@ -45,13 +53,12 @@ function detectPortOrSystemd(port) {
     // We just crab the first socket from fd 3 since sqlpad binds only one
     // port.
     if (passedSocketCount > 0) {
-      console.log('Using port from Systemd');
+      logger.info('Using port from Systemd');
       return Promise.resolve({ fd: 3 });
     } else {
-      console.error(
-        'Warning: Systemd socket asked but not found. Trying to bind port ' +
-          port +
-          ' manually'
+      logger.warn(
+        'Warning: Systemd socket asked but not found. Trying to bind port %d manually',
+        port
       );
     }
   }
@@ -69,8 +76,8 @@ async function startServer() {
     // https only
     const _port = await detectPortOrSystemd(httpsPort);
     if (!isFdObject(_port) && httpsPort !== _port) {
-      console.log(
-        '\nPort %d already occupied. Using port %d instead.',
+      logger.info(
+        'Port %d already occupied. Using port %d instead.',
         httpsPort,
         _port
       );
@@ -91,41 +98,41 @@ async function startServer() {
       .listen(_port, ip, function() {
         const hostIp = ip === '0.0.0.0' ? 'localhost' : ip;
         const url = `https://${hostIp}:${_port}${baseUrl}`;
-        console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`);
+        logger.info('Welcome to SQLPad!. Visit %s to get started', url);
       });
   } else {
     // http only
     const _port = await detectPortOrSystemd(port);
     if (!isFdObject(_port) && port !== _port) {
-      console.log(
-        '\nPort %d already occupied. Using port %d instead.',
+      logger.info(
+        'Port %d already occupied. Using port %d instead.',
         port,
         _port
       );
+
       // TODO FIXME XXX  Persist the new port to the in-memory store.
       // config.set('port', _port)
     }
     server = http.createServer(app).listen(_port, ip, function() {
       const hostIp = ip === '0.0.0.0' ? 'localhost' : ip;
       const url = `http://${hostIp}:${_port}${baseUrl}`;
-      console.log(`\nWelcome to SQLPad!. Visit ${url} to get started`);
+      logger.info('Welcome to SQLPad! Visit %s to get started', url);
     });
   }
   server.setTimeout(timeoutSeconds * 1000);
 }
 
 db.loadPromise.then(startServer).catch(error => {
-  console.log('Error starting SQLPad');
-  console.error(error);
+  logger.error(error, 'Error starting SQLPad');
   process.exit(1);
 });
 
 function handleShutdownSignal(signal) {
   if (!server) {
-    console.log(`Received ${signal}, but no server to shutdown`);
+    logger.info('Received %s, but no server to shutdown', signal);
     process.exit(0);
   } else {
-    console.log(`Received ${signal}, shutting down server...`);
+    logger.info('Received %s, shutting down server...', signal);
     server.close(function() {
       process.exit(0);
     });


### PR DESCRIPTION
Adds `pino` and uses it for logging both application and web log messages. This also adds `pino-pretty` as a dev-dependency for pretty-printing the messages to a more human friendly form, and uninstalls `morgan`. 

Pino logs JSON messages and is tailored to be fast and simple. SQLPad doesn't really need the extra performance it brings, but I really enjoy its simplicity, and the fact that transports are handled separately. (I've battled the complexity quirky behaviors of `winston` in other projects, and `pino` has been really enjoyable to implement).

This adds additional configuration to manage this logging, and some additional documentation in the README to expand on how to use it and what to expect. I'll probably be investing in adding to the SQLPad project page with more in-depth instruction and examples on how to run and administer SQLPad.

## Addition to the README for reference:

## Logging

SQLPad logs json messages using [pino](https://github.com/pinojs/pino), a simple and fast logging library. Log messages are sent to stdout, leaving how to handle the messages up to you. The pino ecosystem supports a variety of transports http://getpino.io/#/docs/transports that should cover most logging setups.

Two categories of messages are logged by SQLPad: "app" messages containing info messages, warnings, and errors relating to application code, and "web" messages relating to the actual http requests handled by SQLPad. The level at which these logs are logged can be configured separately, or even turned off, with the `appLogLevel` and `webLogLevel` settings. This level represents the minimum level to be logged. The value used should be one of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`. Setting the level to `silent` will effectively disable the logger.

In production, log messages will be a single json object per line:

```
> node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini'

{"level":30,"time":1581974034149,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading users","v":1}
{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading connections","v":1}
{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading connectionAccesses","v":1}
{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading queries","v":1}
{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading queryHistory","v":1}
{"level":30,"time":1581974034150,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Loading cache","v":1}
{"level":30,"time":1581974035055,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Creating access on every connection to every user...","v":1}
{"level":30,"time":1581974035066,"pid":7226,"hostname":"hostname.local","name":"sqlpad-app","msg":"Welcome to SQLPad! Visit http://localhost:3010/sqlpad to get started","v":1}
{"level":30,"time":1581974050933,"pid":7226,"hostname":"hostname.local","name":"sqlpad-web","req":{"id":2,"method":"GET","url":"/sqlpad/signin"},"res":{"statusCode":200},"responseTime":3,"msg":"request completed","v":1}
{"level":30,"time":1581974050970,"pid":7226,"hostname":"hostname.local","name":"sqlpad-web","req":{"id":3,"method":"GET","url":"/sqlpad/javascripts/vendor/tauCharts/tauCharts.min.css"},"res":{"statusCode":304},"responseTime":2,"msg":"request completed","v":1}
```

During development, the logs can be piped to `pino-pretty`, which is used when running `npm start` by default, producing a more human friendly format:

```
> node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini' | pino-pretty

[1581974767500] INFO  (sqlpad-app/7387 on hostname.local): Loading users
[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading connections
[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading connectionAccesses
[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading queries
[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading queryHistory
[1581974767501] INFO  (sqlpad-app/7387 on hostname.local): Loading cache
[1581974768401] INFO  (sqlpad-app/7387 on hostname.local): Creating access on every connection to every user...
[1581974768413] INFO  (sqlpad-app/7387 on hostname.local): Welcome to SQLPad! Visit http://localhost:3010/sqlpad to get started
[1581974774313] INFO  (sqlpad-web/7387 on hostname.local): request completed
    req: {
      "id": 1,
      "method": "GET",
      "url": "/sqlpad/signin"
    }
    res: {
      "statusCode": 304
    }
    responseTime: 8
[1581974774342] INFO  (sqlpad-web/7387 on hostname.local): request completed
    req: {
      "id": 2,
      "method": "GET",
      "url": "/sqlpad/javascripts/vendor/tauCharts/tauCharts.min.css"
    }
    res: {
      "statusCode": 304
    }
    responseTime: 3

```