### PR TITLE
Remove errorhandler middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -45,7 +45,6 @@ const samlAuthContext = config.get('samlAuthContext');
 const bodyParser = require('body-parser');
 const favicon = require('serve-favicon');
 const passport = require('passport');
-const errorhandler = require('errorhandler');
 
 const app = express();
 
@@ -59,12 +58,6 @@ app.use(helmet.xssFilter());
 app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
 
 app.set('env', debug ? 'development' : 'production');
-
-// TODO remove error handler - All it sends full stack trace and error to client,
-// and that should be available in logs and other dev tooling instead
-if (debug) {
-  app.use(errorhandler());
-}
 
 app.use(expressPino);
 app.use(favicon(path.join(__dirname, '/public/favicon.ico')));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1188,15 +1188,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "errorhandler": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
-      "integrity": "sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==",
-      "requires": {
-        "accepts": "~1.3.7",
-        "escape-html": "~1.0.3"
-      }
-    },
     "es-abstract": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,6 @@
     "body-parser": "^1.19.0",
     "cassandra-driver": "^4.4.0",
     "detect-port": "^1.3.0",
-    "errorhandler": "^1.5.1",
     "express": "^4.17.1",
     "express-pino-logger": "^4.0.0",
     "express-session": "^1.17.0",


### PR DESCRIPTION
Removes `errorhandler` middleware, which is responsible for sending error and stack trace to the browser on express error. 

This was added way back early days in SQLPad development when I was under the impression it was something you typically add with express setups. 

It still is fairly popular of a library, but not really useful now that SQLPad is a SPA with restish APIs, has API tests, logging library, and so on.