### PR TITLE
Move passport basic authentication to own middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -36,6 +36,7 @@ const expressPino = require('express-pino-logger')({
 const bodyParser = require('body-parser');
 const favicon = require('serve-favicon');
 const passport = require('passport');
+const passportBasic = require('./middleware/passport-basic');
 
 const app = express();
 
@@ -80,6 +81,12 @@ app.use(baseUrl, express.static(path.join(__dirname, 'public')));
 /*  Passport setup
 ============================================================================= */
 require('./middleware/passport.js');
+
+// If local auth is not disabled, support basic auth using a user's email and password
+// This is currently used for running integration tests and serves as a convenient alternative to API keys
+if (!config.get('disableUserpassAuth')) {
+  app.use(passportBasic);
+}
 
 /*  Routes
 ============================================================================= */

--- a/server/middleware/must-be-authenticated-or-chart-link-noauth.js
+++ b/server/middleware/must-be-authenticated-or-chart-link-noauth.js
@@ -1,15 +1,9 @@
-const passport = require('passport');
 const config = require('../lib/config');
 
-// If authenticated continue
-// If not and auth header is present, try authenticated with http basic
-// Otherwise redirect user to signin
+// If authenticated or setting allows it continue. Otherwise redirect user to signin
 module.exports = function mustBeAuthenticatedOrChartLinkNoAuth(req, res, next) {
   if (req.isAuthenticated() || !config.get('tableChartLinksRequireAuth')) {
     return next();
-  }
-  if (req.headers.authorization) {
-    return passport.authenticate('basic', { session: false })(req, res, next);
   }
   res.redirect(config.get('baseUrl') + '/signin');
 };

--- a/server/middleware/must-be-authenticated.js
+++ b/server/middleware/must-be-authenticated.js
@@ -1,15 +1,9 @@
-const passport = require('passport');
 const config = require('../lib/config');
 
-// If authenticated continue
-// If not and auth header is present, try authenticated with http basic
-// Otherwise redirect user to signin
+// If authenticated continue. otherwise redirect user to signin
 module.exports = function mustBeAuthenticated(req, res, next) {
   if (req.isAuthenticated()) {
     return next();
-  }
-  if (req.headers.authorization) {
-    return passport.authenticate('basic', { session: false })(req, res, next);
   }
   res.redirect(config.get('baseUrl') + '/signin');
 };

--- a/server/middleware/passport-basic.js
+++ b/server/middleware/passport-basic.js
@@ -1,0 +1,11 @@
+const passport = require('passport');
+
+module.exports = function(req, res, next) {
+  if (
+    req.headers.authorization &&
+    req.headers.authorization.startsWith('Basic ')
+  ) {
+    return passport.authenticate('basic', { session: false })(req, res, next);
+  }
+  next();
+};


### PR DESCRIPTION
Consolidates the handling of HTTP basic auth and makes it more explicit. It was previously used in both must-be-authenticated middlewares. It instead can be in its own middleware and used only if credentials are supplied. 

Any authenticated checks that follow only need to use the `req.isAuthenticated()` check.