### PR TITLE
Refactor: pass nedb into app and models

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,9 +10,12 @@ const logger = require('./lib/logger');
  * Create an express app using config
  * @param {object} config
  */
-function makeApp(config) {
+function makeApp(config, nedb) {
   if (typeof config.get !== 'function') {
     throw new Error('config is required to create app');
+  }
+  if (!nedb) {
+    throw new Error('nedb is required to create app');
   }
 
   const baseUrl = config.get('baseUrl');
@@ -57,9 +60,10 @@ function makeApp(config) {
   app.use(helmet.xssFilter());
   app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
 
-  // Add config to req.config
+  // Decorate req with app things
   app.use(function(req, res, next) {
     req.config = config;
+    req.nedb = nedb;
     next();
   });
 

--- a/server/lib/connectionsFromConfig.js
+++ b/server/lib/connectionsFromConfig.js
@@ -1,0 +1,79 @@
+const _ = require('lodash');
+const logger = require('./logger');
+const drivers = require('../drivers');
+const getConfigFromFile = require('./config/fromFile.js');
+const [configFromFile] = getConfigFromFile() || {};
+
+/**
+ * Get connections from config.
+ *
+ * For environment variables:
+ * connection env vars must follow the format:
+ * SQLPAD_CONNECTIONS__<connectionId>__<connectionFieldName>
+ *
+ * <connectionId> can be any value to associate a grouping a fields to a connection instance
+ * If supplying a connection that was previously defined in the nedb database,
+ * this would map internally to connection._id object.
+ *
+ * <connectionFieldName> should be a field name identified in drivers.
+ *
+ * To define connections via envvars, `driver` field should be supplied.
+ * _id field is not required, as it is defined in second env var fragment.
+ *
+ * Example: SQLPAD_CONNECTIONS__ab123__sqlserverEncrypt=""
+ *
+ * From file, resulting parsed configuration from file is expected to follow format `connections.<id>.<fieldname>`
+ * {
+ *   connections: {
+ *     ab123: {
+ *       sqlserverEncrypt: true
+ *     }
+ *   }
+ * }
+ *
+ * @param {object} env
+ * @returns {array<object>} arrayOfConnections
+ */
+function getConnectionsFromConfig(env = process.env) {
+  // Create a map of connections from parsing environment variable
+  const connectionsMapFromEnv = Object.keys(env)
+    .filter(key => key.startsWith('SQLPAD_CONNECTIONS__'))
+    .reduce((connectionsMap, envVar) => {
+      // eslint-disable-next-line no-unused-vars
+      const [prefix, id, field] = envVar.split('__');
+      if (!connectionsMap[id]) {
+        connectionsMap[id] = {};
+      }
+      connectionsMap[id][field] = env[envVar];
+      return connectionsMap;
+    }, {});
+
+  // Get copy of connections from config file
+  const { connections } = _.cloneDeep(configFromFile);
+
+  // connections key from file matches format that is constructed from env
+  // merge the 2 together then create an array out of them
+  const connectionsMap = { ...connectionsMapFromEnv, ...connections };
+
+  const connectionsFromConfig = [];
+  Object.keys(connectionsMap).forEach(id => {
+    try {
+      let connection = connectionsMap[id];
+      connection._id = id;
+      connection = drivers.validateConnection(connection);
+      connection.editable = false;
+      connectionsFromConfig.push(connection);
+    } catch (error) {
+      logger.error(
+        error,
+        'Environment connection configuration failed for %s',
+        id
+      );
+    }
+  });
+  return connectionsFromConfig;
+}
+
+module.exports = {
+  getConnectionsFromConfig
+};

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -2,123 +2,150 @@ const path = require('path');
 const datastore = require('nedb-promise');
 const mkdirp = require('mkdirp');
 const logger = require('./logger');
-const config = require('./config');
 const consts = require('./consts');
 const passhash = require('../lib/passhash');
 
-const admin = config.get('admin');
-const adminPassword = config.get('adminPassword');
-const dbPath = config.get('dbPath');
-const allowConnectionAccessToEveryone = config.get(
-  'allowConnectionAccessToEveryone'
-);
+let instances = {};
 
-mkdirp.sync(path.join(dbPath, '/cache'));
-
-const db = {
-  users: datastore({ filename: path.join(dbPath, 'users.db') }),
-  connections: datastore({
-    filename: path.join(dbPath, 'connections.db')
-  }),
-  connectionAccesses: datastore({
-    filename: path.join(dbPath, 'connectionaccesses.db')
-  }),
-  queries: datastore({ filename: path.join(dbPath, 'queries.db') }),
-  queryHistory: datastore({ filename: path.join(dbPath, 'queryhistory.db') }),
-  cache: datastore({ filename: path.join(dbPath, 'cache.db') }),
-  instances: [
-    'users',
-    'connections',
-    'connectionAccesses',
-    'queries',
-    'queryHistory',
-    'cache'
-  ]
-};
-
-// Load dbs, migrate data, and apply indexes
-async function init() {
-  await Promise.all(
-    db.instances.map(dbname => {
-      logger.info('Loading %s', dbname);
-      return db[dbname].loadDatabase();
-    })
-  );
-  // create default connection accesses
-  if (allowConnectionAccessToEveryone) {
-    logger.info('Creating access on every connection to every user...');
-    await db.connectionAccesses.update(
-      {
-        connectionId: consts.EVERY_CONNECTION_ID,
-        userId: consts.EVERYONE_ID
-      },
-      {
-        connectionId: consts.EVERY_CONNECTION_ID,
-        connectionName: consts.EVERY_CONNECTION_NAME,
-        userId: consts.EVERYONE_ID,
-        userEmail: consts.EVERYONE_EMAIL,
-        duration: 0,
-        expiryDate: new Date(new Date().setFullYear(2099))
-      },
-      {
-        upsert: true
-      }
-    );
+function getNedb(instanceAlias = 'default') {
+  const nedb = instances[instanceAlias];
+  if (!nedb) {
+    throw new Error('nedb instance must be created first');
   }
-  // Apply indexes
-  await db.users.ensureIndex({ fieldName: 'email', unique: true });
-  await db.cache.ensureIndex({ fieldName: 'cacheKey', unique: true });
-  await db.connectionAccesses.ensureIndex({ fieldName: 'connectionId' });
-  await db.connectionAccesses.ensureIndex({ fieldName: 'userId' });
-  await db.queryHistory.ensureIndex({ fieldName: 'connectionName' });
-  await db.queryHistory.ensureIndex({ fieldName: 'userEmail' });
-  await db.queryHistory.ensureIndex({ fieldName: 'createdDate' });
-  // set autocompaction
-  const tenMinutes = 1000 * 60 * 10;
-  db.instances.forEach(dbname => {
-    db[dbname].nedb.persistence.setAutocompactionInterval(tenMinutes);
-  });
-  return ensureAdmin();
+  // nedb will already be a promise -- this just makes it explicit
+  return Promise.resolve(nedb);
 }
 
-db.loadPromise = init();
+async function initNedb(config) {
+  const admin = config.get('admin');
+  const adminPassword = config.get('adminPassword');
+  const dbPath = config.get('dbPath');
+  const allowConnectionAccessToEveryone = config.get(
+    'allowConnectionAccessToEveryone'
+  );
 
-async function ensureAdmin() {
-  const adminEmail = admin;
-  if (!adminEmail) {
-    return;
+  mkdirp.sync(path.join(dbPath, '/cache'));
+
+  const nedb = {
+    users: datastore({ filename: path.join(dbPath, 'users.db') }),
+    connections: datastore({
+      filename: path.join(dbPath, 'connections.db')
+    }),
+    connectionAccesses: datastore({
+      filename: path.join(dbPath, 'connectionaccesses.db')
+    }),
+    queries: datastore({ filename: path.join(dbPath, 'queries.db') }),
+    queryHistory: datastore({ filename: path.join(dbPath, 'queryhistory.db') }),
+    cache: datastore({ filename: path.join(dbPath, 'cache.db') }),
+    instances: [
+      'users',
+      'connections',
+      'connectionAccesses',
+      'queries',
+      'queryHistory',
+      'cache'
+    ]
+  };
+
+  // Load dbs, migrate data, and apply indexes
+  async function init() {
+    await Promise.all(
+      nedb.instances.map(dbname => {
+        logger.info('Loading %s', dbname);
+        return nedb[dbname].loadDatabase();
+      })
+    );
+    // create default connection accesses
+    if (allowConnectionAccessToEveryone) {
+      logger.info('Creating access on every connection to every user...');
+      await nedb.connectionAccesses.update(
+        {
+          connectionId: consts.EVERY_CONNECTION_ID,
+          userId: consts.EVERYONE_ID
+        },
+        {
+          connectionId: consts.EVERY_CONNECTION_ID,
+          connectionName: consts.EVERY_CONNECTION_NAME,
+          userId: consts.EVERYONE_ID,
+          userEmail: consts.EVERYONE_EMAIL,
+          duration: 0,
+          expiryDate: new Date(new Date().setFullYear(2099))
+        },
+        {
+          upsert: true
+        }
+      );
+    }
+    // Apply indexes
+    await nedb.users.ensureIndex({ fieldName: 'email', unique: true });
+    await nedb.cache.ensureIndex({ fieldName: 'cacheKey', unique: true });
+    await nedb.connectionAccesses.ensureIndex({ fieldName: 'connectionId' });
+    await nedb.connectionAccesses.ensureIndex({ fieldName: 'userId' });
+    await nedb.queryHistory.ensureIndex({ fieldName: 'connectionName' });
+    await nedb.queryHistory.ensureIndex({ fieldName: 'userEmail' });
+    await nedb.queryHistory.ensureIndex({ fieldName: 'createdDate' });
+    // set autocompaction
+    const tenMinutes = 1000 * 60 * 10;
+    nedb.instances.forEach(dbname => {
+      nedb[dbname].nedb.persistence.setAutocompactionInterval(tenMinutes);
+    });
+    return ensureAdmin();
   }
 
-  try {
-    // if an admin was passed in the command line, check to see if a user exists with that email
-    // if so, set the admin to true
-    // if not, whitelist the email address.
-    // Then log that the person should visit the signup url to finish registration.
-    const user = await db.users.findOne({ email: adminEmail });
-    if (user) {
-      const changes = { role: 'admin' };
-      if (adminPassword) {
-        changes.passhash = await passhash.getPasshash(adminPassword);
-      }
-      await db.users.update({ _id: user._id }, { $set: changes }, {});
-      logger.info('Admin access granted to %s', adminEmail);
+  await init();
+
+  async function ensureAdmin() {
+    const adminEmail = admin;
+    if (!adminEmail) {
       return;
     }
 
-    const newAdmin = {
-      email: adminEmail,
-      role: 'admin'
-    };
-    if (adminPassword) {
-      newAdmin.passhash = await passhash.getPasshash(adminPassword);
+    try {
+      // if an admin was passed in the command line, check to see if a user exists with that email
+      // if so, set the admin to true
+      // if not, whitelist the email address.
+      // Then log that the person should visit the signup url to finish registration.
+      const user = await nedb.users.findOne({ email: adminEmail });
+      if (user) {
+        const changes = { role: 'admin' };
+        if (adminPassword) {
+          changes.passhash = await passhash.getPasshash(adminPassword);
+        }
+        await nedb.users.update({ _id: user._id }, { $set: changes }, {});
+        logger.info('Admin access granted to %s', adminEmail);
+        return;
+      }
+
+      const newAdmin = {
+        email: adminEmail,
+        role: 'admin'
+      };
+      if (adminPassword) {
+        newAdmin.passhash = await passhash.getPasshash(adminPassword);
+      }
+      await nedb.users.insert(newAdmin);
+      logger.info('Admin access granted to %s', adminEmail);
+      logger.info('Please visit signup to complete registration.');
+    } catch (error) {
+      logger.error('Admin access grant failed for %s', adminEmail);
+      throw error;
     }
-    await db.users.insert(newAdmin);
-    logger.info('Admin access granted to %s', adminEmail);
-    logger.info('Please visit signup to complete registration.');
-  } catch (error) {
-    logger.error('Admin access grant failed for %s', adminEmail);
-    throw error;
   }
+
+  return nedb;
 }
 
-module.exports = db;
+function makeNedb(config, instanceAlias = 'default') {
+  // makeNedb should only be called once for a given alias
+  if (instances[instanceAlias]) {
+    throw new Error(`db instance ${instanceAlias} already made`);
+  }
+  const dbPromise = initNedb(config);
+  instances[instanceAlias] = dbPromise;
+  return dbPromise;
+}
+
+module.exports = {
+  makeNedb,
+  getNedb
+};

--- a/server/lib/ensureAdmin.js
+++ b/server/lib/ensureAdmin.js
@@ -1,0 +1,48 @@
+const passhash = require('./passhash');
+const logger = require('./logger');
+
+/**
+ * Ensure admin email is a user if provided
+ * If password is provided, update password
+ * @param {object} nedb
+ * @param {string} adminEmail
+ * @param {string} adminPassword
+ */
+async function ensureAdmin(nedb, adminEmail, adminPassword) {
+  if (!adminEmail) {
+    return;
+  }
+
+  try {
+    // if an admin was passed in the command line, check to see if a user exists with that email
+    // if so, set the admin to true
+    // if not, whitelist the email address.
+    // Then log that the person should visit the signup url to finish registration.
+    const user = await nedb.users.findOne({ email: adminEmail });
+    if (user) {
+      const changes = { role: 'admin' };
+      if (adminPassword) {
+        changes.passhash = await passhash.getPasshash(adminPassword);
+      }
+      await nedb.users.update({ _id: user._id }, { $set: changes }, {});
+      logger.info('Admin access granted to %s', adminEmail);
+      return;
+    }
+
+    const newAdmin = {
+      email: adminEmail,
+      role: 'admin'
+    };
+    if (adminPassword) {
+      newAdmin.passhash = await passhash.getPasshash(adminPassword);
+    }
+    await nedb.users.insert(newAdmin);
+    logger.info('Admin access granted to %s', adminEmail);
+    logger.info('Please visit signup to complete registration.');
+  } catch (error) {
+    logger.error('Admin access grant failed for %s', adminEmail);
+    throw error;
+  }
+}
+
+module.exports = ensureAdmin;

--- a/server/middleware/must-have-connection-access-or-chart-link-noauth.js
+++ b/server/middleware/must-have-connection-access-or-chart-link-noauth.js
@@ -1,18 +1,19 @@
 const mustBeAuthenticated = require('./must-be-authenticated');
-const connectionAccessesUtil = require('../models/connectionAccesses.js');
+const getModels = require('../models');
 
 // If admin or has connection access then continue
 // If no access don't continue but return 200 with an error message
 module.exports = [
   mustBeAuthenticated,
   async function mustHaveConnectionAccessOrChartLinkNoAuth(req, res, next) {
+    const models = getModels(req.nedb);
     if (
       req.user.role === 'admin' ||
       !req.config.get('tableChartLinksRequireAuth')
     ) {
       return next();
     }
-    const connectionAccess = await connectionAccessesUtil.findOneActiveByConnectionIdAndUserId(
+    const connectionAccess = await models.connectionAccesses.findOneActiveByConnectionIdAndUserId(
       req.body.connectionId,
       req.user.id
     );

--- a/server/middleware/must-have-connection-access.js
+++ b/server/middleware/must-have-connection-access.js
@@ -1,16 +1,17 @@
 const mustBeAuthenticated = require('./must-be-authenticated');
-const connectionAccessesUtil = require('../models/connectionAccesses.js');
+const getModels = require('../models');
 
 // If admin or has connection access then continue
 // If no access don't continue but return 200 with an error message
 module.exports = [
   mustBeAuthenticated,
   async function mustHaveConnectionAccess(req, res, next) {
+    const models = getModels(req.nedb);
     if (req.user.role === 'admin') {
       return next();
     }
     const connectionId = req.params.connectionId || req.body.connectionId;
-    const connectionAccess = await connectionAccessesUtil.findOneActiveByConnectionIdAndUserId(
+    const connectionAccess = await models.connectionAccesses.findOneActiveByConnectionIdAndUserId(
       connectionId,
       req.user.id
     );

--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -1,5 +1,6 @@
 const passport = require('passport');
-const usersUtil = require('../models/users.js');
+const { getNedb } = require('../lib/db');
+const getModels = require('../models');
 
 // For actual passport strategy implementations, refer to related route files:
 //   Local & Basic:  routes/signup-signin-signout.js
@@ -14,7 +15,9 @@ passport.serializeUser(function(user, done) {
 
 passport.deserializeUser(async function(id, done) {
   try {
-    const user = await usersUtil.findOneById(id);
+    const nedb = await getNedb();
+    const models = getModels(nedb);
+    const user = await models.users.findOneById(id);
     if (user) {
       return done(null, {
         id: user._id,

--- a/server/models/connectionAccesses.js
+++ b/server/models/connectionAccesses.js
@@ -1,5 +1,4 @@
 const Joi = require('@hapi/joi');
-const db = require('../lib/db.js');
 const consts = require('../lib/consts');
 
 const schema = Joi.object({
@@ -18,123 +17,127 @@ const schema = Joi.object({
   modifiedDate: Joi.date().default(Date.now)
 });
 
-async function save(data) {
-  if (!data.connectionId) {
-    throw new Error('connectionId required when saving connection access');
-  }
-
-  if (!data.userId) {
-    throw new Error('userId required when saving connection access');
-  }
-
-  if (data.duration > 0) {
-    data.expiryDate = new Date(new Date().getTime() + data.duration * 1000);
-  } else {
-    data.expiryDate = new Date().setFullYear(2099);
-  }
-
-  const joiResult = schema.validate(data);
-  if (joiResult.error) {
-    return Promise.reject(joiResult.error);
-  }
-
-  await db.connectionAccesses.update(
-    {
-      connectionId: data.connectionId,
-      connectionName: data.connectionName,
-      userId: data.userId,
-      userEmail: data.userEmail,
-      duration: data.duration,
-      expiryDate: data.expiryDate
-    },
-    joiResult.value,
-    {
-      upsert: true
+function makeConnectionAccesses(nedb) {
+  async function save(data) {
+    if (!data.connectionId) {
+      throw new Error('connectionId required when saving connection access');
     }
-  );
-  return findOneActiveByConnectionIdAndUserId(data.connectionId, data.userId);
-}
 
-async function expire(id) {
-  const connectionAccess = await db.connectionAccesses.findOne({ _id: id });
-  if (!connectionAccess) {
-    throw new Error('Connection access not found');
+    if (!data.userId) {
+      throw new Error('userId required when saving connection access');
+    }
+
+    if (data.duration > 0) {
+      data.expiryDate = new Date(new Date().getTime() + data.duration * 1000);
+    } else {
+      data.expiryDate = new Date().setFullYear(2099);
+    }
+
+    const joiResult = schema.validate(data);
+    if (joiResult.error) {
+      return Promise.reject(joiResult.error);
+    }
+
+    await nedb.connectionAccesses.update(
+      {
+        connectionId: data.connectionId,
+        connectionName: data.connectionName,
+        userId: data.userId,
+        userEmail: data.userEmail,
+        duration: data.duration,
+        expiryDate: data.expiryDate
+      },
+      joiResult.value,
+      {
+        upsert: true
+      }
+    );
+    return findOneActiveByConnectionIdAndUserId(data.connectionId, data.userId);
   }
 
-  connectionAccess.expiryDate = new Date();
-  connectionAccess.modifiedDate = new Date();
+  async function expire(id) {
+    const connectionAccess = await nedb.connectionAccesses.findOne({ _id: id });
+    if (!connectionAccess) {
+      throw new Error('Connection access not found');
+    }
 
-  await db.connectionAccesses.update({ _id: id }, connectionAccess);
-  return findOneById(id);
+    connectionAccess.expiryDate = new Date();
+    connectionAccess.modifiedDate = new Date();
+
+    await nedb.connectionAccesses.update({ _id: id }, connectionAccess);
+    return findOneById(id);
+  }
+
+  function findOneById(id) {
+    return nedb.connectionAccesses.findOne({ _id: id });
+  }
+
+  function findOneActiveByConnectionIdAndUserId(connectionId, userId) {
+    return nedb.connectionAccesses.findOne({
+      $and: [
+        {
+          $or: [
+            {
+              connectionId: { $in: [connectionId, consts.EVERY_CONNECTION_ID] },
+              userId
+            },
+            {
+              connectionId,
+              userId: { $in: [connectionId, consts.EVERYONE_ID] }
+            },
+            {
+              connectionId: consts.EVERY_CONNECTION_ID,
+              userId: consts.EVERYONE_ID
+            }
+          ],
+          expiryDate: { $gt: new Date() }
+        }
+      ]
+    });
+  }
+
+  function findAllActiveByConnectionId(connectionId) {
+    return nedb.connectionAccesses.findOne({
+      connectionId: { $in: [connectionId, consts.EVERY_CONNECTION_ID] },
+      expiryDate: { $gt: new Date() }
+    });
+  }
+
+  function findAllByConnectionId(connectionId) {
+    return nedb.connectionAccesses.findAll({
+      connectionId: { $in: [connectionId, consts.EVERY_CONNECTION_ID] }
+    });
+  }
+
+  function findAllActive() {
+    return nedb.connectionAccesses
+      .cfind({ expiryDate: { $gt: new Date() } })
+      .sort({ expiryDate: -1 })
+      .exec();
+  }
+
+  function findAll() {
+    return nedb.connectionAccesses
+      .cfind({}, {})
+      .sort({ expiryDate: -1 })
+      .exec();
+  }
+
+  function removeById(id) {
+    return nedb.connectionAccesses.remove({ _id: id });
+  }
+
+  return {
+    findOneById,
+    findOneActiveByConnectionIdAndUserId,
+    findAllActiveByConnectionId,
+    findAllByConnectionId,
+    findAllActive,
+    findAll,
+    removeById,
+    expire,
+    save
+  };
 }
 
-function findOneById(id) {
-  return db.connectionAccesses.findOne({ _id: id });
-}
-
-function findOneActiveByConnectionIdAndUserId(connectionId, userId) {
-  return db.connectionAccesses.findOne({
-    $and: [
-      {
-        $or: [
-          {
-            connectionId: { $in: [connectionId, consts.EVERY_CONNECTION_ID] },
-            userId
-          },
-          {
-            connectionId,
-            userId: { $in: [connectionId, consts.EVERYONE_ID] }
-          },
-          {
-            connectionId: consts.EVERY_CONNECTION_ID,
-            userId: consts.EVERYONE_ID
-          }
-        ],
-        expiryDate: { $gt: new Date() }
-      }
-    ]
-  });
-}
-
-function findAllActiveByConnectionId(connectionId) {
-  return db.connectionAccesses.findOne({
-    connectionId: { $in: [connectionId, consts.EVERY_CONNECTION_ID] },
-    expiryDate: { $gt: new Date() }
-  });
-}
-
-function findAllByConnectionId(connectionId) {
-  return db.connectionAccesses.findAll({
-    connectionId: { $in: [connectionId, consts.EVERY_CONNECTION_ID] }
-  });
-}
-
-function findAllActive() {
-  return db.connectionAccesses
-    .cfind({ expiryDate: { $gt: new Date() } })
-    .sort({ expiryDate: -1 })
-    .exec();
-}
-
-function findAll() {
-  return db.connectionAccesses
-    .cfind({}, {})
-    .sort({ expiryDate: -1 })
-    .exec();
-}
-
-function removeById(id) {
-  return db.connectionAccesses.remove({ _id: id });
-}
-
-module.exports = {
-  findOneById,
-  findOneActiveByConnectionIdAndUserId,
-  findAllActiveByConnectionId,
-  findAllByConnectionId,
-  findAllActive,
-  findAll,
-  removeById,
-  expire,
-  save
-};
+module.exports = makeConnectionAccesses;

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -1,83 +1,11 @@
-const logger = require('../lib/logger');
 const _ = require('lodash');
 const drivers = require('../drivers');
 const makeCipher = require('../lib/makeCipher');
 const config = require('../lib/config');
-const getConfigFromFile = require('../lib/config/fromFile.js');
-
-const [configFromFile] = getConfigFromFile() || {};
+// TODO: during app init upsert these into db?
+const { getConnectionsFromConfig } = require('../lib/connectionsFromConfig');
 
 const { cipher, decipher } = makeCipher(config.get('passphrase'));
-
-/**
- * Get connections from config.
- *
- * For environment variables:
- * connection env vars must follow the format:
- * SQLPAD_CONNECTIONS__<connectionId>__<connectionFieldName>
- *
- * <connectionId> can be any value to associate a grouping a fields to a connection instance
- * If supplying a connection that was previously defined in the nedb database,
- * this would map internally to connection._id object.
- *
- * <connectionFieldName> should be a field name identified in drivers.
- *
- * To define connections via envvars, `driver` field should be supplied.
- * _id field is not required, as it is defined in second env var fragment.
- *
- * Example: SQLPAD_CONNECTIONS__ab123__sqlserverEncrypt=""
- *
- * From file, resulting parsed configuration from file is expected to follow format `connections.<id>.<fieldname>`
- * {
- *   connections: {
- *     ab123: {
- *       sqlserverEncrypt: true
- *     }
- *   }
- * }
- *
- * @param {object} env
- * @returns {array<object>} arrayOfConnections
- */
-function getConnectionsFromConfig(env = process.env) {
-  // Create a map of connections from parsing environment variable
-  const connectionsMapFromEnv = Object.keys(env)
-    .filter(key => key.startsWith('SQLPAD_CONNECTIONS__'))
-    .reduce((connectionsMap, envVar) => {
-      // eslint-disable-next-line no-unused-vars
-      const [prefix, id, field] = envVar.split('__');
-      if (!connectionsMap[id]) {
-        connectionsMap[id] = {};
-      }
-      connectionsMap[id][field] = env[envVar];
-      return connectionsMap;
-    }, {});
-
-  // Get copy of connections from config file
-  const { connections } = _.cloneDeep(configFromFile);
-
-  // connections key from file matches format that is constructed from env
-  // merge the 2 together then create an array out of them
-  const connectionsMap = { ...connectionsMapFromEnv, ...connections };
-
-  const connectionsFromConfig = [];
-  Object.keys(connectionsMap).forEach(id => {
-    try {
-      let connection = connectionsMap[id];
-      connection._id = id;
-      connection = drivers.validateConnection(connection);
-      connection.editable = false;
-      connectionsFromConfig.push(connection);
-    } catch (error) {
-      logger.error(
-        error,
-        'Environment connection configuration failed for %s',
-        id
-      );
-    }
-  });
-  return connectionsFromConfig;
-}
 
 function decipherConnection(connection) {
   if (connection.username) {
@@ -148,8 +76,7 @@ function makeConnections(nedb) {
     findAll,
     findOneById,
     removeOneById,
-    save,
-    getConnectionsFromConfig
+    save
   };
 }
 

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -6,8 +6,6 @@ const makeQueries = require('./queries');
 const makeConnections = require('./connections');
 const makeConnectionAccesses = require('./connectionAccesses');
 
-// TODO FIX ME - remove anything that depends on single instance from these utilities
-// (clean up jobs and whatever else)
 module.exports = function(nedb) {
   return {
     users: makeUsers(nedb),

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,0 +1,21 @@
+const makeUsers = require('./users');
+const makeSchemaInfo = require('./schemaInfo');
+const makeResultCache = require('./resultCache');
+const makeQueryHistory = require('./queryHistory');
+const makeQueries = require('./queries');
+const makeConnections = require('./connections');
+const makeConnectionAccesses = require('./connectionAccesses');
+
+// TODO FIX ME - remove anything that depends on single instance from these utilities
+// (clean up jobs and whatever else)
+module.exports = function(nedb) {
+  return {
+    users: makeUsers(nedb),
+    schemaInfo: makeSchemaInfo(nedb),
+    resultCache: makeResultCache(nedb),
+    queryHistory: makeQueryHistory(nedb),
+    queries: makeQueries(nedb),
+    connections: makeConnections(nedb),
+    connectionAccesses: makeConnectionAccesses(nedb)
+  };
+};

--- a/server/models/queryHistory.js
+++ b/server/models/queryHistory.js
@@ -42,12 +42,12 @@ function makeQueryHistory(nedb) {
     const days = config.get('queryHistoryRetentionTimeInDays') * 86400 * 1000;
     const retentionPeriodStartTime = new Date(new Date().getTime() - days);
 
-    // Compaction function called separately in every ten minutes
     return nedb.queryHistory.remove(
       { createdDate: { $lt: retentionPeriodStartTime } },
       { multi: true }
     );
   }
+
   /**
    * Save queryHistory object
    * returns saved queryHistory object

--- a/server/models/queryHistory.js
+++ b/server/models/queryHistory.js
@@ -1,4 +1,3 @@
-const db = require('../lib/db.js');
 const Joi = require('@hapi/joi');
 const config = require('../lib/config');
 
@@ -19,52 +18,56 @@ const schema = Joi.object({
   createdDate: Joi.date().default(new Date())
 });
 
-function findOneById(id) {
-  return db.queryHistory.findOne({ _id: id });
-}
-
-async function findAll() {
-  return db.queryHistory
-    .cfind({}, {})
-    .sort({ startTime: -1 })
-    .exec();
-}
-
-function findByFilter(filter) {
-  return db.queryHistory
-    .cfind(filter || {}, {})
-    .sort({ startTime: -1 })
-    .limit(config.get('queryHistoryResultMaxRows'))
-    .exec();
-}
-
-async function removeOldEntries() {
-  const days = config.get('queryHistoryRetentionTimeInDays') * 86400 * 1000;
-  const retentionPeriodStartTime = new Date(new Date().getTime() - days);
-
-  // Compaction function called separately in every ten minutes
-  return db.queryHistory.remove(
-    { createdDate: { $lt: retentionPeriodStartTime } },
-    { multi: true }
-  );
-}
-/**
- * Save queryHistory object
- * returns saved queryHistory object
- * @param {object} queryHistory
- */
-async function save(data) {
-  const joiResult = schema.validate(data);
-  if (joiResult.error) {
-    return Promise.reject(joiResult.error);
+function makeQueryHistory(nedb) {
+  function findOneById(id) {
+    return nedb.queryHistory.findOne({ _id: id });
   }
-  return db.queryHistory.insert(joiResult.value);
+
+  async function findAll() {
+    return nedb.queryHistory
+      .cfind({}, {})
+      .sort({ startTime: -1 })
+      .exec();
+  }
+
+  function findByFilter(filter) {
+    return nedb.queryHistory
+      .cfind(filter || {}, {})
+      .sort({ startTime: -1 })
+      .limit(config.get('queryHistoryResultMaxRows'))
+      .exec();
+  }
+
+  async function removeOldEntries() {
+    const days = config.get('queryHistoryRetentionTimeInDays') * 86400 * 1000;
+    const retentionPeriodStartTime = new Date(new Date().getTime() - days);
+
+    // Compaction function called separately in every ten minutes
+    return nedb.queryHistory.remove(
+      { createdDate: { $lt: retentionPeriodStartTime } },
+      { multi: true }
+    );
+  }
+  /**
+   * Save queryHistory object
+   * returns saved queryHistory object
+   * @param {object} queryHistory
+   */
+  async function save(data) {
+    const joiResult = schema.validate(data);
+    if (joiResult.error) {
+      return Promise.reject(joiResult.error);
+    }
+    return nedb.queryHistory.insert(joiResult.value);
+  }
+
+  return {
+    findOneById,
+    findAll,
+    findByFilter,
+    removeOldEntries,
+    save
+  };
 }
 
-module.exports = {
-  findOneById,
-  findAll,
-  findByFilter,
-  removeOldEntries,
-  save
-};
+module.exports = makeQueryHistory;

--- a/server/models/resultCache.js
+++ b/server/models/resultCache.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const moment = require('moment');
 const sanitize = require('sanitize-filename');
-const db = require('../lib/db.js');
 const logger = require('../lib/logger');
 const xlsx = require('node-xlsx');
 const { parse } = require('json2csv');
@@ -21,32 +20,79 @@ function jsonFilePath(cacheKey) {
   return path.join(dbPath, '/cache/', cacheKey + '.json');
 }
 
-async function findOneByCacheKey(cacheKey) {
-  return db.cache.findOne({ cacheKey });
-}
-
-async function saveResultCache(cacheKey, queryName) {
-  if (!cacheKey) {
-    throw new Error('cacheKey required');
-  }
-  const EIGHT_HOURS = 1000 * 60 * 60 * 8;
-  const expiration = new Date(Date.now() + EIGHT_HOURS);
-  const modifiedDate = new Date();
-
-  const savedQueryName = sanitize(
-    (queryName || 'SQLPad Query Results') + ' ' + moment().format('YYYY-MM-DD')
-  );
-
-  const doc = { cacheKey, expiration, queryName: savedQueryName, modifiedDate };
-
-  const existing = await findOneByCacheKey(cacheKey);
-  if (!existing) {
-    doc.createdDate = new Date();
+function makeResultCache(nedb) {
+  async function findOneByCacheKey(cacheKey) {
+    return nedb.cache.findOne({ cacheKey });
   }
 
-  return db.cache.update({ cacheKey }, doc, {
-    upsert: true
-  });
+  async function saveResultCache(cacheKey, queryName) {
+    if (!cacheKey) {
+      throw new Error('cacheKey required');
+    }
+    const EIGHT_HOURS = 1000 * 60 * 60 * 8;
+    const expiration = new Date(Date.now() + EIGHT_HOURS);
+    const modifiedDate = new Date();
+
+    const savedQueryName = sanitize(
+      (queryName || 'SQLPad Query Results') +
+        ' ' +
+        moment().format('YYYY-MM-DD')
+    );
+
+    const doc = {
+      cacheKey,
+      expiration,
+      queryName: savedQueryName,
+      modifiedDate
+    };
+
+    const existing = await findOneByCacheKey(cacheKey);
+    if (!existing) {
+      doc.createdDate = new Date();
+    }
+
+    return nedb.cache.update({ cacheKey }, doc, {
+      upsert: true
+    });
+  }
+
+  /*  Result cache maintenance
+  ============================================================================== */
+  async function removeExpired() {
+    try {
+      const docs = await nedb.cache.find({ expiration: { $lt: new Date() } });
+      for (const doc of docs) {
+        const filepaths = [
+          xlsxFilePath(doc.cacheKey),
+          csvFilePath(doc.cacheKey)
+        ];
+        filepaths.forEach(fp => {
+          if (fs.existsSync(fp)) {
+            fs.unlinkSync(fp);
+          }
+        });
+        // eslint-disable-next-line no-await-in-loop
+        await nedb.cache.remove({ _id: doc._id }, {});
+      }
+    } catch (error) {
+      logger.error(error);
+    }
+  }
+
+  // Every five minutes check and expire cache
+  const FIVE_MINUTES = 1000 * 60 * 5;
+  setInterval(removeExpired, FIVE_MINUTES);
+
+  return {
+    csvFilePath,
+    findOneByCacheKey,
+    jsonFilePath,
+    saveResultCache,
+    writeCsv,
+    writeJson,
+    writeXlsx,
+    xlsxFilePath
+  };
 }
 
 function writeXlsx(cacheKey, queryResult) {
@@ -119,38 +165,4 @@ function writeJson(cacheKey, queryResult) {
   });
 }
 
-/*  Result cache maintenance
-============================================================================== */
-
-async function removeExpired() {
-  try {
-    const docs = await db.cache.find({ expiration: { $lt: new Date() } });
-    for (const doc of docs) {
-      const filepaths = [xlsxFilePath(doc.cacheKey), csvFilePath(doc.cacheKey)];
-      filepaths.forEach(fp => {
-        if (fs.existsSync(fp)) {
-          fs.unlinkSync(fp);
-        }
-      });
-      // eslint-disable-next-line no-await-in-loop
-      await db.cache.remove({ _id: doc._id }, {});
-    }
-  } catch (error) {
-    logger.error(error);
-  }
-}
-
-// Every five minutes check and expire cache
-const FIVE_MINUTES = 1000 * 60 * 5;
-setInterval(removeExpired, FIVE_MINUTES);
-
-module.exports = {
-  csvFilePath,
-  findOneByCacheKey,
-  jsonFilePath,
-  saveResultCache,
-  writeCsv,
-  writeJson,
-  writeXlsx,
-  xlsxFilePath
-};
+module.exports = makeResultCache;

--- a/server/models/resultCache.js
+++ b/server/models/resultCache.js
@@ -56,8 +56,6 @@ function makeResultCache(nedb) {
     });
   }
 
-  /*  Result cache maintenance
-  ============================================================================== */
   async function removeExpired() {
     try {
       const docs = await nedb.cache.find({ expiration: { $lt: new Date() } });
@@ -79,14 +77,11 @@ function makeResultCache(nedb) {
     }
   }
 
-  // Every five minutes check and expire cache
-  const FIVE_MINUTES = 1000 * 60 * 5;
-  setInterval(removeExpired, FIVE_MINUTES);
-
   return {
     csvFilePath,
     findOneByCacheKey,
     jsonFilePath,
+    removeExpired,
     saveResultCache,
     writeCsv,
     writeJson,

--- a/server/models/schemaInfo.js
+++ b/server/models/schemaInfo.js
@@ -1,55 +1,56 @@
-const db = require('../lib/db.js');
-
 function getCacheKey(connectionId) {
   return 'schemaCache:' + connectionId;
 }
 
-/**
- * Get schemaInfo for connection id
- * @param {string} connectionId
- */
-async function getSchemaInfo(connectionId) {
-  const cacheKey = getCacheKey(connectionId);
-  const doc = await db.cache.findOne({ cacheKey });
+function makeSchemaInfo(nedb) {
+  /**
+   * Get schemaInfo for connection id
+   * @param {string} connectionId
+   */
+  async function getSchemaInfo(connectionId) {
+    const cacheKey = getCacheKey(connectionId);
+    const doc = await nedb.cache.findOne({ cacheKey });
 
-  if (!doc) {
-    return;
+    if (!doc) {
+      return;
+    }
+
+    let schemaInfo;
+    try {
+      schemaInfo =
+        typeof doc.schema === 'string' ? JSON.parse(doc.schema) : doc.schema;
+    } catch (error) {
+      // do nothing. valid schema will be updated
+    }
+
+    return schemaInfo;
   }
 
-  let schemaInfo;
-  try {
-    schemaInfo =
-      typeof doc.schema === 'string' ? JSON.parse(doc.schema) : doc.schema;
-  } catch (error) {
-    // do nothing. valid schema will be updated
+  /**
+   * Save schemaInfo to cache db object
+   * Schema needs to be stringified as JSON
+   * Column names could have dots in name (incompatible with nedb)
+   * @param {string} connectionId
+   * @param {object} schemaInfo
+   */
+  async function saveSchemaInfo(connectionId, schemaInfo) {
+    const cacheKey = getCacheKey(connectionId);
+    if (schemaInfo && Object.keys(schemaInfo).length) {
+      const schema = JSON.stringify(schemaInfo);
+      const doc = {
+        cacheKey,
+        schema,
+        modifiedDate: new Date()
+      };
+      return nedb.cache.update({ cacheKey }, doc, {
+        upsert: true
+      });
+    }
   }
-
-  return schemaInfo;
+  return {
+    getSchemaInfo,
+    saveSchemaInfo
+  };
 }
 
-/**
- * Save schemaInfo to cache db object
- * Schema needs to be stringified as JSON
- * Column names could have dots in name (incompatible with nedb)
- * @param {string} connectionId
- * @param {object} schemaInfo
- */
-async function saveSchemaInfo(connectionId, schemaInfo) {
-  const cacheKey = getCacheKey(connectionId);
-  if (schemaInfo && Object.keys(schemaInfo).length) {
-    const schema = JSON.stringify(schemaInfo);
-    const doc = {
-      cacheKey,
-      schema,
-      modifiedDate: new Date()
-    };
-    return db.cache.update({ cacheKey }, doc, {
-      upsert: true
-    });
-  }
-}
-
-module.exports = {
-  getSchemaInfo,
-  saveSchemaInfo
-};
+module.exports = makeSchemaInfo;

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -1,15 +1,16 @@
 const router = require('express').Router();
 const packageJson = require('../package.json');
-const usersUtil = require('../models/users.js');
+const getModels = require('../models');
 const sendError = require('../lib/sendError');
 
 // NOTE: this route needs a wildcard because it is fetched as a relative url
 // from the front-end. The static SPA does not know if sqlpad is mounted at
 // the root of a domain or if there is a base-url provided in the config
 router.get('*/api/app', async (req, res) => {
-  const { config } = req;
+  const { config, nedb } = req;
   try {
-    const adminRegistrationOpen = await usersUtil.adminRegistrationOpen();
+    const models = getModels(nedb);
+    const adminRegistrationOpen = await models.users.adminRegistrationOpen();
     const currentUser =
       req.isAuthenticated() && req.user
         ? {

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -1,5 +1,5 @@
 const router = require('express').Router();
-const connections = require('../models/connections.js');
+const getModels = require('../models');
 const mustBeAdmin = require('../middleware/must-be-admin.js');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const sendError = require('../lib/sendError');
@@ -11,7 +11,8 @@ function removePassword(connection) {
 
 router.get('/api/connections', mustBeAuthenticated, async function(req, res) {
   try {
-    const docs = await connections.findAll();
+    const models = getModels(req.nedb);
+    const docs = await models.connections.findAll();
     return res.json({
       connections: docs.map(removePassword)
     });
@@ -25,7 +26,8 @@ router.get('/api/connections/:_id', mustBeAuthenticated, async function(
   res
 ) {
   try {
-    const connection = await connections.findOneById(req.params._id);
+    const models = getModels(req.nedb);
+    const connection = await models.connections.findOneById(req.params._id);
     if (!connection) {
       return sendError(res, null, 'Connection not found');
     }
@@ -39,7 +41,8 @@ router.get('/api/connections/:_id', mustBeAuthenticated, async function(
 
 router.post('/api/connections', mustBeAdmin, async function(req, res) {
   try {
-    const newConnection = await connections.save(req.body);
+    const models = getModels(req.nedb);
+    const newConnection = await models.connections.save(req.body);
     return res.json({
       connection: removePassword(newConnection)
     });
@@ -50,12 +53,13 @@ router.post('/api/connections', mustBeAdmin, async function(req, res) {
 
 router.put('/api/connections/:_id', mustBeAdmin, async function(req, res) {
   try {
-    let connection = await connections.findOneById(req.params._id);
+    const models = getModels(req.nedb);
+    let connection = await models.connections.findOneById(req.params._id);
     if (!connection) {
       return sendError(res, null, 'Connection not found');
     }
     Object.assign(connection, req.body);
-    connection = await connections.save(connection);
+    connection = await models.connections.save(connection);
     return res.json({
       connection: removePassword(connection)
     });
@@ -66,7 +70,8 @@ router.put('/api/connections/:_id', mustBeAdmin, async function(req, res) {
 
 router.delete('/api/connections/:_id', mustBeAdmin, async function(req, res) {
   try {
-    await connections.removeOneById(req.params._id);
+    const models = getModels(req.nedb);
+    await models.connections.removeOneById(req.params._id);
     return res.json({});
   } catch (error) {
     sendError(res, error, 'Problem deleting connection');

--- a/server/routes/download-results.js
+++ b/server/routes/download-results.js
@@ -1,13 +1,14 @@
 const fs = require('fs');
 const router = require('express').Router();
-const resultCache = require('../models/resultCache.js');
+const getModels = require('../models');
 const logger = require('../lib/logger');
 
 router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
   const { cacheKey } = req.params;
+  const models = getModels(req.nedb);
   try {
     if (req.config.get('allowCsvDownload')) {
-      const cache = await resultCache.findOneByCacheKey(cacheKey);
+      const cache = await models.resultCache.findOneByCacheKey(cacheKey);
       if (!cache) {
         return next(new Error('Result cache not found'));
       }
@@ -17,7 +18,7 @@ router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
         'attachment; filename="' + encodeURIComponent(filename) + '"'
       );
       res.setHeader('Content-Type', 'text/csv');
-      fs.createReadStream(resultCache.csvFilePath(cacheKey)).pipe(res);
+      fs.createReadStream(models.resultCache.csvFilePath(cacheKey)).pipe(res);
     } else {
       return next(new Error('CSV download disabled'));
     }
@@ -30,9 +31,10 @@ router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
 
 router.get('/download-results/:cacheKey.xlsx', async function(req, res, next) {
   const { cacheKey } = req.params;
+  const models = getModels(req.nedb);
   try {
     if (req.config.get('allowCsvDownload')) {
-      const cache = await resultCache.findOneByCacheKey(cacheKey);
+      const cache = await models.resultCache.findOneByCacheKey(cacheKey);
       if (!cache) {
         return next(new Error('Result cache not found'));
       }
@@ -45,7 +47,7 @@ router.get('/download-results/:cacheKey.xlsx', async function(req, res, next) {
         'Content-Type',
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
       );
-      fs.createReadStream(resultCache.xlsxFilePath(cacheKey)).pipe(res);
+      fs.createReadStream(models.resultCache.xlsxFilePath(cacheKey)).pipe(res);
     } else {
       return next(new Error('XLSX download disabled'));
     }
@@ -58,9 +60,10 @@ router.get('/download-results/:cacheKey.xlsx', async function(req, res, next) {
 
 router.get('/download-results/:cacheKey.json', async function(req, res, next) {
   const { cacheKey } = req.params;
+  const models = getModels(req.nedb);
   try {
     if (req.config.get('allowCsvDownload')) {
-      const cache = await resultCache.findOneByCacheKey(cacheKey);
+      const cache = await models.resultCache.findOneByCacheKey(cacheKey);
       if (!cache) {
         return next(new Error('Result cache not found'));
       }
@@ -70,7 +73,7 @@ router.get('/download-results/:cacheKey.json', async function(req, res, next) {
         'attachment; filename="' + encodeURIComponent(filename) + '"'
       );
       res.setHeader('Content-Type', 'application/json');
-      fs.createReadStream(resultCache.jsonFilePath(cacheKey)).pipe(res);
+      fs.createReadStream(models.resultCache.jsonFilePath(cacheKey)).pipe(res);
     } else {
       return next(new Error('JSON download disabled'));
     }

--- a/server/routes/forgot-password.js
+++ b/server/routes/forgot-password.js
@@ -1,11 +1,12 @@
 const router = require('express').Router();
 const uuid = require('uuid');
-const usersUtil = require('../models/users.js');
+const getModels = require('../models');
 const makeEmail = require('../lib/email');
 const sendError = require('../lib/sendError');
 const logger = require('../lib/logger');
 
 router.post('/api/forgot-password', async function(req, res) {
+  const models = getModels(req.nedb);
   if (!req.body.email) {
     return sendError(res, null, 'Email address must be provided');
   }
@@ -16,7 +17,7 @@ router.post('/api/forgot-password', async function(req, res) {
   const email = makeEmail(req.config);
 
   try {
-    const user = await usersUtil.findOneByEmail(req.body.email);
+    const user = await models.users.findOneByEmail(req.body.email);
 
     // If user not found send success regardless
     // This is not a user-validation service
@@ -26,7 +27,7 @@ router.post('/api/forgot-password', async function(req, res) {
 
     user.passwordResetId = uuid.v4();
 
-    await usersUtil.save(user);
+    await models.users.save(user);
 
     // Send email, but do not block response
     const resetPath = `/password-reset/${user.passwordResetId}`;

--- a/server/routes/password-reset.js
+++ b/server/routes/password-reset.js
@@ -1,11 +1,12 @@
 const router = require('express').Router();
-const usersUtil = require('../models/users.js');
+const getModels = require('../models');
 const sendError = require('../lib/sendError');
 
 // This route used to set new password given a passwordResetId
 router.post('/api/password-reset/:passwordResetId', async function(req, res) {
   try {
-    const user = await usersUtil.findOneByPasswordResetId(
+    const models = getModels(req.nedb);
+    const user = await models.users.findOneByPasswordResetId(
       req.params.passwordResetId
     );
 
@@ -20,7 +21,7 @@ router.post('/api/password-reset/:passwordResetId', async function(req, res) {
     }
     user.password = req.body.password;
     user.passwordResetId = '';
-    await usersUtil.save(user);
+    await models.users.save(user);
     return res.json({});
   } catch (error) {
     sendError(res, error, 'Problem querying user database');

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -1,5 +1,5 @@
 const router = require('express').Router();
-const queriesUtil = require('../models/queries.js');
+const getModels = require('../models');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const mustBeAuthenticatedOrChartLink = require('../middleware/must-be-authenticated-or-chart-link-noauth.js');
 const sendError = require('../lib/sendError');
@@ -27,7 +27,8 @@ router.delete('/api/queries/:_id', mustBeAuthenticated, async function(
   res
 ) {
   try {
-    await queriesUtil.removeById(req.params._id);
+    const models = getModels(req.nedb);
+    await models.queries.removeById(req.params._id);
     return res.json({});
   } catch (error) {
     sendError(res, error, 'Problem deleting query');
@@ -36,7 +37,8 @@ router.delete('/api/queries/:_id', mustBeAuthenticated, async function(
 
 router.get('/api/queries', mustBeAuthenticated, async function(req, res) {
   try {
-    const queries = await queriesUtil.findAll();
+    const models = getModels(req.nedb);
+    const queries = await models.queries.findAll();
     return res.json({ queries });
   } catch (error) {
     sendError(res, error, 'Problem querying query database');
@@ -48,7 +50,8 @@ router.get('/api/queries/:_id', mustBeAuthenticatedOrChartLink, async function(
   res
 ) {
   try {
-    const query = await queriesUtil.findOneById(req.params._id);
+    const models = getModels(req.nedb);
+    const query = await models.queries.findOneById(req.params._id);
     if (!query) {
       return res.json({
         query: {}
@@ -75,7 +78,8 @@ router.post('/api/queries', mustBeAuthenticated, async function(req, res) {
   };
 
   try {
-    const newQuery = await queriesUtil.save(query);
+    const models = getModels(req.nedb);
+    const newQuery = await models.queries.save(query);
     // This is async, but save operation doesn't care about when/if finished
     pushQueryToSlack(req.config, newQuery);
     return res.json({
@@ -88,7 +92,8 @@ router.post('/api/queries', mustBeAuthenticated, async function(req, res) {
 
 router.put('/api/queries/:_id', mustBeAuthenticated, async function(req, res) {
   try {
-    const query = await queriesUtil.findOneById(req.params._id);
+    const models = getModels(req.nedb);
+    const query = await models.queries.findOneById(req.params._id);
     if (!query) {
       return sendError(res, null, 'Query not found');
     }
@@ -111,7 +116,7 @@ router.put('/api/queries/:_id', mustBeAuthenticated, async function(req, res) {
       modifiedBy: email
     });
 
-    const newQuery = await queriesUtil.save(query);
+    const newQuery = await models.queries.save(query);
     return res.json({ query: newQuery });
   } catch (error) {
     sendError(res, error, 'Problem saving query');

--- a/server/routes/saml.js
+++ b/server/routes/saml.js
@@ -2,7 +2,8 @@ const passport = require('passport');
 const SamlStrategy = require('passport-saml').Strategy;
 const router = require('express').Router();
 const logger = require('../lib/logger');
-const usersUtil = require('../models/users.js');
+const { getNedb } = require('../lib/db');
+const getModels = require('../models');
 
 /**
  * Adds passport SAML strategy and SAML auth routes if SAML is configured
@@ -41,7 +42,9 @@ function makeSamlAuth(config) {
             p[
               'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'
             ];
-          const user = await usersUtil.findOneByEmail(email);
+          const nedb = await getNedb();
+          const models = getModels(nedb);
+          const user = await models.users.findOneByEmail(email);
           logger.info('User logged in via SAML %s', email);
           if (!user) {
             return done(null, false);

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -1,12 +1,13 @@
 const _ = require('lodash');
 const router = require('express').Router();
-const queriesUtil = require('../models/queries.js');
+const getModels = require('../models');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const sendError = require('../lib/sendError');
 
 router.get('/api/tags', mustBeAuthenticated, async function(req, res) {
   try {
-    const queries = await queriesUtil.findAll();
+    const models = getModels(req.nedb);
+    const queries = await models.queries.findAll();
     const tags = _.uniq(_.flatten(_.map(queries, 'tags')))
       .sort()
       .filter(t => t);

--- a/server/test/api/password-reset.js
+++ b/server/test/api/password-reset.js
@@ -1,13 +1,16 @@
 const assert = require('assert');
 const utils = require('../utils');
 const uuid = require('uuid');
-const usersUtil = require('../../models/users');
+const { getNedb } = require('../../lib/db');
+const getModels = require('../../models');
 
 async function setReset() {
-  const user = await usersUtil.findOneByEmail('admin@test.com');
+  const nedb = await getNedb();
+  const models = getModels(nedb);
+  const user = await models.users.findOneByEmail('admin@test.com');
   const passwordResetId = uuid.v4();
   user.passwordResetId = passwordResetId;
-  await usersUtil.save(user);
+  await models.users.save(user);
   return passwordResetId;
 }
 

--- a/server/test/models/connections.js
+++ b/server/test/models/connections.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { getNedb } = require('../../lib/db');
+const { getConnectionsFromConfig } = require('../../lib/connectionsFromConfig');
 const getModels = require('../../models');
 
 describe('getConnectionsFromConfig', function() {
@@ -12,12 +13,12 @@ describe('getConnectionsFromConfig', function() {
   });
 
   it('handles empty object', function() {
-    const cs = models.connections.getConnectionsFromConfig({});
+    const cs = getConnectionsFromConfig({});
     assert(Array.isArray(cs));
   });
 
   it('skips partial connections', function() {
-    const cs = models.connections.getConnectionsFromConfig({
+    const cs = getConnectionsFromConfig({
       SQLPAD_CONNECTIONS__abc__driver: 'postgres'
     });
     assert(Array.isArray(cs));
@@ -25,7 +26,7 @@ describe('getConnectionsFromConfig', function() {
   });
 
   it('parses connection properly', function() {
-    const cs = models.connections.getConnectionsFromConfig({
+    const cs = getConnectionsFromConfig({
       SQLPAD_CONNECTIONS__abc__driver: 'postgres',
       SQLPAD_CONNECTIONS__abc__name: 'env-postgres',
       SQLPAD_CONNECTIONS__abc__host: 'localhost',

--- a/server/test/models/connections.js
+++ b/server/test/models/connections.js
@@ -1,14 +1,23 @@
 const assert = require('assert');
-const connections = require('../../models/connections.js');
+const { getNedb } = require('../../lib/db');
+const getModels = require('../../models');
 
 describe('getConnectionsFromConfig', function() {
+  let nedb;
+  let models;
+
+  before(async function() {
+    nedb = await getNedb();
+    models = getModels(nedb);
+  });
+
   it('handles empty object', function() {
-    const cs = connections.getConnectionsFromConfig({});
+    const cs = models.connections.getConnectionsFromConfig({});
     assert(Array.isArray(cs));
   });
 
   it('skips partial connections', function() {
-    const cs = connections.getConnectionsFromConfig({
+    const cs = models.connections.getConnectionsFromConfig({
       SQLPAD_CONNECTIONS__abc__driver: 'postgres'
     });
     assert(Array.isArray(cs));
@@ -16,7 +25,7 @@ describe('getConnectionsFromConfig', function() {
   });
 
   it('parses connection properly', function() {
-    const cs = connections.getConnectionsFromConfig({
+    const cs = models.connections.getConnectionsFromConfig({
       SQLPAD_CONNECTIONS__abc__driver: 'postgres',
       SQLPAD_CONNECTIONS__abc__name: 'env-postgres',
       SQLPAD_CONNECTIONS__abc__host: 'localhost',
@@ -42,7 +51,7 @@ describe('getConnectionsFromConfig', function() {
     process.env.SQLPAD_CONNECTIONS__abc__port = '5432';
     process.env.SQLPAD_CONNECTIONS__abc__postgresSsl = 'true';
 
-    const allConnections = await connections.findAll();
+    const allConnections = await models.connections.findAll();
     const connection = allConnections.find(c => c._id === 'abc');
     assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
     assert.strictEqual(connection.editable, false, 'connection.editable');
@@ -61,7 +70,7 @@ describe('getConnectionsFromConfig', function() {
     process.env.SQLPAD_CONNECTIONS__abc__port = '5432';
     process.env.SQLPAD_CONNECTIONS__abc__postgresSsl = 'true';
 
-    const connection = await connections.findOneById('abc');
+    const connection = await models.connections.findOneById('abc');
     assert.strictEqual(connection.name, 'env-postgres', 'connection.name');
     assert.strictEqual(connection.editable, false, 'connection.editable');
 


### PR DESCRIPTION
Refactors app and models to take nedb as a parameter in an effort to reduce references to config and db/models objects, which is an effort to help make things easier to test (#539)

Some notes on how things are arranged with this PR:

`/lib/db.js` manages creating and getting the nedb instance. Getting the nedb via `getNedb` should be done as little as possible, as it is kind of an escape hatch to deal with cases where nedb isn't being passed in to various functions. For most cases, the nedb instance should be pulled from `req.nedb`. 

All model utilities have been restructured to be the result of a factory function of sorts, taking an nedb instance to build. These model utilities have been modified to be stateless functions. 

A common pattern throughout the application is to take the `nedb` reference from `req` and build model utilities from it.

This gets a bit repetitive, but enables auto complete in vs code, and provides some clarity as to where these functions are coming from. (If there's a way to note this in the JS using some fancy jsdoc syntax to provide this benefit, I'd be open to populating `req.models` in middleware and removing this repetitive code.)