### PR TITLE
Passport/auth refinements

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -123,7 +123,8 @@ function makeApp(config, nedb) {
     require('./routes/schema-info.js'),
     require('./routes/tags.js'),
     require('./routes/format-sql.js'),
-    require('./routes/signup-signin-signout.js')(config),
+    require('./routes/signout.js'),
+    require('./routes/local-auth.js')(config),
     require('./routes/oauth.js')(config),
     require('./routes/saml.js')(config)
   ];

--- a/server/routes/local-auth.js
+++ b/server/routes/local-auth.js
@@ -146,19 +146,6 @@ function makeLocalAuth(config) {
     router.post('/api/signin', passport.authenticate('local'), sendSuccess);
   }
 
-  // Sign out route should always exist
-  router.get('/api/signout', function(req, res) {
-    if (!req.session) {
-      return res.json({});
-    }
-    req.session.destroy(function(err) {
-      if (err) {
-        logger.error(err);
-      }
-      res.json({});
-    });
-  });
-
   return router;
 }
 

--- a/server/routes/oauth.js
+++ b/server/routes/oauth.js
@@ -3,7 +3,6 @@ const PassportGoogleStrategy = require('passport-google-oauth20').Strategy;
 const router = require('express').Router();
 const logger = require('../lib/logger');
 const checkWhitelist = require('../lib/check-whitelist.js');
-const { getNedb } = require('../lib/db');
 const getModels = require('../models');
 
 /**
@@ -17,6 +16,7 @@ function makeGoogleAuth(config) {
   const publicUrl = config.get('publicUrl');
 
   async function passportGoogleStrategyHandler(
+    req,
     accessToken,
     refreshToken,
     profile,
@@ -30,8 +30,7 @@ function makeGoogleAuth(config) {
       });
     }
 
-    const nedb = await getNedb();
-    const models = getModels(nedb);
+    const models = getModels(req.nedb);
 
     try {
       let [openAdminRegistration, user] = await Promise.all([
@@ -73,6 +72,7 @@ function makeGoogleAuth(config) {
     passport.use(
       new PassportGoogleStrategy(
         {
+          passReqToCallback: true,
           clientID: googleClientId,
           clientSecret: googleClientSecret,
           callbackURL: publicUrl + baseUrl + '/auth/google/callback',

--- a/server/routes/signout.js
+++ b/server/routes/signout.js
@@ -1,0 +1,18 @@
+const router = require('express').Router();
+const logger = require('../lib/logger');
+
+// Regardless of authentication strategy, signout route should always exist
+// It clears out the session which is used regardless of strategy
+router.get('/api/signout', function(req, res) {
+  if (!req.session) {
+    return res.json({});
+  }
+  req.session.destroy(function(err) {
+    if (err) {
+      logger.error(err);
+    }
+    res.json({});
+  });
+});
+
+module.exports = router;

--- a/server/routes/signup-signin-signout.js
+++ b/server/routes/signup-signin-signout.js
@@ -4,7 +4,6 @@ const BasicStrategy = require('passport-http').BasicStrategy;
 const router = require('express').Router();
 const checkWhitelist = require('../lib/check-whitelist');
 const getModels = require('../models');
-const { getNedb } = require('../lib/db');
 const sendError = require('../lib/sendError');
 const logger = require('../lib/logger');
 const passhash = require('../lib/passhash.js');
@@ -72,12 +71,17 @@ function makeLocalAuth(config) {
     passport.use(
       new PassportLocalStrategy(
         {
+          passReqToCallback: true,
           usernameField: 'email'
         },
-        async function passportLocalStrategyHandler(email, password, done) {
+        async function passportLocalStrategyHandler(
+          req,
+          email,
+          password,
+          done
+        ) {
           try {
-            const nedb = await getNedb();
-            const models = getModels(nedb);
+            const models = getModels(req.nedb);
             const user = await models.users.findOneByEmail(email);
             if (!user) {
               return done(null, false, { message: 'wrong email or password' });
@@ -105,26 +109,30 @@ function makeLocalAuth(config) {
     // TODO - basic auth should perhaps be something opted into as a separate config
     logger.info('Enabling basic authentication strategy.');
     passport.use(
-      new BasicStrategy(async function(username, password, callback) {
-        try {
-          const nedb = await getNedb();
-          const models = getModels(nedb);
-          const user = await models.users.findOneByEmail(username);
-          if (!user) {
-            return callback(null, false);
+      new BasicStrategy(
+        {
+          passReqToCallback: true
+        },
+        async function(req, username, password, callback) {
+          try {
+            const models = getModels(req.nedb);
+            const user = await models.users.findOneByEmail(username);
+            if (!user) {
+              return callback(null, false);
+            }
+            const isMatch = await passhash.comparePassword(
+              password,
+              user.passhash
+            );
+            if (!isMatch) {
+              return callback(null, false);
+            }
+            return callback(null, user);
+          } catch (error) {
+            callback(error);
           }
-          const isMatch = await passhash.comparePassword(
-            password,
-            user.passhash
-          );
-          if (!isMatch) {
-            return callback(null, false);
-          }
-          return callback(null, user);
-        } catch (error) {
-          callback(error);
         }
-      })
+      )
     );
 
     // Add routes for local auth signup & signin


### PR DESCRIPTION
Misc set of improvements to auth code organization

* Passport authentication strategies use `passReqToCallback` to receive the `req` object in verification function. This is useful as it allows referencing the nedb instance decorated on all requests. This reduces the need for the hacky workaround storing a global database connection reference via `getNedb`
* deserializeUser also has been updated to receive the `req` object. This was available in passport, but undocumented.
* The entire user object is stored on `req` instead of a subset of user info. 
* Local auth strategy and routes have been broken out from signout route file. The signout route is always applicable