### PR TITLE
Add model classes and middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const helmet = require('helmet');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 const logger = require('./lib/logger');
+const getModels = require('./models');
 
 /**
  * Create an express app using config
@@ -43,7 +44,7 @@ function makeApp(config, nedb) {
   });
 
   /*  Express setup
-============================================================================= */
+  ============================================================================= */
   const bodyParser = require('body-parser');
   const favicon = require('serve-favicon');
   const passport = require('passport');
@@ -64,6 +65,7 @@ function makeApp(config, nedb) {
   app.use(function(req, res, next) {
     req.config = config;
     req.nedb = nedb;
+    req.models = getModels(nedb);
     next();
   });
 
@@ -97,7 +99,7 @@ function makeApp(config, nedb) {
   app.use(baseUrl, express.static(path.join(__dirname, 'public')));
 
   /*  Passport setup
-============================================================================= */
+  ============================================================================= */
   require('./middleware/passport.js');
 
   // If local auth is not disabled, support basic auth using a user's email and password
@@ -107,7 +109,7 @@ function makeApp(config, nedb) {
   }
 
   /*  Routes
-============================================================================= */
+  ============================================================================= */
   const routers = [
     require('./routes/drivers.js'),
     require('./routes/users.js'),

--- a/server/app.js
+++ b/server/app.js
@@ -64,7 +64,6 @@ function makeApp(config, nedb) {
   // Decorate req with app things
   app.use(function(req, res, next) {
     req.config = config;
-    req.nedb = nedb;
     req.models = getModels(nedb);
     next();
   });

--- a/server/middleware/must-have-connection-access-or-chart-link-noauth.js
+++ b/server/middleware/must-have-connection-access-or-chart-link-noauth.js
@@ -1,12 +1,11 @@
 const mustBeAuthenticated = require('./must-be-authenticated');
-const getModels = require('../models');
 
 // If admin or has connection access then continue
 // If no access don't continue but return 200 with an error message
 module.exports = [
   mustBeAuthenticated,
   async function mustHaveConnectionAccessOrChartLinkNoAuth(req, res, next) {
-    const models = getModels(req.nedb);
+    const { models } = req;
     if (
       req.user.role === 'admin' ||
       !req.config.get('tableChartLinksRequireAuth')

--- a/server/middleware/must-have-connection-access.js
+++ b/server/middleware/must-have-connection-access.js
@@ -1,12 +1,11 @@
 const mustBeAuthenticated = require('./must-be-authenticated');
-const getModels = require('../models');
 
 // If admin or has connection access then continue
 // If no access don't continue but return 200 with an error message
 module.exports = [
   mustBeAuthenticated,
   async function mustHaveConnectionAccess(req, res, next) {
-    const models = getModels(req.nedb);
+    const { models } = req;
     if (req.user.role === 'admin') {
       return next();
     }

--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -1,5 +1,4 @@
 const passport = require('passport');
-const getModels = require('../models');
 
 // For actual passport strategy implementations, refer to related route files:
 //   Local & Basic:  routes/signup-signin-signout.js
@@ -21,8 +20,8 @@ passport.serializeUser(function(user, done) {
 // https://github.com/jaredhanson/passport/issues/743
 // https://github.com/passport/www.passportjs.org/pull/83/files
 passport.deserializeUser(async function(req, id, done) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const user = await models.users.findOneById(id);
     if (user) {
       // decorate req.user with full user object, plus `id` aliased for _id

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -17,9 +17,13 @@ function decipherConnection(connection) {
   return connection;
 }
 
-function makeConnections(nedb) {
-  async function findAll() {
-    let connectionsFromDb = await nedb.connections.find({});
+class Connections {
+  constructor(nedb) {
+    this.nedb = nedb;
+  }
+
+  async findAll() {
+    let connectionsFromDb = await this.nedb.connections.find({});
     connectionsFromDb = connectionsFromDb.map(conn => {
       conn.editable = true;
       return decipherConnection(conn);
@@ -29,8 +33,8 @@ function makeConnections(nedb) {
     return _.sortBy(allConnections, c => c.name.toLowerCase());
   }
 
-  async function findOneById(id) {
-    const connection = await nedb.connections.findOne({ _id: id });
+  async findOneById(id) {
+    const connection = await this.nedb.connections.findOne({ _id: id });
     if (connection) {
       connection.editable = true;
       return decipherConnection(connection);
@@ -44,11 +48,11 @@ function makeConnections(nedb) {
     return connectionFromEnv;
   }
 
-  async function removeOneById(id) {
-    return nedb.connections.remove({ _id: id });
+  async removeOneById(id) {
+    return this.nedb.connections.remove({ _id: id });
   }
 
-  async function save(connection) {
+  async save(connection) {
     if (!connection) {
       throw new Error('connections.save() requires a connection');
     }
@@ -65,19 +69,12 @@ function makeConnections(nedb) {
     const { _id } = connection;
 
     if (_id) {
-      await nedb.connections.update({ _id }, connection, {});
-      return findOneById(_id);
+      await this.nedb.connections.update({ _id }, connection, {});
+      return this.findOneById(_id);
     }
-    const newDoc = await nedb.connections.insert(connection);
-    return findOneById(newDoc._id);
+    const newDoc = await this.nedb.connections.insert(connection);
+    return this.findOneById(newDoc._id);
   }
-
-  return {
-    findAll,
-    findOneById,
-    removeOneById,
-    save
-  };
 }
 
-module.exports = makeConnections;
+module.exports = Connections;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -4,7 +4,7 @@ const makeResultCache = require('./resultCache');
 const makeQueryHistory = require('./queryHistory');
 const makeQueries = require('./queries');
 const makeConnections = require('./connections');
-const makeConnectionAccesses = require('./connectionAccesses');
+const ConnectionAccesses = require('./connectionAccesses');
 
 module.exports = function(nedb) {
   return {
@@ -14,6 +14,6 @@ module.exports = function(nedb) {
     queryHistory: makeQueryHistory(nedb),
     queries: makeQueries(nedb),
     connections: makeConnections(nedb),
-    connectionAccesses: makeConnectionAccesses(nedb)
+    connectionAccesses: new ConnectionAccesses(nedb)
   };
 };

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,5 +1,5 @@
 const Users = require('./users');
-const makeSchemaInfo = require('./schemaInfo');
+const SchemaInfo = require('./schemaInfo');
 const makeResultCache = require('./resultCache');
 const makeQueryHistory = require('./queryHistory');
 const makeQueries = require('./queries');
@@ -9,7 +9,7 @@ const ConnectionAccesses = require('./connectionAccesses');
 module.exports = function(nedb) {
   return {
     users: new Users(nedb),
-    schemaInfo: makeSchemaInfo(nedb),
+    schemaInfo: new SchemaInfo(nedb),
     resultCache: makeResultCache(nedb),
     queryHistory: makeQueryHistory(nedb),
     queries: makeQueries(nedb),

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,6 +1,6 @@
 const Users = require('./users');
 const SchemaInfo = require('./schemaInfo');
-const makeResultCache = require('./resultCache');
+const ResultCache = require('./resultCache');
 const makeQueryHistory = require('./queryHistory');
 const makeQueries = require('./queries');
 const makeConnections = require('./connections');
@@ -10,7 +10,7 @@ module.exports = function(nedb) {
   return {
     users: new Users(nedb),
     schemaInfo: new SchemaInfo(nedb),
-    resultCache: makeResultCache(nedb),
+    resultCache: new ResultCache(nedb),
     queryHistory: makeQueryHistory(nedb),
     queries: makeQueries(nedb),
     connections: makeConnections(nedb),

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,4 +1,4 @@
-const makeUsers = require('./users');
+const Users = require('./users');
 const makeSchemaInfo = require('./schemaInfo');
 const makeResultCache = require('./resultCache');
 const makeQueryHistory = require('./queryHistory');
@@ -8,7 +8,7 @@ const ConnectionAccesses = require('./connectionAccesses');
 
 module.exports = function(nedb) {
   return {
-    users: makeUsers(nedb),
+    users: new Users(nedb),
     schemaInfo: makeSchemaInfo(nedb),
     resultCache: makeResultCache(nedb),
     queryHistory: makeQueryHistory(nedb),

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,9 +1,9 @@
 const Users = require('./users');
 const SchemaInfo = require('./schemaInfo');
 const ResultCache = require('./resultCache');
-const makeQueryHistory = require('./queryHistory');
-const makeQueries = require('./queries');
-const makeConnections = require('./connections');
+const QueryHistory = require('./queryHistory');
+const Queries = require('./queries');
+const Connections = require('./connections');
 const ConnectionAccesses = require('./connectionAccesses');
 
 module.exports = function(nedb) {
@@ -11,9 +11,9 @@ module.exports = function(nedb) {
     users: new Users(nedb),
     schemaInfo: new SchemaInfo(nedb),
     resultCache: new ResultCache(nedb),
-    queryHistory: makeQueryHistory(nedb),
-    queries: makeQueries(nedb),
-    connections: makeConnections(nedb),
+    queryHistory: new QueryHistory(nedb),
+    queries: new Queries(nedb),
+    connections: new Connections(nedb),
     connectionAccesses: new ConnectionAccesses(nedb)
   };
 };

--- a/server/models/queries.js
+++ b/server/models/queries.js
@@ -43,21 +43,25 @@ const schema = Joi.object({
   lastAccessDate: Joi.date().default(Date.now)
 });
 
-function makeQueries(nedb) {
-  function findOneById(id) {
-    return nedb.queries.findOne({ _id: id });
+class Queries {
+  constructor(nedb) {
+    this.nedb = nedb;
   }
 
-  function findAll() {
-    return nedb.queries.find({});
+  findOneById(id) {
+    return this.nedb.queries.findOne({ _id: id });
   }
 
-  function findByFilter(filter) {
-    return nedb.queries.find(filter);
+  findAll() {
+    return this.nedb.queries.find({});
   }
 
-  function removeById(id) {
-    return nedb.queries.remove({ _id: id });
+  findByFilter(filter) {
+    return this.nedb.queries.find(filter);
+  }
+
+  removeById(id) {
+    return this.nedb.queries.remove({ _id: id });
   }
 
   /**
@@ -65,7 +69,7 @@ function makeQueries(nedb) {
    * returns saved query object
    * @param {object} query
    */
-  async function save(query) {
+  async save(query) {
     query.modifiedDate = new Date();
     query.lastAccessDate = new Date();
 
@@ -85,22 +89,14 @@ function makeQueries(nedb) {
       return Promise.reject(joiResult.error);
     }
     if (query._id) {
-      await nedb.queries.update({ _id: query._id }, joiResult.value, {
+      await this.nedb.queries.update({ _id: query._id }, joiResult.value, {
         upsert: true
       });
-      return findOneById(query._id);
+      return this.findOneById(query._id);
     }
-    const newQuery = await nedb.queries.insert(joiResult.value);
+    const newQuery = await this.nedb.queries.insert(joiResult.value);
     return newQuery;
   }
-
-  return {
-    findOneById,
-    findAll,
-    findByFilter,
-    removeById,
-    save
-  };
 }
 
-module.exports = makeQueries;
+module.exports = Queries;

--- a/server/models/resultCache.js
+++ b/server/models/resultCache.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 const fs = require('fs');
 const path = require('path');
 const moment = require('moment');
@@ -8,24 +9,39 @@ const { parse } = require('json2csv');
 const config = require('../lib/config');
 const dbPath = config.get('dbPath');
 
-function xlsxFilePath(cacheKey) {
-  return path.join(dbPath, '/cache/', cacheKey + '.xlsx');
-}
+// This is a workaround till BigInt is fully supported by the standard
+// See https://tc39.es/ecma262/#sec-ecmascript-language-types-bigint-type
+// and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+// If this is not done, then a JSON.stringify(BigInt) throws
+// "TypeError: Do not know how to serialize a BigInt"
+/* global BigInt:writable */
+/* eslint no-extend-native: ["error", { "exceptions": ["BigInt"] }] */
+BigInt.prototype.toJSON = function() {
+  return this.toString();
+};
 
-function csvFilePath(cacheKey) {
-  return path.join(dbPath, '/cache/', cacheKey + '.csv');
-}
-
-function jsonFilePath(cacheKey) {
-  return path.join(dbPath, '/cache/', cacheKey + '.json');
-}
-
-function makeResultCache(nedb) {
-  async function findOneByCacheKey(cacheKey) {
-    return nedb.cache.findOne({ cacheKey });
+class ResultCache {
+  constructor(nedb) {
+    this.nedb = nedb;
   }
 
-  async function saveResultCache(cacheKey, queryName) {
+  xlsxFilePath(cacheKey) {
+    return path.join(dbPath, '/cache/', cacheKey + '.xlsx');
+  }
+
+  csvFilePath(cacheKey) {
+    return path.join(dbPath, '/cache/', cacheKey + '.csv');
+  }
+
+  jsonFilePath(cacheKey) {
+    return path.join(dbPath, '/cache/', cacheKey + '.json');
+  }
+
+  async findOneByCacheKey(cacheKey) {
+    return this.nedb.cache.findOne({ cacheKey });
+  }
+
+  async saveResultCache(cacheKey, queryName) {
     if (!cacheKey) {
       throw new Error('cacheKey required');
     }
@@ -46,23 +62,25 @@ function makeResultCache(nedb) {
       modifiedDate
     };
 
-    const existing = await findOneByCacheKey(cacheKey);
+    const existing = await this.findOneByCacheKey(cacheKey);
     if (!existing) {
       doc.createdDate = new Date();
     }
 
-    return nedb.cache.update({ cacheKey }, doc, {
+    return this.nedb.cache.update({ cacheKey }, doc, {
       upsert: true
     });
   }
 
-  async function removeExpired() {
+  async removeExpired() {
     try {
-      const docs = await nedb.cache.find({ expiration: { $lt: new Date() } });
+      const docs = await this.nedb.cache.find({
+        expiration: { $lt: new Date() }
+      });
       for (const doc of docs) {
         const filepaths = [
-          xlsxFilePath(doc.cacheKey),
-          csvFilePath(doc.cacheKey)
+          this.xlsxFilePath(doc.cacheKey),
+          this.csvFilePath(doc.cacheKey)
         ];
         filepaths.forEach(fp => {
           if (fs.existsSync(fp)) {
@@ -70,94 +88,73 @@ function makeResultCache(nedb) {
           }
         });
         // eslint-disable-next-line no-await-in-loop
-        await nedb.cache.remove({ _id: doc._id }, {});
+        await this.nedb.cache.remove({ _id: doc._id }, {});
       }
     } catch (error) {
       logger.error(error);
     }
   }
 
-  return {
-    csvFilePath,
-    findOneByCacheKey,
-    jsonFilePath,
-    removeExpired,
-    saveResultCache,
-    writeCsv,
-    writeJson,
-    writeXlsx,
-    xlsxFilePath
-  };
-}
-
-function writeXlsx(cacheKey, queryResult) {
-  // loop through rows and build out an array of arrays
-  const resultArray = [];
-  resultArray.push(queryResult.fields);
-  for (let i = 0; i < queryResult.rows.length; i++) {
-    const row = [];
-    for (let c = 0; c < queryResult.fields.length; c++) {
-      const fieldName = queryResult.fields[c];
-      row.push(queryResult.rows[i][fieldName]);
-    }
-    resultArray.push(row);
-  }
-  const xlsxBuffer = xlsx.build([{ name: 'query-results', data: resultArray }]);
-  return new Promise(resolve => {
-    fs.writeFile(xlsxFilePath(cacheKey), xlsxBuffer, function(err) {
-      // if there's an error log it but otherwise continue on
-      // we can still send results even if download file failed to create
-      if (err) {
-        logger.error(err);
+  writeXlsx(cacheKey, queryResult) {
+    // loop through rows and build out an array of arrays
+    const resultArray = [];
+    resultArray.push(queryResult.fields);
+    for (let i = 0; i < queryResult.rows.length; i++) {
+      const row = [];
+      for (let c = 0; c < queryResult.fields.length; c++) {
+        const fieldName = queryResult.fields[c];
+        row.push(queryResult.rows[i][fieldName]);
       }
-      return resolve();
+      resultArray.push(row);
+    }
+    const xlsxBuffer = xlsx.build([
+      { name: 'query-results', data: resultArray }
+    ]);
+    return new Promise(resolve => {
+      fs.writeFile(this.xlsxFilePath(cacheKey), xlsxBuffer, function(err) {
+        // if there's an error log it but otherwise continue on
+        // we can still send results even if download file failed to create
+        if (err) {
+          logger.error(err);
+        }
+        return resolve();
+      });
     });
-  });
-}
+  }
 
-function writeCsv(cacheKey, queryResult) {
-  return new Promise(resolve => {
-    try {
-      const csv = parse(queryResult.rows, { fields: queryResult.fields });
-      fs.writeFile(csvFilePath(cacheKey), csv, function(err) {
-        if (err) {
-          logger.error(err);
-        }
+  writeCsv(cacheKey, queryResult) {
+    return new Promise(resolve => {
+      try {
+        const csv = parse(queryResult.rows, { fields: queryResult.fields });
+        fs.writeFile(this.csvFilePath(cacheKey), csv, function(err) {
+          if (err) {
+            logger.error(err);
+          }
+          return resolve();
+        });
+      } catch (error) {
+        logger.error(error);
         return resolve();
-      });
-    } catch (error) {
-      logger.error(error);
-      return resolve();
-    }
-  });
-}
+      }
+    });
+  }
 
-// This is a workaround till BigInt is fully supported by the standard
-// See https://tc39.es/ecma262/#sec-ecmascript-language-types-bigint-type
-// and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
-// If this is not done, then a JSON.stringify(BigInt) throws
-// "TypeError: Do not know how to serialize a BigInt"
-/* global BigInt:writable */
-/* eslint no-extend-native: ["error", { "exceptions": ["BigInt"] }] */
-BigInt.prototype.toJSON = function() {
-  return this.toString();
-};
-
-function writeJson(cacheKey, queryResult) {
-  return new Promise(resolve => {
-    try {
-      const json = JSON.stringify(queryResult.rows);
-      fs.writeFile(jsonFilePath(cacheKey), json, function(err) {
-        if (err) {
-          logger.error(err);
-        }
+  writeJson(cacheKey, queryResult) {
+    return new Promise(resolve => {
+      try {
+        const json = JSON.stringify(queryResult.rows);
+        fs.writeFile(this.jsonFilePath(cacheKey), json, function(err) {
+          if (err) {
+            logger.error(err);
+          }
+          return resolve();
+        });
+      } catch (error) {
+        logger.error(error);
         return resolve();
-      });
-    } catch (error) {
-      logger.error(error);
-      return resolve();
-    }
-  });
+      }
+    });
+  }
 }
 
-module.exports = makeResultCache;
+module.exports = ResultCache;

--- a/server/models/schemaInfo.js
+++ b/server/models/schemaInfo.js
@@ -2,14 +2,18 @@ function getCacheKey(connectionId) {
   return 'schemaCache:' + connectionId;
 }
 
-function makeSchemaInfo(nedb) {
+class SchemaInfo {
+  constructor(nedb) {
+    this.nedb = nedb;
+  }
+
   /**
    * Get schemaInfo for connection id
    * @param {string} connectionId
    */
-  async function getSchemaInfo(connectionId) {
+  async getSchemaInfo(connectionId) {
     const cacheKey = getCacheKey(connectionId);
-    const doc = await nedb.cache.findOne({ cacheKey });
+    const doc = await this.nedb.cache.findOne({ cacheKey });
 
     if (!doc) {
       return;
@@ -33,7 +37,7 @@ function makeSchemaInfo(nedb) {
    * @param {string} connectionId
    * @param {object} schemaInfo
    */
-  async function saveSchemaInfo(connectionId, schemaInfo) {
+  async saveSchemaInfo(connectionId, schemaInfo) {
     const cacheKey = getCacheKey(connectionId);
     if (schemaInfo && Object.keys(schemaInfo).length) {
       const schema = JSON.stringify(schemaInfo);
@@ -42,15 +46,11 @@ function makeSchemaInfo(nedb) {
         schema,
         modifiedDate: new Date()
       };
-      return nedb.cache.update({ cacheKey }, doc, {
+      return this.nedb.cache.update({ cacheKey }, doc, {
         upsert: true
       });
     }
   }
-  return {
-    getSchemaInfo,
-    saveSchemaInfo
-  };
 }
 
-module.exports = makeSchemaInfo;
+module.exports = SchemaInfo;

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -1,15 +1,13 @@
 const router = require('express').Router();
 const packageJson = require('../package.json');
-const getModels = require('../models');
 const sendError = require('../lib/sendError');
 
 // NOTE: this route needs a wildcard because it is fetched as a relative url
 // from the front-end. The static SPA does not know if sqlpad is mounted at
 // the root of a domain or if there is a base-url provided in the config
 router.get('*/api/app', async (req, res) => {
-  const { config, nedb } = req;
+  const { config, models } = req;
   try {
-    const models = getModels(nedb);
     const adminRegistrationOpen = await models.users.adminRegistrationOpen();
     const currentUser =
       req.isAuthenticated() && req.user

--- a/server/routes/connection-accesses.js
+++ b/server/routes/connection-accesses.js
@@ -10,13 +10,14 @@ const sendError = require('../lib/sendError');
  * @param {*} res
  */
 async function listConnectionAccesses(req, res) {
+  const { models } = req;
   try {
     const { includeInactives } = req.query;
     let connectionAccesses;
     if (includeInactives) {
-      connectionAccesses = await req.models.connectionAccesses.findAll();
+      connectionAccesses = await models.connectionAccesses.findAll();
     } else {
-      connectionAccesses = await req.models.connectionAccesses.findAllActive();
+      connectionAccesses = await models.connectionAccesses.findAllActive();
     }
     return res.json({ connectionAccesses });
   } catch (error) {
@@ -35,8 +36,9 @@ router.get(
  * @param {*} res
  */
 async function getConnectionAccess(req, res) {
+  const { models } = req;
   try {
-    const connectionAccess = await req.models.connectionAccesses.findOneById(
+    const connectionAccess = await models.connectionAccesses.findOneById(
       req.params._id
     );
     if (!connectionAccess) {
@@ -59,6 +61,7 @@ router.get(
  * @param {*} res
  */
 async function createConnectionAccess(req, res) {
+  const { models } = req;
   try {
     let user = {
       id: consts.EVERYONE_ID,
@@ -70,7 +73,7 @@ async function createConnectionAccess(req, res) {
     };
 
     if (req.body.userId !== consts.EVERYONE_ID) {
-      user = await req.models.users.findOneById(req.body.userId);
+      user = await models.users.findOneById(req.body.userId);
       if (!user) {
         return sendError(res, null, 'User not exists');
       }
@@ -83,21 +86,19 @@ async function createConnectionAccess(req, res) {
       }
     }
     if (req.body.connectionId !== consts.EVERY_CONNECTION_ID) {
-      connection = await req.models.connections.findOneById(
-        req.body.connectionId
-      );
+      connection = await models.connections.findOneById(req.body.connectionId);
       if (!connection) {
         return sendError(res, null, 'Connection not exists');
       }
     }
-    let activeAccess = await req.models.connectionAccesses.findOneActiveByConnectionIdAndUserId(
+    let activeAccess = await models.connectionAccesses.findOneActiveByConnectionIdAndUserId(
       req.body.connectionId,
       req.body.userId
     );
     if (activeAccess) {
       return sendError(res, null, 'User has active access to connection');
     }
-    let connectionAccess = await req.models.connectionAccesses.save({
+    let connectionAccess = await models.connectionAccesses.save({
       connectionId: req.body.connectionId,
       connectionName: connection.name,
       userId: req.body.userId,
@@ -121,8 +122,9 @@ router.post('/api/connection-accesses', mustBeAdmin, createConnectionAccess);
  * @param {*} res
  */
 async function updateConnectionAccess(req, res) {
+  const { models } = req;
   try {
-    const connectionAccess = await req.models.connectionAccesses.expire(
+    const connectionAccess = await models.connectionAccesses.expire(
       req.params._id
     );
     return res.json({ connectionAccess });

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -1,5 +1,4 @@
 const router = require('express').Router();
-const getModels = require('../models');
 const mustBeAdmin = require('../middleware/must-be-admin.js');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const sendError = require('../lib/sendError');
@@ -10,8 +9,8 @@ function removePassword(connection) {
 }
 
 router.get('/api/connections', mustBeAuthenticated, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const docs = await models.connections.findAll();
     return res.json({
       connections: docs.map(removePassword)
@@ -25,8 +24,8 @@ router.get('/api/connections/:_id', mustBeAuthenticated, async function(
   req,
   res
 ) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const connection = await models.connections.findOneById(req.params._id);
     if (!connection) {
       return sendError(res, null, 'Connection not found');
@@ -40,8 +39,8 @@ router.get('/api/connections/:_id', mustBeAuthenticated, async function(
 });
 
 router.post('/api/connections', mustBeAdmin, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const newConnection = await models.connections.save(req.body);
     return res.json({
       connection: removePassword(newConnection)
@@ -52,8 +51,8 @@ router.post('/api/connections', mustBeAdmin, async function(req, res) {
 });
 
 router.put('/api/connections/:_id', mustBeAdmin, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     let connection = await models.connections.findOneById(req.params._id);
     if (!connection) {
       return sendError(res, null, 'Connection not found');
@@ -69,8 +68,8 @@ router.put('/api/connections/:_id', mustBeAdmin, async function(req, res) {
 });
 
 router.delete('/api/connections/:_id', mustBeAdmin, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     await models.connections.removeOneById(req.params._id);
     return res.json({});
   } catch (error) {

--- a/server/routes/download-results.js
+++ b/server/routes/download-results.js
@@ -1,11 +1,10 @@
 const fs = require('fs');
 const router = require('express').Router();
-const getModels = require('../models');
 const logger = require('../lib/logger');
 
 router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
+  const { models } = req;
   const { cacheKey } = req.params;
-  const models = getModels(req.nedb);
   try {
     if (req.config.get('allowCsvDownload')) {
       const cache = await models.resultCache.findOneByCacheKey(cacheKey);
@@ -30,8 +29,8 @@ router.get('/download-results/:cacheKey.csv', async function(req, res, next) {
 });
 
 router.get('/download-results/:cacheKey.xlsx', async function(req, res, next) {
+  const { models } = req;
   const { cacheKey } = req.params;
-  const models = getModels(req.nedb);
   try {
     if (req.config.get('allowCsvDownload')) {
       const cache = await models.resultCache.findOneByCacheKey(cacheKey);
@@ -59,8 +58,8 @@ router.get('/download-results/:cacheKey.xlsx', async function(req, res, next) {
 });
 
 router.get('/download-results/:cacheKey.json', async function(req, res, next) {
+  const { models } = req;
   const { cacheKey } = req.params;
-  const models = getModels(req.nedb);
   try {
     if (req.config.get('allowCsvDownload')) {
       const cache = await models.resultCache.findOneByCacheKey(cacheKey);

--- a/server/routes/forgot-password.js
+++ b/server/routes/forgot-password.js
@@ -1,12 +1,11 @@
 const router = require('express').Router();
 const uuid = require('uuid');
-const getModels = require('../models');
 const makeEmail = require('../lib/email');
 const sendError = require('../lib/sendError');
 const logger = require('../lib/logger');
 
 router.post('/api/forgot-password', async function(req, res) {
-  const models = getModels(req.nedb);
+  const { models } = req;
   if (!req.body.email) {
     return sendError(res, null, 'Email address must be provided');
   }

--- a/server/routes/local-auth.js
+++ b/server/routes/local-auth.js
@@ -3,14 +3,13 @@ const PassportLocalStrategy = require('passport-local').Strategy;
 const BasicStrategy = require('passport-http').BasicStrategy;
 const router = require('express').Router();
 const checkWhitelist = require('../lib/check-whitelist');
-const getModels = require('../models');
 const sendError = require('../lib/sendError');
 const logger = require('../lib/logger');
 const passhash = require('../lib/passhash.js');
 
 async function handleSignup(req, res, next) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const whitelistedDomains = req.config.get('whitelistedDomains');
 
     if (req.body.password !== req.body.passwordConfirmation) {
@@ -81,7 +80,7 @@ function makeLocalAuth(config) {
           done
         ) {
           try {
-            const models = getModels(req.nedb);
+            const { models } = req;
             const user = await models.users.findOneByEmail(email);
             if (!user) {
               return done(null, false, { message: 'wrong email or password' });
@@ -115,7 +114,7 @@ function makeLocalAuth(config) {
         },
         async function(req, username, password, callback) {
           try {
-            const models = getModels(req.nedb);
+            const { models } = req;
             const user = await models.users.findOneByEmail(username);
             if (!user) {
               return callback(null, false);

--- a/server/routes/oauth.js
+++ b/server/routes/oauth.js
@@ -3,7 +3,6 @@ const PassportGoogleStrategy = require('passport-google-oauth20').Strategy;
 const router = require('express').Router();
 const logger = require('../lib/logger');
 const checkWhitelist = require('../lib/check-whitelist.js');
-const getModels = require('../models');
 
 /**
  * Adds Google auth strategy and adds Google auth routes if Google auth is configured
@@ -22,6 +21,7 @@ function makeGoogleAuth(config) {
     profile,
     done
   ) {
+    const { models } = req;
     const email = profile && profile._json && profile._json.email;
 
     if (!email) {
@@ -29,8 +29,6 @@ function makeGoogleAuth(config) {
         message: 'email not provided from Google'
       });
     }
-
-    const models = getModels(req.nedb);
 
     try {
       let [openAdminRegistration, user] = await Promise.all([

--- a/server/routes/password-reset.js
+++ b/server/routes/password-reset.js
@@ -1,11 +1,10 @@
 const router = require('express').Router();
-const getModels = require('../models');
 const sendError = require('../lib/sendError');
 
 // This route used to set new password given a passwordResetId
 router.post('/api/password-reset/:passwordResetId', async function(req, res) {
   try {
-    const models = getModels(req.nedb);
+    const { models } = req;
     const user = await models.users.findOneByPasswordResetId(
       req.params.passwordResetId
     );

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -1,5 +1,4 @@
 const router = require('express').Router();
-const getModels = require('../models');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const mustBeAuthenticatedOrChartLink = require('../middleware/must-be-authenticated-or-chart-link-noauth.js');
 const sendError = require('../lib/sendError');
@@ -26,8 +25,8 @@ router.delete('/api/queries/:_id', mustBeAuthenticated, async function(
   req,
   res
 ) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     await models.queries.removeById(req.params._id);
     return res.json({});
   } catch (error) {
@@ -36,8 +35,8 @@ router.delete('/api/queries/:_id', mustBeAuthenticated, async function(
 });
 
 router.get('/api/queries', mustBeAuthenticated, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const queries = await models.queries.findAll();
     return res.json({ queries });
   } catch (error) {
@@ -49,8 +48,8 @@ router.get('/api/queries/:_id', mustBeAuthenticatedOrChartLink, async function(
   req,
   res
 ) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const query = await models.queries.findOneById(req.params._id);
     if (!query) {
       return res.json({
@@ -64,6 +63,7 @@ router.get('/api/queries/:_id', mustBeAuthenticatedOrChartLink, async function(
 });
 
 router.post('/api/queries', mustBeAuthenticated, async function(req, res) {
+  const { models } = req;
   const { name, tags, connectionId, queryText, chartConfiguration } = req.body;
   const { email } = req.user;
 
@@ -78,7 +78,6 @@ router.post('/api/queries', mustBeAuthenticated, async function(req, res) {
   };
 
   try {
-    const models = getModels(req.nedb);
     const newQuery = await models.queries.save(query);
     // This is async, but save operation doesn't care about when/if finished
     pushQueryToSlack(req.config, newQuery);
@@ -91,8 +90,8 @@ router.post('/api/queries', mustBeAuthenticated, async function(req, res) {
 });
 
 router.put('/api/queries/:_id', mustBeAuthenticated, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const query = await models.queries.findOneById(req.params._id);
     if (!query) {
       return sendError(res, null, 'Query not found');

--- a/server/routes/query-history.js
+++ b/server/routes/query-history.js
@@ -1,15 +1,13 @@
 const router = require('express').Router();
 const uuid = require('uuid');
 const getMeta = require('../lib/getMeta');
-const getModels = require('../models');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const urlFilterToNeDbFilter = require('../lib/urlFilterToNeDbFilter');
 const sendError = require('../lib/sendError');
 
 router.get('/api/query-history', mustBeAuthenticated, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
-
     const queryHistory = {
       id: uuid.v4(),
       cacheKey: null,
@@ -52,8 +50,8 @@ router.get('/api/query-history/:_id', mustBeAuthenticated, async function(
   req,
   res
 ) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const queryHistoryItem = await models.queryHistory.findOneById(
       req.params._id
     );

--- a/server/routes/query-result.js
+++ b/server/routes/query-result.js
@@ -1,6 +1,5 @@
 const router = require('express').Router();
 const { runQuery } = require('../drivers/index');
-const getModels = require('../models');
 const mustHaveConnectionAccess = require('../middleware/must-have-connection-access.js');
 const mustHaveConnectionAccessOrChartLink = require('../middleware/must-have-connection-access-or-chart-link-noauth');
 const sendError = require('../lib/sendError');
@@ -11,8 +10,8 @@ router.get(
   '/api/query-result/:_queryId',
   mustHaveConnectionAccessOrChartLink,
   async function(req, res) {
+    const { models } = req;
     try {
-      const models = getModels(req.nedb);
       const query = await models.queries.findOneById(req.params._queryId);
       if (!query) {
         return sendError(res, null, 'Query not found (save query first)');
@@ -62,7 +61,7 @@ router.post('/api/query-result', mustHaveConnectionAccess, async function(
 });
 
 async function getQueryResult(req, data) {
-  const models = getModels(req.nedb);
+  const { models } = req;
   const { connectionId, cacheKey, queryId, queryName, queryText, user } = data;
   const connection = await models.connections.findOneById(connectionId);
 

--- a/server/routes/saml.js
+++ b/server/routes/saml.js
@@ -2,7 +2,6 @@ const passport = require('passport');
 const SamlStrategy = require('passport-saml').Strategy;
 const router = require('express').Router();
 const logger = require('../lib/logger');
-const getModels = require('../models');
 
 /**
  * Adds passport SAML strategy and SAML auth routes if SAML is configured
@@ -42,7 +41,7 @@ function makeSamlAuth(config) {
             p[
               'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'
             ];
-          const models = getModels(req.nedb);
+          const { models } = req;
           const user = await models.users.findOneByEmail(email);
           logger.info('User logged in via SAML %s', email);
           if (!user) {

--- a/server/routes/schema-info.js
+++ b/server/routes/schema-info.js
@@ -1,5 +1,4 @@
 const router = require('express').Router();
-const getModels = require('../models');
 const driver = require('../drivers');
 const mustHaveConnectionAccess = require('../middleware/must-have-connection-access.js');
 const sendError = require('../lib/sendError');
@@ -8,7 +7,7 @@ router.get(
   '/api/schema-info/:connectionId',
   mustHaveConnectionAccess,
   async function(req, res) {
-    const models = getModels(req.nedb);
+    const { models } = req;
     const { connectionId } = req.params;
     const reload = req.query.reload === 'true';
 

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -1,12 +1,11 @@
 const _ = require('lodash');
 const router = require('express').Router();
-const getModels = require('../models');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const sendError = require('../lib/sendError');
 
 router.get('/api/tags', mustBeAuthenticated, async function(req, res) {
+  const { models } = req;
   try {
-    const models = getModels(req.nedb);
     const queries = await models.queries.findAll();
     const tags = _.uniq(_.flatten(_.map(queries, 'tags')))
       .sort()

--- a/server/typedefs.js
+++ b/server/typedefs.js
@@ -1,7 +1,13 @@
 /**
  * A collection of data access objects
  * @typedef {Object} Models
- * @property {import('./models/connectionAccesses')} connectionAccesses - connection accesses
+ * @property {import('./models/connectionAccesses')} connectionAccesses - connection accesses DAO
+ * @property {import('./models/connections')} connections - connections DAO
+ * @property {import('./models/queries')} queries - queries DAO
+ * @property {import('./models/queryHistory')} queryHistory - queryHistory DAO
+ * @property {import('./models/resultCache')} resultCache - resultCache DAO
+ * @property {import('./models/schemaInfo')} schemaInfo - schemaInfo DAO
+ * @property {import('./models/users')} users - users DAO
  */
 
 /**

--- a/server/typedefs.js
+++ b/server/typedefs.js
@@ -1,0 +1,11 @@
+/**
+ * A collection of data access objects
+ * @typedef {Object} Models
+ * @property {import('./models/connectionAccesses')} connectionAccesses - connection accesses
+ */
+
+/**
+ * The expressjs Request object plus decorations
+ * @typedef {Object} Req
+ * @property {Models} models - Collection of data access objects
+ */


### PR DESCRIPTION
Converts the various model data access object factory functions into classes. Primary motivation for doing this is to be able to provide better better hinting when decorating the `req` with jsdoc type definitions.

This PR also adds a middleware to decorate `req` with `models` on every request, and updates connection accesses routes to show how this works.

The nice thing about this is when using vs code (and presumably other editors that read through jsdoc definitions?) you can get intellisense prompts on methods of models, which out needing to call `getModels(nedb)` every request. 

Eventually models only needs to be instantiated once for an application as well.