### PR TITLE
Add connection template support

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -4,6 +4,7 @@ const passhash = require('../lib/passhash.js');
 const schema = Joi.object({
   _id: Joi.string().optional(), // will be auto-gen by nedb
   email: Joi.string().required(),
+  name: Joi.string().optional(),
   role: Joi.string()
     .lowercase()
     .allow('admin', 'editor', 'viewer'),
@@ -17,7 +18,12 @@ const schema = Joi.object({
     .strip(),
   createdDate: Joi.date().default(Date.now),
   modifiedDate: Joi.date().default(Date.now),
-  signupDate: Joi.date().optional()
+  signupDate: Joi.date().optional(),
+  // `data` field is intended to be something end users populate via various means
+  // That is data can be anything, managed by user, not by SQLPad
+  // The data object's primary purpose will be to store values for replacement in connection templates
+  // For any official SQLPad use, fields should be specified on user object
+  data: Joi.object().optional()
 });
 
 class Users {

--- a/server/routes/schema-info.js
+++ b/server/routes/schema-info.js
@@ -7,7 +7,7 @@ router.get(
   '/api/schema-info/:connectionId',
   mustHaveConnectionAccess,
   async function(req, res) {
-    const { models } = req;
+    const { models, user } = req;
     const { connectionId } = req.params;
     const reload = req.query.reload === 'true';
 
@@ -24,7 +24,7 @@ router.get(
         return res.json({ schemaInfo });
       }
 
-      schemaInfo = await driver.getSchema(conn);
+      schemaInfo = await driver.getSchema(conn, user);
       if (Object.keys(schemaInfo).length) {
         await models.schemaInfo.saveSchemaInfo(connectionId, schemaInfo);
       }

--- a/server/routes/test-connection.js
+++ b/server/routes/test-connection.js
@@ -7,9 +7,8 @@ const sendError = require('../lib/sendError');
  * A non-error response is considered a success or valid connection config
  */
 router.post('/api/test-connection', mustBeAdmin, async function(req, res) {
-  const { body } = req;
   try {
-    await testConnection(body);
+    await testConnection(req.body, req.user);
     res.send({ success: true });
   } catch (error) {
     sendError(res, error);

--- a/server/test/drivers.js
+++ b/server/test/drivers.js
@@ -71,4 +71,33 @@ describe('drivers', function() {
       });
     }, 'boolean not convertable throws error');
   });
+
+  it('renders connection with user', function() {
+    const secret = '123<>!@#$%^&*()-_+=';
+    const user = {
+      data: {
+        secret
+      }
+    };
+    const connection = {
+      connectionString: '{{user.data.secret}}',
+      singleStache: '{single}',
+      port: 6543
+    };
+    const rendered = drivers.renderConnection(connection, user);
+    assert.strictEqual(rendered.connectionString, secret);
+    assert.strictEqual(rendered.singleStache, '{single}', 'single left alone');
+    assert.strictEqual(rendered.port, 6543, 'number left alone');
+  });
+
+  it('renders connection without user', function() {
+    const connection = {
+      connectionString: 'test',
+      singleStache: '{single}',
+      port: 6543
+    };
+    const rendered = drivers.renderConnection(connection);
+    assert.strictEqual(rendered.connectionString, 'test');
+    assert.strictEqual(rendered.singleStache, '{single}');
+  });
 });


### PR DESCRIPTION
Adds the ability to reference user info in connection configuration using a mustache/handlebars like syntax. 

For any text (string) connection field, user info may be referenced using `{{user.fieldName}}` syntax. 

This also adds additional user fields, `name` and `data`. Name will be used eventually for a the preferred human friendly user name. `data` is to be used to store whatever end users would like to store, and is not something SQLPad will be caring about.

Example: Let's say each SQLPad user has a specific database username they are to use when connecting to a database. You may specify this value in the SQLPad `user.data` field as `user.data.dbuser` (how that is to happen TBD), then reference that value when defining a connection, setting username to `{{user.data.dbuser}}`. When queries are run against a database using that connection, `{{user.data.dbuser}}` gets swapped out with the value associated with the user running the query.
