### PR TITLE
Remove config reference from drivers

### DIFF
--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -1,11 +1,8 @@
 const uuid = require('uuid');
 const _ = require('lodash');
-const config = require('../lib/config');
 const utils = require('./utils');
 const getMeta = require('../lib/getMeta');
 const logger = require('../lib/logger');
-
-const debug = config.get('debug');
 
 const drivers = {};
 
@@ -112,23 +109,18 @@ function requireValidate(path, optional = false) {
 
 // Loads and validates drivers
 // Will populate drivers {} map
-requireValidate('../drivers/crate');
-requireValidate('../drivers/drill');
-requireValidate('../drivers/hdb');
-requireValidate('../drivers/mysql');
-requireValidate('../drivers/postgres');
-requireValidate('../drivers/presto');
-requireValidate('../drivers/sqlserver');
-requireValidate('../drivers/unixodbc', true);
-requireValidate('../drivers/vertica');
-requireValidate('../drivers/cassandra');
-requireValidate('../drivers/snowflake');
-
-// If debug is turned on also add in mock drivers
-// This is used for test cases, and is also useful for end-user debugging
-if (debug) {
-  requireValidate('../drivers/mock');
-}
+requireValidate('./crate');
+requireValidate('./drill');
+requireValidate('./hdb');
+requireValidate('./mysql');
+requireValidate('./postgres');
+requireValidate('./presto');
+requireValidate('./sqlserver');
+requireValidate('./unixodbc', true);
+requireValidate('./vertica');
+requireValidate('./cassandra');
+requireValidate('./snowflake');
+requireValidate('./mock');
 
 /**
  * Run query using driver implementation of connection

--- a/server/routes/drivers.js
+++ b/server/routes/drivers.js
@@ -1,13 +1,21 @@
 const router = require('express').Router();
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
-const drivers = require('../drivers');
+const driversUtil = require('../drivers');
 const sendError = require('../lib/sendError');
 
 router.get('/api/drivers', mustBeAuthenticated, function(req, res) {
+  const { config } = req;
+  const debug = config.get('debug');
+
   try {
-    return res.json({
-      drivers: drivers.getDrivers()
+    // If debug is turned on show all drivers, otherwise exclude mock driver
+    // The mock driver is used for test cases, and is also useful for end-user debugging
+    // TODO - deprecate debug for a config to enable mock
+    const drivers = driversUtil.getDrivers().filter(driver => {
+      return debug || driver.id !== 'mock';
     });
+
+    return res.json({ drivers });
   } catch (error) {
     return sendError(res, error, 'Error getting drivers');
   }


### PR DESCRIPTION
One less thing referencing config directly outside the scope of an app. Instead the logic to not show mock driver is done inside the route handling the request.