### PR TITLE
Add custom application header

### DIFF
--- a/client/src/queryEditor/CustomAppHeader.js
+++ b/client/src/queryEditor/CustomAppHeader.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'unistore/react';
+import fetchHtml from '../utilities/fetchHtml';
+
+function mapStateToProps(state) {
+  return {
+    config: state.config
+  };
+}
+
+const ConnectedCustomAppHeader = connect(mapStateToProps)(
+  React.memo(CustomAppHeader)
+);
+
+function CustomAppHeader({ config }) {
+  const [headerHtml, setHeaderHtml] = useState({ __html: '' });
+
+  useEffect(() => {
+    if (config.customAppTemplateConfigured) {
+      let subscribed = true;
+      fetchHtml('/custom-app-header').then(result => {
+        if (subscribed) {
+          setHeaderHtml({ __html: result });
+        }
+      });
+      return () => {
+        subscribed = false;
+      };
+    }
+  }, [config]);
+
+  if (headerHtml && headerHtml.__html) {
+    return <div dangerouslySetInnerHTML={headerHtml} />;
+  }
+  return null;
+}
+
+export default ConnectedCustomAppHeader;

--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -8,6 +8,7 @@ import SchemaSidebar from '../schema/SchemaSidebar.js';
 import { loadConnections } from '../stores/connections';
 import { loadQuery, resetNewQuery } from '../stores/queries';
 import { loadTags } from '../stores/tags';
+import CustomAppHeader from './CustomAppHeader';
 import DocumentTitle from './DocumentTitle';
 import QueryEditorChart from './QueryEditorChart';
 import QueryEditorChartToolbar from './QueryEditorChartToolbar';
@@ -117,6 +118,7 @@ function QueryEditor(props) {
         flexDirection: 'column'
       }}
     >
+      <CustomAppHeader />
       <Toolbar />
       <div style={{ position: 'relative', flexGrow: 1 }}>{sqlTabPane}</div>
       <UnsavedQuerySelector queryId={queryId} />

--- a/client/src/utilities/fetchHtml.js
+++ b/client/src/utilities/fetchHtml.js
@@ -1,0 +1,30 @@
+import 'whatwg-fetch';
+import message from '../common/message';
+
+export default function fetchHtml(url) {
+  const BASE_URL = window.BASE_URL || '';
+  const opts = {
+    method: 'GET',
+    credentials: 'same-origin'
+  };
+
+  let fetchUrl = BASE_URL + url;
+  if (BASE_URL && url.substring(0, 1) !== '/') {
+    fetchUrl = BASE_URL + '/' + url;
+  }
+
+  return fetch(fetchUrl, opts)
+    .then(response => {
+      if (response.redirected) {
+        return (window.location = response.url);
+      } else if (response.status === 200) {
+        return response.text();
+      } else {
+        console.error(response);
+        throw new Error('Server responded not ok');
+      }
+    })
+    .catch(error => {
+      message.error(error.toString());
+    });
+}

--- a/server/app.js
+++ b/server/app.js
@@ -110,6 +110,7 @@ function makeApp(config, models) {
   /*  Routes
   ============================================================================= */
   const routers = [
+    require('./routes/custom-app-header.js')(config),
     require('./routes/drivers.js'),
     require('./routes/users.js'),
     require('./routes/forgot-password.js'),

--- a/server/config.dev.ini
+++ b/server/config.dev.ini
@@ -1,4 +1,11 @@
-; INI config file that defines some connections for development purposes
+; INI config file for dev setup
+port = 3010
+baseUrl = "/sqlpad"
+appHeaderTemplate = "./test/fixtures/app-header-template.html"
+debug = true
+dbPath = ../db
+appLogLevel = debug
+webLogLevel = debug
 
 [connections.devdbdriverid123]
 driver = mock

--- a/server/lib/config/configItems.js
+++ b/server/lib/config/configItems.js
@@ -218,6 +218,11 @@ const configItems = [
     key: 'webLogLevel',
     envVar: 'SQLPAD_WEB_LOG_LEVEL',
     default: 'info'
+  },
+  {
+    key: 'appHeaderTemplate',
+    envVar: 'SQLPAD_APP_HEADER_TEMPLATE',
+    default: ''
   }
 ];
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2898,6 +2898,11 @@
         }
       }
     },
+    "mustache": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.0.tgz",
+      "integrity": "sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA=="
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "prepublishOnly": "cd .. && ./scripts/build.sh",
-    "start": "node-dev server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad --config './config.dev.ini' | pino-pretty",
+    "start": "node-dev server.js --config './config.dev.ini' | pino-pretty",
     "test": "rimraf ../dbtest && SQLPAD_DB_PATH='../dbtest' SQLPAD_DEBUG='true' SQLPAD_APP_LOG_LEVEL='silent' SQLPAD_WEB_LOG_LEVEL='silent' mocha test --timeout 10000 --recursive --exit",
     "fixlint": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "mkdirp": "^1.0.3",
     "moment": "^2.24.0",
     "mssql": "^6.0.1",
+    "mustache": "^4.0.0",
     "mysql": "^2.18.1",
     "nedb": "^1.8.0",
     "nedb-promise": "^2.0.1",

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -22,6 +22,7 @@ router.get('*/api/app', async (req, res) => {
       adminRegistrationOpen,
       currentUser,
       config: {
+        customAppTemplateConfigured: Boolean(config.get('appHeaderTemplate')),
         publicUrl: config.get('publicUrl'),
         allowCsvDownload: config.get('allowCsvDownload'),
         editorWordWrap: config.get('editorWordWrap'),

--- a/server/routes/custom-app-header.js
+++ b/server/routes/custom-app-header.js
@@ -1,0 +1,41 @@
+const mustache = require('mustache');
+const fs = require('fs');
+const router = require('express').Router();
+const appLog = require('../lib/appLog');
+
+/**
+ * Adds custom app header route if configured with path to template file
+ * @param {object} config
+ */
+function getAppHeaderRouter(config) {
+  const appHeaderTemplate = config.get('appHeaderTemplate');
+
+  if (appHeaderTemplate) {
+    appLog.info('Adding custom app header');
+
+    let template;
+
+    try {
+      appLog.debug('Reading template file %s', appHeaderTemplate);
+      template = fs.readFileSync(appHeaderTemplate, 'utf8');
+    } catch (error) {
+      appLog.error(error, 'Error reading app header template');
+    }
+
+    router.get('/custom-app-header', function(req, res) {
+      const view = {
+        user: {
+          email: req.user.email,
+          name: req.user.name || req.user.email
+        }
+      };
+
+      const htmlResult = mustache.render(template, view);
+      res.send(htmlResult);
+    });
+  }
+
+  return router;
+}
+
+module.exports = getAppHeaderRouter;

--- a/server/routes/custom-app-header.js
+++ b/server/routes/custom-app-header.js
@@ -26,7 +26,9 @@ function getAppHeaderRouter(config) {
       const view = {
         user: {
           email: req.user.email,
-          name: req.user.name || req.user.email
+          name: req.user.name || req.user.email,
+          role: req.user.role,
+          data: req.user.data
         }
       };
 

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -9,6 +9,7 @@ const expectedKeys = [
 ];
 
 const expectedConfigKeys = [
+  'customAppTemplateConfigured',
   'baseUrl',
   'allowCsvDownload',
   'editorWordWrap',

--- a/server/test/fixtures/app-header-template.html
+++ b/server/test/fixtures/app-header-template.html
@@ -1,5 +1,5 @@
 <style>
-  .root {
+  .custom-header-root {
     background-color: rgba(0, 0, 0, 0.82);
     border-bottom: 1px solid rgb(204, 204, 204);
     color: #fff;
@@ -10,12 +10,12 @@
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.12);
   }
 
-  .header-link {
+  .custom-header-link {
     color: #fff;
   }
 </style>
-<div class="root">
-  <div><a href="/" class="header-link">&lsaquo; BACK</a></div>
-  <div>My SQLPad</div>
+<div class="custom-header-root">
+  <div><a href="/" class="custom-header-link">&lsaquo; Link to somewhere</a></div>
+  <div>My Custom SQLPad</div>
   <div>{{user.name}}</div>
 </div>

--- a/server/test/fixtures/app-header-template.html
+++ b/server/test/fixtures/app-header-template.html
@@ -1,0 +1,21 @@
+<style>
+  .root {
+    background-color: rgba(0, 0, 0, 0.82);
+    border-bottom: 1px solid rgb(204, 204, 204);
+    color: #fff;
+    display: flex;
+    height: 40px;
+    justify-content: space-between;
+    padding: 8px;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.12);
+  }
+
+  .header-link {
+    color: #fff;
+  }
+</style>
+<div class="root">
+  <div><a href="/" class="header-link">&lsaquo; BACK</a></div>
+  <div>My SQLPad</div>
+  <div>{{user.name}}</div>
+</div>


### PR DESCRIPTION
Adds a config option to specify a mustache template to be used for a custom application header rendered above the editor toolbar. The template can reference `name`, `email`, and `data` fields of the user, for cases where the logged in user info is desired. 

The template path may be specified using the key `appHeaderTemplate` and environment variable `SQLPAD_APP_HEADER_TEMPLATE`. 

## Example

The following template file is saved under `server/test/fixtures/app-header-template.html` and provided via ini setting `appHeaderTemplate = "./test/fixtures/app-header-template.html"`.

```html
<style>
  .custom-header-root {
    background-color: rgba(0, 0, 0, 0.82);
    border-bottom: 1px solid rgb(204, 204, 204);
    color: #fff;
    display: flex;
    height: 40px;
    justify-content: space-between;
    padding: 8px;
    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.12);
  }

  .custom-header-link {
    color: #fff;
  }
</style>
<div class="custom-header-root">
  <div><a href="/" class="custom-header-link">&lsaquo; Link to somewhere</a></div>
  <div>My Custom SQLPad</div>
  <div>{{user.name}}</div>
</div>
```

It results in the following:

<img width="1055" alt="Screen Shot 2020-02-21 at 3 29 39 PM" src="https://user-images.githubusercontent.com/303966/75073796-dbb85980-54bf-11ea-9498-35f970ba8986.png">

If no template is specified, no application header is rendered.
