### PR TITLE
Add a build pipeline

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,6 +2,8 @@
 set -x
 
 apt-get update
-# apt-get install -y --no-install-recommends jq g++ make python3 python3-setuptools unixodbc-dev
 apt-get install -y --no-install-recommends g++ make python3 python3-setuptools unixodbc-dev
-bash scripts/build.sh
+
+bash -x scripts/build.sh
+
+tar -cavf sqlpad.tar.gz -C server/public .

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -x
+
+apt-get update
+# apt-get install -y --no-install-recommends jq g++ make python3 python3-setuptools unixodbc-dev
+apt-get install -y --no-install-recommends g++ make python3 python3-setuptools unixodbc-dev
+bash scripts/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code ${{ github.sha }}
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build
         uses: docker://node:13-slim
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.0.0
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload archive to release
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,6 @@ jobs:
           entrypoint: bash
           args: .github/workflows/build.sh
 
-      - name: Archive
-        run: tar -cavf sqlpad.tar.gz -C build server/public
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: SQLPad release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    name: Build and upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code ${{ github.sha }}
+        uses: actions/checkout@v1
+
+      - name: Build
+        uses: docker://node:13-slim
+        with:
+          entrypoint: bash
+          args: .github/workflows/build.sh
+
+      - name: Archive
+        run: tar -cavf sqlpad.tar.gz -C build server/public
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload archive to release
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./sqlpad.tar.gz
+          asset_name: sqlpad.tar.gz
+          asset_content_type: application/gzip

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 db/
 dbtest/
 node_modules/
+sqlpad.tar.gz

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 SQLPAD_CLIENT_DIR=$(pwd)/client
 SQLPAD_SERVER_DIR=$(pwd)/server
 SCRIPTS_DIR=$(pwd)/scripts

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,12 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 SQLPAD_CLIENT_DIR=$(pwd)/client
 SQLPAD_SERVER_DIR=$(pwd)/server
 SCRIPTS_DIR=$(pwd)/scripts
 
-if [[ ! -d $SCRIPTS_DIR ]] || \
-   [[ ! -d $SQLPAD_CLIENT_DIR ]] || \
-   [[ ! -d $SQLPAD_SERVER_DIR ]]
-then
+if [ ! -d $SCRIPTS_DIR ] ||
+    [ ! -d $SQLPAD_CLIENT_DIR ] ||
+    [ ! -d $SQLPAD_SERVER_DIR ]; then
     echo This script must be executed from the sqlpad project directory
     exit 1
 fi


### PR DESCRIPTION
This PR add a Github Action build pipeline to SQLPad. 

Every tag on the repository will trigger the usual build, tar the result and add it to Github Release next to the source code, like this https://github.com/rgarrigue/sqlpad/releases/tag/v4.0.2

This will allow users to install SQLPad on a basic web server downloading / untaring / adding a config file without installing all the build dependencies.
 


