### PR TITLE
Isolate toolbar components

### DIFF
--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -1,23 +1,16 @@
-import { MenuItem } from '@reach/menu-button';
 import CopyIcon from 'mdi-react/ContentCopyIcon';
 import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
 import SaveIcon from 'mdi-react/ContentSaveIcon';
 import DatabaseIcon from 'mdi-react/DatabaseIcon';
-import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon';
 import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
 import NewIcon from 'mdi-react/PlusIcon';
 import TagsIcon from 'mdi-react/TagMultipleIcon';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { Redirect } from 'react-router-dom';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
-import Drawer from '../../common/Drawer';
 import IconButton from '../../common/IconButton';
-import IconMenu from '../../common/IconMenu';
 import Input from '../../common/Input';
-import ConnectionListDrawer from '../../connections/ConnectionListDrawer';
-import ConnectionAccessListDrawer from '../../connectionAccesses/ConnectionAccessListDrawer';
 import {
   formatQuery,
   handleCloneClick,
@@ -27,19 +20,15 @@ import {
   setQueryState
 } from '../../stores/queries';
 import { toggleSchema } from '../../stores/schema';
-import UserList from '../../users/UserList';
-import fetchJson from '../../utilities/fetch-json.js';
 import ConnectionDropDown from '../ConnectionDropdown';
-import QueryHistoryModal from '../../queryHistory/QueryHistoryModal';
-import AboutModal from './AboutModal';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
 import QueryTagsModal from './QueryTagsModal';
+import ToolbarMenu from './ToolbarMenu';
 import ToolbarSpacer from './ToolbarSpacer';
 
 function mapStateToProps(state) {
   return {
-    currentUser: state.currentUser,
     isRunning: state.isRunning,
     isSaving: state.isSaving,
     queryId: state.query && state.query._id,
@@ -60,7 +49,6 @@ const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
 }))(React.memo(Toolbar));
 
 function Toolbar({
-  currentUser,
   formatQuery,
   handleCloneClick,
   isRunning,
@@ -76,42 +64,9 @@ function Toolbar({
   unsavedChanges
 }) {
   const [showTags, setShowTags] = useState(false);
-  const [showUsers, setShowUsers] = useState(false);
-  const [redirectToSignIn, setRedirectToSignIn] = useState(false);
-  const [showQueryHistory, setShowQueryHistory] = useState(false);
-  const [showAbout, setShowAbout] = useState(false);
-  const [showConnections, setShowConnections] = useState(false);
-  const [showConnectionAccesses, setShowConnectionAccesses] = useState(false);
 
   const error = showValidation && !queryName.length;
   const cloneDisabled = !queryId;
-
-  const isAdmin = currentUser.role === 'admin';
-
-  if (redirectToSignIn) {
-    return <Redirect push to="/signin" />;
-  }
-
-  // Reach UI menu / IconMenu does not like the {someBoolean && <element/>} patterm
-  // As a workaround optional MenuItems are managed in an array
-  let menuItems = [];
-  if (isAdmin) {
-    menuItems = [
-      <MenuItem key="connections" onSelect={() => setShowConnections(true)}>
-        Connections
-      </MenuItem>,
-      <MenuItem key="users" onSelect={() => setShowUsers(true)}>
-        Users
-      </MenuItem>,
-      <MenuItem
-        key="connectionAccessess"
-        style={{ borderBottom: '1px solid #ddd' }}
-        onSelect={() => setShowConnectionAccesses(true)}
-      >
-        Connection Accesses
-      </MenuItem>
-    ];
-  }
 
   return (
     <div
@@ -191,57 +146,7 @@ function Toolbar({
 
         <ToolbarSpacer grow />
 
-        <IconMenu icon={<DotsVerticalIcon aria-label="menu" />}>
-          {menuItems}
-          <MenuItem
-            key="queryHistory"
-            style={{ borderBottom: '1px solid #ddd' }}
-            onSelect={() => setShowQueryHistory(true)}
-          >
-            Query History
-          </MenuItem>
-          <MenuItem
-            style={{ borderBottom: '1px solid #ddd' }}
-            onSelect={() => setShowAbout(true)}
-          >
-            About
-          </MenuItem>
-          <MenuItem
-            onSelect={async () => {
-              await fetchJson('GET', '/api/signout');
-              setRedirectToSignIn(true);
-            }}
-          >
-            Sign out
-          </MenuItem>
-        </IconMenu>
-
-        <Drawer
-          title={'Users'}
-          visible={showUsers}
-          width={600}
-          onClose={() => setShowUsers(false)}
-          placement={'right'}
-        >
-          <UserList />
-        </Drawer>
-
-        <QueryHistoryModal
-          visible={showQueryHistory}
-          onClose={() => setShowQueryHistory(false)}
-        />
-
-        <AboutModal visible={showAbout} onClose={() => setShowAbout(false)} />
-
-        <ConnectionListDrawer
-          visible={showConnections}
-          onClose={() => setShowConnections(false)}
-        />
-
-        <ConnectionAccessListDrawer
-          visible={showConnectionAccesses}
-          onClose={() => setShowConnectionAccesses(false)}
-        />
+        <ToolbarMenu />
       </div>
     </div>
   );

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -1,4 +1,3 @@
-import CopyIcon from 'mdi-react/ContentCopyIcon';
 import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
 import SaveIcon from 'mdi-react/ContentSaveIcon';
 import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
@@ -7,15 +6,11 @@ import React from 'react';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
 import IconButton from '../../common/IconButton';
-import {
-  formatQuery,
-  handleCloneClick,
-  runQuery,
-  saveQuery
-} from '../../stores/queries';
+import { formatQuery, runQuery, saveQuery } from '../../stores/queries';
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
+import ToolbarCloneButton from './ToolbarCloneButton';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarNewQueryButton from './ToolbarNewQueryButton';
 import ToolbarQueryNameInput from './ToolbarQueryNameInput';
@@ -27,7 +22,6 @@ function mapStateToProps(state) {
   return {
     isRunning: state.isRunning,
     isSaving: state.isSaving,
-    queryId: state.query && state.query._id,
     unsavedChanges: state.unsavedChanges
   };
 }
@@ -35,23 +29,17 @@ function mapStateToProps(state) {
 const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
   formatQuery,
   runQuery: runQuery(store),
-  saveQuery: saveQuery(store),
-  handleCloneClick
+  saveQuery: saveQuery(store)
 }))(React.memo(Toolbar));
 
 function Toolbar({
   formatQuery,
-  handleCloneClick,
   isRunning,
   isSaving,
-  queryId,
   runQuery,
   saveQuery,
-
   unsavedChanges
 }) {
-  const cloneDisabled = !queryId;
-
   return (
     <div
       style={{
@@ -63,13 +51,11 @@ function Toolbar({
     >
       <div style={{ display: 'flex' }}>
         <QueryListButton />
-
         <ToolbarNewQueryButton />
 
         <ToolbarSpacer grow />
 
         <ToolbarToggleSchemaButton />
-
         <ConnectionDropDown />
 
         <ToolbarSpacer />
@@ -79,14 +65,7 @@ function Toolbar({
         <ToolbarSpacer />
 
         <ToolbarTagsButton />
-
-        <IconButton
-          tooltip="Clone"
-          onClick={handleCloneClick}
-          disabled={cloneDisabled}
-        >
-          <CopyIcon />
-        </IconButton>
+        <ToolbarCloneButton />
 
         <IconButton tooltip="Format" onClick={formatQuery}>
           <FormatIcon />
@@ -121,11 +100,9 @@ function Toolbar({
 Toolbar.propTypes = {
   isSaving: PropTypes.bool.isRequired,
   isRunning: PropTypes.bool.isRequired,
-  handleCloneClick: PropTypes.func.isRequired,
   saveQuery: PropTypes.func.isRequired,
   runQuery: PropTypes.func.isRequired,
   formatQuery: PropTypes.func.isRequired,
-  queryId: PropTypes.string,
   unsavedChanges: PropTypes.bool.isRequired
 };
 

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -2,9 +2,8 @@ import CopyIcon from 'mdi-react/ContentCopyIcon';
 import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
 import SaveIcon from 'mdi-react/ContentSaveIcon';
 import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
-import TagsIcon from 'mdi-react/TagMultipleIcon';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
 import IconButton from '../../common/IconButton';
@@ -17,11 +16,11 @@ import {
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
-import QueryTagsModal from './QueryTagsModal';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarNewQueryButton from './ToolbarNewQueryButton';
 import ToolbarQueryNameInput from './ToolbarQueryNameInput';
 import ToolbarSpacer from './ToolbarSpacer';
+import ToolbarTagsButton from './ToolbarTagsButton';
 import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
 
 function mapStateToProps(state) {
@@ -51,8 +50,6 @@ function Toolbar({
 
   unsavedChanges
 }) {
-  const [showTags, setShowTags] = useState(false);
-
   const cloneDisabled = !queryId;
 
   return (
@@ -81,11 +78,7 @@ function Toolbar({
 
         <ToolbarSpacer />
 
-        <IconButton tooltip="Tags" onClick={() => setShowTags(true)}>
-          <TagsIcon />
-        </IconButton>
-
-        <QueryTagsModal visible={showTags} onClose={() => setShowTags(false)} />
+        <ToolbarTagsButton />
 
         <IconButton
           tooltip="Clone"

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -1,37 +1,32 @@
-import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
-import SaveIcon from 'mdi-react/ContentSaveIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
-import IconButton from '../../common/IconButton';
-import { runQuery, saveQuery } from '../../stores/queries';
+import { runQuery } from '../../stores/queries';
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
 import ToolbarCloneButton from './ToolbarCloneButton';
+import ToolbarFormatQueryButton from './ToolbarFormatQueryButton';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarNewQueryButton from './ToolbarNewQueryButton';
 import ToolbarQueryNameInput from './ToolbarQueryNameInput';
+import ToolbarSaveButton from './ToolbarSaveButton';
 import ToolbarSpacer from './ToolbarSpacer';
 import ToolbarTagsButton from './ToolbarTagsButton';
 import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
-import ToolbarFormatQueryButton from './ToolbarFormatQueryButton';
 
 function mapStateToProps(state) {
   return {
-    isRunning: state.isRunning,
-    isSaving: state.isSaving,
-    unsavedChanges: state.unsavedChanges
+    isRunning: state.isRunning
   };
 }
 
 const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
-  runQuery: runQuery(store),
-  saveQuery: saveQuery(store)
+  runQuery: runQuery(store)
 }))(React.memo(Toolbar));
 
-function Toolbar({ isRunning, isSaving, runQuery, saveQuery, unsavedChanges }) {
+function Toolbar({ isRunning, runQuery }) {
   return (
     <div
       style={{
@@ -59,14 +54,7 @@ function Toolbar({ isRunning, isSaving, runQuery, saveQuery, unsavedChanges }) {
         <ToolbarTagsButton />
         <ToolbarCloneButton />
         <ToolbarFormatQueryButton />
-
-        <IconButton
-          tooltip="Save"
-          onClick={() => saveQuery()}
-          disabled={isSaving}
-        >
-          {unsavedChanges ? <UnsavedIcon /> : <SaveIcon />}
-        </IconButton>
+        <ToolbarSaveButton />
 
         <ToolbarSpacer />
 
@@ -87,11 +75,8 @@ function Toolbar({ isRunning, isSaving, runQuery, saveQuery, unsavedChanges }) {
 }
 
 Toolbar.propTypes = {
-  isSaving: PropTypes.bool.isRequired,
   isRunning: PropTypes.bool.isRequired,
-  saveQuery: PropTypes.func.isRequired,
-  runQuery: PropTypes.func.isRequired,
-  unsavedChanges: PropTypes.bool.isRequired
+  runQuery: PropTypes.func.isRequired
 };
 
 export default ConnectedEditorNavBar;

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -3,7 +3,6 @@ import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
 import SaveIcon from 'mdi-react/ContentSaveIcon';
 import DatabaseIcon from 'mdi-react/DatabaseIcon';
 import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
-import NewIcon from 'mdi-react/PlusIcon';
 import TagsIcon from 'mdi-react/TagMultipleIcon';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
@@ -14,7 +13,6 @@ import Input from '../../common/Input';
 import {
   formatQuery,
   handleCloneClick,
-  resetNewQuery,
   runQuery,
   saveQuery,
   setQueryState
@@ -25,6 +23,7 @@ import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
 import QueryTagsModal from './QueryTagsModal';
 import ToolbarMenu from './ToolbarMenu';
+import ToolbarNewQueryButton from './ToolbarNewQueryButton';
 import ToolbarSpacer from './ToolbarSpacer';
 
 function mapStateToProps(state) {
@@ -44,7 +43,6 @@ const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
   runQuery: runQuery(store),
   saveQuery: saveQuery(store),
   handleCloneClick,
-  resetNewQuery,
   setQueryState
 }))(React.memo(Toolbar));
 
@@ -55,7 +53,6 @@ function Toolbar({
   isSaving,
   queryId,
   queryName,
-  resetNewQuery,
   runQuery,
   saveQuery,
   setQueryState,
@@ -80,13 +77,7 @@ function Toolbar({
       <div style={{ display: 'flex' }}>
         <QueryListButton />
 
-        <IconButton
-          to="/queries/new"
-          tooltip="New query"
-          onClick={() => resetNewQuery()}
-        >
-          <NewIcon />
-        </IconButton>
+        <ToolbarNewQueryButton />
 
         <ToolbarSpacer grow />
 

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -1,7 +1,6 @@
 import CopyIcon from 'mdi-react/ContentCopyIcon';
 import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
 import SaveIcon from 'mdi-react/ContentSaveIcon';
-import DatabaseIcon from 'mdi-react/DatabaseIcon';
 import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
 import TagsIcon from 'mdi-react/TagMultipleIcon';
 import PropTypes from 'prop-types';
@@ -17,7 +16,6 @@ import {
   saveQuery,
   setQueryState
 } from '../../stores/queries';
-import { toggleSchema } from '../../stores/schema';
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
@@ -25,6 +23,7 @@ import QueryTagsModal from './QueryTagsModal';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarNewQueryButton from './ToolbarNewQueryButton';
 import ToolbarSpacer from './ToolbarSpacer';
+import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
 
 function mapStateToProps(state) {
   return {
@@ -38,7 +37,6 @@ function mapStateToProps(state) {
 }
 
 const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
-  toggleSchema,
   formatQuery,
   runQuery: runQuery(store),
   saveQuery: saveQuery(store),
@@ -57,7 +55,6 @@ function Toolbar({
   saveQuery,
   setQueryState,
   showValidation,
-  toggleSchema,
   unsavedChanges
 }) {
   const [showTags, setShowTags] = useState(false);
@@ -81,9 +78,7 @@ function Toolbar({
 
         <ToolbarSpacer grow />
 
-        <IconButton tooltip="Toggle schema" onClick={toggleSchema}>
-          <DatabaseIcon />
-        </IconButton>
+        <ToolbarToggleSchemaButton />
 
         <ConnectionDropDown />
 

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -35,16 +35,7 @@ import AboutModal from './AboutModal';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
 import QueryTagsModal from './QueryTagsModal';
-
-const growSpacerStyle = { flexShrink: 0, flexGrow: 1, width: 8 };
-const spacerStyle = { flexShrink: 0, width: 8 };
-
-function Spacer({ grow }) {
-  if (grow) {
-    return <div style={growSpacerStyle} />;
-  }
-  return <div style={spacerStyle} />;
-}
+import ToolbarSpacer from './ToolbarSpacer';
 
 function mapStateToProps(state) {
   return {
@@ -142,7 +133,7 @@ function Toolbar({
           <NewIcon />
         </IconButton>
 
-        <Spacer grow />
+        <ToolbarSpacer grow />
 
         <IconButton tooltip="Toggle schema" onClick={toggleSchema}>
           <DatabaseIcon />
@@ -150,7 +141,7 @@ function Toolbar({
 
         <ConnectionDropDown />
 
-        <Spacer />
+        <ToolbarSpacer />
 
         <Input
           error={error}
@@ -160,7 +151,7 @@ function Toolbar({
           onChange={e => setQueryState('name', e.target.value)}
         />
 
-        <Spacer />
+        <ToolbarSpacer />
 
         <IconButton tooltip="Tags" onClick={() => setShowTags(true)}>
           <TagsIcon />
@@ -188,17 +179,17 @@ function Toolbar({
           {unsavedChanges ? <UnsavedIcon /> : <SaveIcon />}
         </IconButton>
 
-        <Spacer />
+        <ToolbarSpacer />
 
         <Button type="primary" onClick={() => runQuery()} disabled={isRunning}>
           Run
         </Button>
 
-        <Spacer />
+        <ToolbarSpacer />
 
         <ChartButton />
 
-        <Spacer grow />
+        <ToolbarSpacer grow />
 
         <IconMenu icon={<DotsVerticalIcon aria-label="menu" />}>
           {menuItems}

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -1,12 +1,11 @@
 import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
 import SaveIcon from 'mdi-react/ContentSaveIcon';
-import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
 import IconButton from '../../common/IconButton';
-import { formatQuery, runQuery, saveQuery } from '../../stores/queries';
+import { runQuery, saveQuery } from '../../stores/queries';
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
@@ -17,6 +16,7 @@ import ToolbarQueryNameInput from './ToolbarQueryNameInput';
 import ToolbarSpacer from './ToolbarSpacer';
 import ToolbarTagsButton from './ToolbarTagsButton';
 import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
+import ToolbarFormatQueryButton from './ToolbarFormatQueryButton';
 
 function mapStateToProps(state) {
   return {
@@ -27,19 +27,11 @@ function mapStateToProps(state) {
 }
 
 const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
-  formatQuery,
   runQuery: runQuery(store),
   saveQuery: saveQuery(store)
 }))(React.memo(Toolbar));
 
-function Toolbar({
-  formatQuery,
-  isRunning,
-  isSaving,
-  runQuery,
-  saveQuery,
-  unsavedChanges
-}) {
+function Toolbar({ isRunning, isSaving, runQuery, saveQuery, unsavedChanges }) {
   return (
     <div
       style={{
@@ -66,10 +58,7 @@ function Toolbar({
 
         <ToolbarTagsButton />
         <ToolbarCloneButton />
-
-        <IconButton tooltip="Format" onClick={formatQuery}>
-          <FormatIcon />
-        </IconButton>
+        <ToolbarFormatQueryButton />
 
         <IconButton
           tooltip="Save"
@@ -102,7 +91,6 @@ Toolbar.propTypes = {
   isRunning: PropTypes.bool.isRequired,
   saveQuery: PropTypes.func.isRequired,
   runQuery: PropTypes.func.isRequired,
-  formatQuery: PropTypes.func.isRequired,
   unsavedChanges: PropTypes.bool.isRequired
 };
 

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -8,13 +8,11 @@ import React, { useState } from 'react';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
 import IconButton from '../../common/IconButton';
-import Input from '../../common/Input';
 import {
   formatQuery,
   handleCloneClick,
   runQuery,
-  saveQuery,
-  setQueryState
+  saveQuery
 } from '../../stores/queries';
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
@@ -22,6 +20,7 @@ import QueryListButton from './QueryListButton';
 import QueryTagsModal from './QueryTagsModal';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarNewQueryButton from './ToolbarNewQueryButton';
+import ToolbarQueryNameInput from './ToolbarQueryNameInput';
 import ToolbarSpacer from './ToolbarSpacer';
 import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
 
@@ -30,8 +29,6 @@ function mapStateToProps(state) {
     isRunning: state.isRunning,
     isSaving: state.isSaving,
     queryId: state.query && state.query._id,
-    queryName: state.query && state.query.name,
-    showValidation: state.showValidation,
     unsavedChanges: state.unsavedChanges
   };
 }
@@ -40,8 +37,7 @@ const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
   formatQuery,
   runQuery: runQuery(store),
   saveQuery: saveQuery(store),
-  handleCloneClick,
-  setQueryState
+  handleCloneClick
 }))(React.memo(Toolbar));
 
 function Toolbar({
@@ -50,16 +46,13 @@ function Toolbar({
   isRunning,
   isSaving,
   queryId,
-  queryName,
   runQuery,
   saveQuery,
-  setQueryState,
-  showValidation,
+
   unsavedChanges
 }) {
   const [showTags, setShowTags] = useState(false);
 
-  const error = showValidation && !queryName.length;
   const cloneDisabled = !queryId;
 
   return (
@@ -84,13 +77,7 @@ function Toolbar({
 
         <ToolbarSpacer />
 
-        <Input
-          error={error}
-          style={{ width: 260 }}
-          placeholder="Query name"
-          value={queryName}
-          onChange={e => setQueryState('name', e.target.value)}
-        />
+        <ToolbarQueryNameInput />
 
         <ToolbarSpacer />
 
@@ -145,9 +132,7 @@ Toolbar.propTypes = {
   saveQuery: PropTypes.func.isRequired,
   runQuery: PropTypes.func.isRequired,
   formatQuery: PropTypes.func.isRequired,
-  queryName: PropTypes.string.isRequired,
   queryId: PropTypes.string,
-  showValidation: PropTypes.bool.isRequired,
   unsavedChanges: PropTypes.bool.isRequired
 };
 

--- a/client/src/queryEditor/toolbar/Toolbar.js
+++ b/client/src/queryEditor/toolbar/Toolbar.js
@@ -1,8 +1,4 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'unistore/react';
-import Button from '../../common/Button';
-import { runQuery } from '../../stores/queries';
 import ConnectionDropDown from '../ConnectionDropdown';
 import ChartButton from './ChartButton';
 import QueryListButton from './QueryListButton';
@@ -11,22 +7,13 @@ import ToolbarFormatQueryButton from './ToolbarFormatQueryButton';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarNewQueryButton from './ToolbarNewQueryButton';
 import ToolbarQueryNameInput from './ToolbarQueryNameInput';
+import ToolbarRunButton from './ToolbarRunButton';
 import ToolbarSaveButton from './ToolbarSaveButton';
 import ToolbarSpacer from './ToolbarSpacer';
 import ToolbarTagsButton from './ToolbarTagsButton';
 import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
 
-function mapStateToProps(state) {
-  return {
-    isRunning: state.isRunning
-  };
-}
-
-const ConnectedEditorNavBar = connect(mapStateToProps, store => ({
-  runQuery: runQuery(store)
-}))(React.memo(Toolbar));
-
-function Toolbar({ isRunning, runQuery }) {
+function Toolbar() {
   return (
     <div
       style={{
@@ -58,9 +45,7 @@ function Toolbar({ isRunning, runQuery }) {
 
         <ToolbarSpacer />
 
-        <Button type="primary" onClick={() => runQuery()} disabled={isRunning}>
-          Run
-        </Button>
+        <ToolbarRunButton />
 
         <ToolbarSpacer />
 
@@ -74,9 +59,4 @@ function Toolbar({ isRunning, runQuery }) {
   );
 }
 
-Toolbar.propTypes = {
-  isRunning: PropTypes.bool.isRequired,
-  runQuery: PropTypes.func.isRequired
-};
-
-export default ConnectedEditorNavBar;
+export default React.memo(Toolbar);

--- a/client/src/queryEditor/toolbar/ToolbarCloneButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarCloneButton.js
@@ -1,0 +1,31 @@
+import CopyIcon from 'mdi-react/ContentCopyIcon';
+import React from 'react';
+import { connect } from 'unistore/react';
+import IconButton from '../../common/IconButton';
+import { handleCloneClick } from '../../stores/queries';
+
+function mapStateToProps(state) {
+  return {
+    queryId: state.query && state.query._id
+  };
+}
+
+const ConnectedToolbarCloneButton = connect(mapStateToProps, store => ({
+  handleCloneClick
+}))(React.memo(ToolbarCloneButton));
+
+function ToolbarCloneButton({ handleCloneClick, queryId }) {
+  const cloneDisabled = !queryId;
+
+  return (
+    <IconButton
+      tooltip="Clone"
+      onClick={handleCloneClick}
+      disabled={cloneDisabled}
+    >
+      <CopyIcon />
+    </IconButton>
+  );
+}
+
+export default ConnectedToolbarCloneButton;

--- a/client/src/queryEditor/toolbar/ToolbarFormatQueryButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarFormatQueryButton.js
@@ -1,0 +1,23 @@
+import FormatIcon from 'mdi-react/FormatAlignLeftIcon';
+import React from 'react';
+import { connect } from 'unistore/react';
+import IconButton from '../../common/IconButton';
+import { formatQuery } from '../../stores/queries';
+
+function mapStateToProps(state) {
+  return {};
+}
+
+const ConnectedToolbarFormatQueryButton = connect(mapStateToProps, store => ({
+  formatQuery
+}))(React.memo(ToolbarFormatQueryButton));
+
+function ToolbarFormatQueryButton({ formatQuery }) {
+  return (
+    <IconButton tooltip="Format" onClick={formatQuery}>
+      <FormatIcon />
+    </IconButton>
+  );
+}
+
+export default ConnectedToolbarFormatQueryButton;

--- a/client/src/queryEditor/toolbar/ToolbarMenu.js
+++ b/client/src/queryEditor/toolbar/ToolbarMenu.js
@@ -1,0 +1,115 @@
+import { MenuItem } from '@reach/menu-button';
+import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon';
+import React, { useState } from 'react';
+import { Redirect } from 'react-router-dom';
+import { connect } from 'unistore/react';
+import Drawer from '../../common/Drawer';
+import IconMenu from '../../common/IconMenu';
+import ConnectionAccessListDrawer from '../../connectionAccesses/ConnectionAccessListDrawer';
+import ConnectionListDrawer from '../../connections/ConnectionListDrawer';
+import QueryHistoryModal from '../../queryHistory/QueryHistoryModal';
+import UserList from '../../users/UserList';
+import fetchJson from '../../utilities/fetch-json.js';
+import AboutModal from './AboutModal';
+
+function mapStateToProps(state) {
+  return {
+    currentUser: state.currentUser
+  };
+}
+
+const ConnectedToolbarMenu = connect(mapStateToProps)(React.memo(ToolbarMenu));
+
+function ToolbarMenu({ currentUser }) {
+  const [showUsers, setShowUsers] = useState(false);
+  const [redirectToSignIn, setRedirectToSignIn] = useState(false);
+  const [showQueryHistory, setShowQueryHistory] = useState(false);
+  const [showAbout, setShowAbout] = useState(false);
+  const [showConnections, setShowConnections] = useState(false);
+  const [showConnectionAccesses, setShowConnectionAccesses] = useState(false);
+
+  const isAdmin = currentUser.role === 'admin';
+
+  if (redirectToSignIn) {
+    return <Redirect push to="/signin" />;
+  }
+
+  // Reach UI menu / IconMenu does not like the {someBoolean && <element/>} patterm
+  // As a workaround optional MenuItems are managed in an array
+  let menuItems = [];
+  if (isAdmin) {
+    menuItems = [
+      <MenuItem key="connections" onSelect={() => setShowConnections(true)}>
+        Connections
+      </MenuItem>,
+      <MenuItem key="users" onSelect={() => setShowUsers(true)}>
+        Users
+      </MenuItem>,
+      <MenuItem
+        key="connectionAccessess"
+        style={{ borderBottom: '1px solid #ddd' }}
+        onSelect={() => setShowConnectionAccesses(true)}
+      >
+        Connection Accesses
+      </MenuItem>
+    ];
+  }
+
+  return (
+    <div>
+      <IconMenu icon={<DotsVerticalIcon aria-label="menu" />}>
+        {menuItems}
+        <MenuItem
+          key="queryHistory"
+          style={{ borderBottom: '1px solid #ddd' }}
+          onSelect={() => setShowQueryHistory(true)}
+        >
+          Query History
+        </MenuItem>
+        <MenuItem
+          style={{ borderBottom: '1px solid #ddd' }}
+          onSelect={() => setShowAbout(true)}
+        >
+          About
+        </MenuItem>
+        <MenuItem
+          onSelect={async () => {
+            await fetchJson('GET', '/api/signout');
+            setRedirectToSignIn(true);
+          }}
+        >
+          Sign out
+        </MenuItem>
+      </IconMenu>
+
+      <Drawer
+        title={'Users'}
+        visible={showUsers}
+        width={600}
+        onClose={() => setShowUsers(false)}
+        placement={'right'}
+      >
+        <UserList />
+      </Drawer>
+
+      <QueryHistoryModal
+        visible={showQueryHistory}
+        onClose={() => setShowQueryHistory(false)}
+      />
+
+      <AboutModal visible={showAbout} onClose={() => setShowAbout(false)} />
+
+      <ConnectionListDrawer
+        visible={showConnections}
+        onClose={() => setShowConnections(false)}
+      />
+
+      <ConnectionAccessListDrawer
+        visible={showConnectionAccesses}
+        onClose={() => setShowConnectionAccesses(false)}
+      />
+    </div>
+  );
+}
+
+export default ConnectedToolbarMenu;

--- a/client/src/queryEditor/toolbar/ToolbarNewQueryButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarNewQueryButton.js
@@ -1,0 +1,27 @@
+import NewIcon from 'mdi-react/PlusIcon';
+import React from 'react';
+import { connect } from 'unistore/react';
+import IconButton from '../../common/IconButton';
+import { resetNewQuery } from '../../stores/queries';
+
+function mapStateToProps(state) {
+  return {};
+}
+
+const ConnectedToolbarNewQueryButton = connect(mapStateToProps, store => ({
+  resetNewQuery
+}))(React.memo(ToolbarNewQueryButton));
+
+function ToolbarNewQueryButton({ resetNewQuery }) {
+  return (
+    <IconButton
+      to="/queries/new"
+      tooltip="New query"
+      onClick={() => resetNewQuery()}
+    >
+      <NewIcon />
+    </IconButton>
+  );
+}
+
+export default ConnectedToolbarNewQueryButton;

--- a/client/src/queryEditor/toolbar/ToolbarQueryNameInput.js
+++ b/client/src/queryEditor/toolbar/ToolbarQueryNameInput.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'unistore/react';
+import Input from '../../common/Input';
+import { setQueryState } from '../../stores/queries';
+
+function mapStateToProps(state) {
+  return {
+    queryName: state.query && state.query.name,
+    showValidation: state.showValidation
+  };
+}
+
+const ConnectedToolbarQueryNameInput = connect(mapStateToProps, store => ({
+  setQueryState
+}))(React.memo(ToolbarQueryNameInput));
+
+function ToolbarQueryNameInput({ queryName, setQueryState, showValidation }) {
+  const error = showValidation && !queryName.length;
+
+  return (
+    <Input
+      error={error}
+      style={{ width: 260 }}
+      placeholder="Query name"
+      value={queryName}
+      onChange={e => setQueryState('name', e.target.value)}
+    />
+  );
+}
+
+export default ConnectedToolbarQueryNameInput;

--- a/client/src/queryEditor/toolbar/ToolbarRunButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarRunButton.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'unistore/react';
+import Button from '../../common/Button';
+import { runQuery } from '../../stores/queries';
+
+function mapStateToProps(state) {
+  return {
+    isRunning: state.isRunning
+  };
+}
+
+const ConnectedToolbarRunButton = connect(mapStateToProps, store => ({
+  runQuery: runQuery(store)
+}))(React.memo(ToolbarRunButton));
+
+function ToolbarRunButton({ isRunning, runQuery }) {
+  return (
+    <Button type="primary" onClick={() => runQuery()} disabled={isRunning}>
+      Run
+    </Button>
+  );
+}
+
+ToolbarRunButton.propTypes = {
+  isRunning: PropTypes.bool.isRequired,
+  runQuery: PropTypes.func.isRequired
+};
+
+export default ConnectedToolbarRunButton;

--- a/client/src/queryEditor/toolbar/ToolbarSaveButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarSaveButton.js
@@ -1,0 +1,34 @@
+import UnsavedIcon from 'mdi-react/ContentSaveEditIcon';
+import SaveIcon from 'mdi-react/ContentSaveIcon';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'unistore/react';
+import IconButton from '../../common/IconButton';
+import { saveQuery } from '../../stores/queries';
+
+function mapStateToProps(state) {
+  return {
+    isSaving: state.isSaving,
+    unsavedChanges: state.unsavedChanges
+  };
+}
+
+const ConnectedToolbarSaveButton = connect(mapStateToProps, store => ({
+  saveQuery: saveQuery(store)
+}))(React.memo(ToolbarSaveButton));
+
+function ToolbarSaveButton({ isSaving, saveQuery, unsavedChanges }) {
+  return (
+    <IconButton tooltip="Save" onClick={() => saveQuery()} disabled={isSaving}>
+      {unsavedChanges ? <UnsavedIcon /> : <SaveIcon />}
+    </IconButton>
+  );
+}
+
+ToolbarSaveButton.propTypes = {
+  isSaving: PropTypes.bool.isRequired,
+  saveQuery: PropTypes.func.isRequired,
+  unsavedChanges: PropTypes.bool.isRequired
+};
+
+export default ConnectedToolbarSaveButton;

--- a/client/src/queryEditor/toolbar/ToolbarSpacer.js
+++ b/client/src/queryEditor/toolbar/ToolbarSpacer.js
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const growSpacerStyle = { flexShrink: 0, flexGrow: 1, width: 8 };
+const spacerStyle = { flexShrink: 0, width: 8 };
+
+function ToolbarSpacer({ grow }) {
+  if (grow) {
+    return <div style={growSpacerStyle} />;
+  }
+  return <div style={spacerStyle} />;
+}
+
+ToolbarSpacer.propTypes = {
+  grow: PropTypes.bool
+};
+
+export default ToolbarSpacer;

--- a/client/src/queryEditor/toolbar/ToolbarTagsButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarTagsButton.js
@@ -1,0 +1,20 @@
+import TagsIcon from 'mdi-react/TagMultipleIcon';
+import React, { useState } from 'react';
+import IconButton from '../../common/IconButton';
+import QueryTagsModal from './QueryTagsModal';
+
+function ToolbarTagsButton() {
+  const [showTags, setShowTags] = useState(false);
+
+  return (
+    <div>
+      <IconButton tooltip="Tags" onClick={() => setShowTags(true)}>
+        <TagsIcon />
+      </IconButton>
+
+      <QueryTagsModal visible={showTags} onClose={() => setShowTags(false)} />
+    </div>
+  );
+}
+
+export default ToolbarTagsButton;

--- a/client/src/queryEditor/toolbar/ToolbarToggleSchemaButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarToggleSchemaButton.js
@@ -1,0 +1,23 @@
+import DatabaseIcon from 'mdi-react/DatabaseIcon';
+import React from 'react';
+import { connect } from 'unistore/react';
+import IconButton from '../../common/IconButton';
+import { toggleSchema } from '../../stores/schema';
+
+function mapStateToProps(state) {
+  return {};
+}
+
+const ConnectedToolbarToggleSchemaButton = connect(mapStateToProps, store => ({
+  toggleSchema
+}))(React.memo(ToolbarToggleSchemaButton));
+
+function ToolbarToggleSchemaButton({ toggleSchema }) {
+  return (
+    <IconButton tooltip="Toggle schema" onClick={toggleSchema}>
+      <DatabaseIcon />
+    </IconButton>
+  );
+}
+
+export default ConnectedToolbarToggleSchemaButton;


### PR DESCRIPTION
Breaks toolbar components into smaller subcomponents, each connected to unistore and owning their own behavior. No behavior changes are contained within this change.