### PR TITLE
Query ACL enhancements: Add userEmail and groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,9 +534,9 @@ Queries are created or replaced matching on query id. At this time the query ACL
 
 At this point SQLPad does not enforce referential integrity, so queries may be created with a `createdBy` containing an email address for a user that does not exist.
 
-Example seed query JSON file:
+Example seed query JSON file (comments only added for doc purposes):
 
-```json
+```js
 {
   "id": "seed-query-1",
   "name": "Seed query 1",
@@ -544,8 +544,20 @@ Example seed query JSON file:
   "queryText": "SELECT * FROM seed_table",
   "createdBy": "admin@sqlpad.com",
   "acl": [
+    // an ACL entry with write=false allows that user to read (and execute if they have connection permission)
     {
-      "userId": "__EVERYONE__",
+      "userId": "some-userId-in-sqlpad",
+      "write": false
+    },
+    // ACL entry can also be specified with a users email address.
+    // The user does not need to exist in SQLPad at this point
+    {
+      "userEmail": "someone@sqlpad.com",
+      "write": true
+    },
+    // Alternatively a special __EVERYONE__ group may be used to share the query with all SQLPad users
+    {
+      "groupId": "__EVERYONE__",
       "write": true
     }
   ]

--- a/README.md
+++ b/README.md
@@ -544,7 +544,9 @@ Example seed query JSON file (comments only added for doc purposes):
   "queryText": "SELECT * FROM seed_table",
   "createdBy": "admin@sqlpad.com",
   "acl": [
-    // an ACL entry with write=false allows that user to read (and execute if they have connection permission)
+    // an ACL entry with write=false allows that user to read
+    // (and execute if they have connection permission)
+    // write=true allows user to save query
     {
       "userId": "some-userId-in-sqlpad",
       "write": false

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -137,9 +137,6 @@ function QueryListDrawer({
     const chartUrl = `/query-chart/${query._id}`;
     const queryUrl = `/queries/${query._id}`;
 
-    const canDelete =
-      currentUser.role === 'admin' || currentUser.email === query.createdBy;
-
     const hasChart =
       query && query.chartConfiguration && query.chartConfiguration.chartType;
 
@@ -181,7 +178,7 @@ function QueryListDrawer({
             key="del"
             confirmMessage={`Delete ${query.name}`}
             onConfirm={e => deleteQuery(query._id)}
-            disabled={!canDelete}
+            disabled={!query.canDelete}
           >
             Delete
           </DeleteConfirmButton>

--- a/client/src/queryEditor/toolbar/ToolbarShareQueryButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarShareQueryButton.js
@@ -20,7 +20,7 @@ function ToolbarShareQueryButton({ shared, setQueryState }) {
   function handleClick() {
     setQueryState(
       'acl',
-      shared ? [] : [{ userId: '__EVERYONE__', write: true }]
+      shared ? [] : [{ groupId: '__EVERYONE__', write: true }]
     );
   }
 

--- a/client/src/stores/queries.js
+++ b/client/src/stores/queries.js
@@ -17,7 +17,10 @@ export const NEW_QUERY = {
   chartConfiguration: {
     chartType: '',
     fields: {} // key value for chart
-  }
+  },
+  canRead: true,
+  canWrite: true,
+  canDelete: true
 };
 
 export const initialState = {

--- a/server/lib/decorateQueryUserAccess.js
+++ b/server/lib/decorateQueryUserAccess.js
@@ -18,9 +18,19 @@ function decorateQueryUserAccess(query, user) {
     clone.canWrite = true;
     clone.canDelete = true;
   } else if (clone.acl.length) {
-    const writeAcl = clone.acl.find(a => a.write === true);
+    const writeAcl = clone.acl
+      // filter acl records that match for this user
+      .filter(
+        acl =>
+          acl.groupId === consts.EVERYONE_ID ||
+          acl.userId === user._id ||
+          acl.userEmail === user.email
+      )
+      // and return first one that has write
+      .find(a => a.write === true);
     clone.canWrite = Boolean(writeAcl);
 
+    // A record in ACL allows read permissions
     const canRead = query.acl.find(
       acl =>
         acl.groupId === consts.EVERYONE_ID ||

--- a/server/lib/decorateQueryUserAccess.js
+++ b/server/lib/decorateQueryUserAccess.js
@@ -1,0 +1,36 @@
+const consts = require('./consts');
+
+// Not sure where to put utilities like these
+
+/**
+ * Returns a decorated query object with canRead, canWrite, and canDelete properties
+ * @param {object} query
+ * @param {object} user
+ */
+function decorateQueryUserAccess(query, user) {
+  const { ...clone } = query;
+  clone.canRead = false;
+  clone.canWrite = false;
+  clone.canDelete = false;
+
+  if (user.role === 'admin' || user.email === clone.createdBy) {
+    clone.canRead = true;
+    clone.canWrite = true;
+    clone.canDelete = true;
+  } else if (clone.acl.length) {
+    const writeAcl = clone.acl.find(a => a.write === true);
+    clone.canWrite = Boolean(writeAcl);
+
+    const canRead = query.acl.find(
+      acl =>
+        acl.groupId === consts.EVERYONE_ID ||
+        acl.userId === user._id ||
+        acl.userEmail === user.email
+    );
+    clone.canRead = Boolean(canRead);
+  }
+
+  return clone;
+}
+
+module.exports = decorateQueryUserAccess;

--- a/server/migrations/04-00110-query-acl-data.js
+++ b/server/migrations/04-00110-query-acl-data.js
@@ -1,5 +1,3 @@
-const consts = require('../lib/consts');
-
 /**
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {import('../lib/config')} config
@@ -14,7 +12,7 @@ async function up(queryInterface, config, appLog, nedb) {
     const records = queries.map(query => {
       return {
         query_id: query._id,
-        user_id: consts.EVERYONE_ID,
+        user_id: '__EVERYONE__', // value in consts.EVERYONE_ID at time of migration
         write: true,
         created_at: new Date(),
         updated_at: new Date()

--- a/server/migrations/04-00120-query-acl-remove-old-constraint.js
+++ b/server/migrations/04-00120-query-acl-remove-old-constraint.js
@@ -1,0 +1,18 @@
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  // Remove unique constraint on query_id_user_id (it'll be added again switched around later)
+  await queryInterface.removeConstraint(
+    'query_acl',
+    'query_acl_query_id_user_id_key'
+  );
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00121-query-acl-add-user-email.js
+++ b/server/migrations/04-00121-query-acl-add-user-email.js
@@ -1,0 +1,18 @@
+const Sequelize = require('sequelize');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  await queryInterface.addColumn('query_acl', 'user_email', {
+    type: Sequelize.STRING
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00122-query-acl-add-group-id.js
+++ b/server/migrations/04-00122-query-acl-add-group-id.js
@@ -1,0 +1,18 @@
+const Sequelize = require('sequelize');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  await queryInterface.addColumn('query_acl', 'group_id', {
+    type: Sequelize.STRING
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00123-query-acl-remove-user-id-not-null.js
+++ b/server/migrations/04-00123-query-acl-remove-user-id-not-null.js
@@ -1,0 +1,20 @@
+const Sequelize = require('sequelize');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  // remove not-null constraint for user_id
+  await queryInterface.changeColumn('query_acl', 'user_id', {
+    type: Sequelize.STRING,
+    allowNull: true
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00124-query-acl-add-constraint-user-email-query.js
+++ b/server/migrations/04-00124-query-acl-add-constraint-user-email-query.js
@@ -1,0 +1,18 @@
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  // Add unique constraint for (user_email, query_id) and (group_id, query_id)
+  await queryInterface.addConstraint('query_acl', ['user_email', 'query_id'], {
+    type: 'unique',
+    name: 'query_acl_user_email_query_id_key'
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00125-query-acl-add-constraint-group-query.js
+++ b/server/migrations/04-00125-query-acl-add-constraint-group-query.js
@@ -1,0 +1,17 @@
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  await queryInterface.addConstraint('query_acl', ['group_id', 'query_id'], {
+    type: 'unique',
+    name: 'query_acl_group_id_query_id_key'
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00126-query-acl-add-constraint-user-id-query.js
+++ b/server/migrations/04-00126-query-acl-add-constraint-user-id-query.js
@@ -1,0 +1,18 @@
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  // Swap unique constraint around for (query_id, user_id) for index strategy, then add query_id index
+  await queryInterface.addConstraint('query_acl', ['user_id', 'query_id'], {
+    type: 'unique',
+    name: 'query_acl_user_id_query_id_key'
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00127-query-acl-add-index-query-id.js
+++ b/server/migrations/04-00127-query-acl-add-index-query-id.js
@@ -1,0 +1,17 @@
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  await queryInterface.addIndex('query_acl', {
+    fields: ['query_id'],
+    name: 'query_acl_query_id'
+  });
+}
+
+module.exports = {
+  up
+};

--- a/server/migrations/04-00128-query-acl-move-everyone-id-to-group.js
+++ b/server/migrations/04-00128-query-acl-move-everyone-id-to-group.js
@@ -1,0 +1,24 @@
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  // For any acl entries created in 04-00110, move the "__EVERYONE__" value to groupId
+  await queryInterface.bulkUpdate(
+    'query_acl',
+    {
+      user_id: null,
+      group_id: '__EVERYONE__' // value in consts.EVERYONE_ID at time of migration
+    },
+    {
+      user_id: '__EVERYONE__' // value in consts.EVERYONE_ID at time of migration
+    }
+  );
+}
+
+module.exports = {
+  up
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -7,6 +7,7 @@ const Queries = require('./queries');
 const Connections = require('./connections');
 const ConnectionAccesses = require('./connectionAccesses');
 const QueryAcl = require('./queryAcl');
+const decorateQueryUserAccess = require('../lib/decorateQueryUserAccess');
 
 class Models {
   constructor(nedb, sequelizeDb, config) {
@@ -26,43 +27,29 @@ class Models {
    * If user is an admin, get all queries
    * If user is NOT an admin, get queries created by user or that are shared
    *
-   * This needs to merge queries, acl, and user data
-   * Fetching all query/user/acl data is not ideal, but is probably okay for now
+   * This needs to merge queries and acl
+   * Fetching both query and acl data is not ideal, but is probably okay for now
    * This will become problematic for large SQLPad environments
    * Eventually this can be a better SQL query once all data is moved to SQLite
    * @param {object} user
    */
   async findQueriesForUser(user) {
     const queries = await this.queries.findAll();
-
-    // If user is an admin return all queries and avoid extra work
-    if (user.role === 'admin') {
-      return queries;
-    }
-
-    const queryAcls = await this.queryAcl.findAllByUser(user);
+    const queryAcls = await this.queryAcl.findAll();
     const queryAclsByQueryId = _.groupBy(queryAcls, 'queryId');
 
-    const usersQueries = queries.map(query => {
-      const acl = queryAclsByQueryId[query._id] || [];
-
-      // If user is the owner return it
-      if (query.createdBy === user.email) {
-        return query;
-      }
-
-      // If user has access via acl return it
-      if (acl.length > 0) {
-        return query;
-      }
-
-      // Otherwise user does not have access
-      return null;
-    });
-
-    // The map() may have returned nulls,
-    // which represent queries the user does not have access to
-    return usersQueries.filter(query => Boolean(query));
+    return (
+      queries
+        // Join in query ACL info needed for decorateQueryUserAccess
+        .map(query => {
+          query.acl = queryAclsByQueryId[query._id] || [];
+          return query;
+        })
+        // Decorate query with canRead/canWrite/canDelete
+        .map(query => decorateQueryUserAccess(query, user))
+        // Only include queries user can read
+        .filter(query => query.canRead)
+    );
   }
 
   /**

--- a/server/models/queryAcl.js
+++ b/server/models/queryAcl.js
@@ -1,4 +1,5 @@
 const consts = require('../lib/consts');
+const { Op } = require('sequelize');
 
 // NOTE - because QueryAcl is driven off of Sequelize ORM model
 // and not nedb (which is schemaless) I am skipping defining a Joi schema here.
@@ -16,9 +17,15 @@ class QueryAcl {
     this.config = config;
   }
 
-  findAllByUserId(userId) {
+  findAllByUser(user) {
     return this.sequelizeDb.QueryAcl.findAll({
-      where: { userId: [userId, consts.EVERYONE_ID] }
+      where: {
+        [Op.or]: [
+          { userId: user._id },
+          { userEmail: user.email },
+          { groupId: consts.EVERYONE_ID }
+        ]
+      }
     });
   }
 
@@ -30,12 +37,6 @@ class QueryAcl {
 
   findOneById(id) {
     return this.sequelizeDb.QueryAcl.findOne({ where: { id } });
-  }
-
-  findOneByQueryIdUserId(queryId, userId) {
-    return this.sequelizeDb.QueryAcl.findOne({
-      where: { queryId, userId: [userId, consts.EVERYONE_ID] }
-    });
   }
 
   removeByQueryId(queryId) {

--- a/server/models/queryAcl.js
+++ b/server/models/queryAcl.js
@@ -17,6 +17,10 @@ class QueryAcl {
     this.config = config;
   }
 
+  findAll() {
+    return this.sequelizeDb.QueryAcl.findAll();
+  }
+
   findAllByUser(user) {
     return this.sequelizeDb.QueryAcl.findAll({
       where: {

--- a/server/sequelizeDb/QueryAcl.js
+++ b/server/sequelizeDb/QueryAcl.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 
 module.exports = function(sequelize) {
-  // An entry in this table gives access to a query for a user or user id constant
+  // An entry in this table gives access to a query for a user_id, user_email, or group_id
   const QueryAcl = sequelize.define(
     'QueryAcl',
     {
@@ -13,14 +13,25 @@ module.exports = function(sequelize) {
       // For historical reasons, queryId can be any string
       queryId: {
         type: DataTypes.STRING,
-        allowNull: false,
-        unique: 'query_acl_query_id_user_id_key'
+        allowNull: false
       },
       // For historical reasons, userId can be any string
       userId: {
         type: DataTypes.STRING,
-        allowNull: false,
-        unique: 'query_acl_query_id_user_id_key'
+        allowNull: true
+      },
+      // Email address can also be specified if userId is not known
+      userEmail: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      // The "Group" data model does not exist yet today but some day maybe will
+      // It is intended to be a generic grouping mechanism
+      // For now it'll contain special group values like "__EVERYONE__" found in consts.EVERYONE_ID
+      // This prevents putting non-user-id values in userId column.
+      groupId: {
+        type: DataTypes.STRING,
+        allowNull: true
       },
       write: {
         type: DataTypes.BOOLEAN,

--- a/server/test/api/queries.js
+++ b/server/test/api/queries.js
@@ -126,10 +126,10 @@ describe('api/queries', function() {
     assert(!body3.error);
   });
 
-  it('Special __EVERYONE__ gives access like expected', async function() {
+  it('acl userEmail gives access like expected', async function() {
     const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
       ...createQueryBody,
-      acl: [{ userId: consts.EVERYONE_ID, write: true }]
+      acl: [{ userEmail: 'editor2@test.com', write: true }]
     });
     assert(!body1.error);
 
@@ -138,7 +138,24 @@ describe('api/queries', function() {
 
     const body3 = await utils.put('editor2', `/api/queries/${query._id}`, {
       ...createQueryBody,
-      acl: [{ userId: consts.EVERYONE_ID, write: true }]
+      acl: [{ userEmail: 'editor2@test.com', write: true }]
+    });
+    assert(!body3.error);
+  });
+
+  it('groupId __EVERYONE__ gives access like expected', async function() {
+    const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      acl: [{ groupId: consts.EVERYONE_ID, write: true }]
+    });
+    assert(!body1.error);
+
+    const body2 = await utils.get('editor2', `/api/queries/${query._id}`);
+    assert(body2.query);
+
+    const body3 = await utils.put('editor2', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      acl: [{ groupId: consts.EVERYONE_ID, write: true }]
     });
     assert(!body3.error);
   });

--- a/server/test/api/queries.js
+++ b/server/test/api/queries.js
@@ -55,6 +55,10 @@ describe('api/queries', function() {
     assert.equal(body.query.name, 'test query2');
   });
 
+  it('Requires authentication', function() {
+    return utils.get(null, `/api/queries/${query._id}`, 302);
+  });
+
   it('Owner can get own query', async function() {
     const body = await utils.get('editor', `/api/queries/${query._id}`);
     assert(!body.error, 'no error');
@@ -70,50 +74,162 @@ describe('api/queries', function() {
     assert(body.error);
   });
 
-  it('Editor2 can get query with specific userId permission', async function() {
+  it('Permissions for other users are not used', async function() {
     const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
       ...createQueryBody,
       name: 'test query2',
-      acl: [{ userId: utils.users.editor2._id, write: false }]
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true }
+      ]
     });
     assert(!body1.error);
 
     const body2 = await utils.get('editor2', `/api/queries/${query._id}`);
-    assert(!body2.error);
-  });
+    assert(body2.error);
 
-  it('Editor2 can only view without write permission', async function() {
-    const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
+    // Add read access for editor 2
+    const body3 = await utils.put('editor', `/api/queries/${query._id}`, {
       ...createQueryBody,
-      acl: [{ userId: utils.users.editor2._id, write: false }]
-    });
-    assert(!body1.error);
-
-    const body2 = await utils.get('editor2', `/api/queries/${query._id}`);
-    assert(!body2.error);
-
-    const body3 = await utils.put('editor2', `/api/queries/${query._id}`, {
-      ...createQueryBody,
-      acl: [{ userId: utils.users.editor2._id, write: false }]
-    });
-    assert(body3.error);
-  });
-
-  it('Editor2 can update with write permission', async function() {
-    const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
-      ...createQueryBody,
-      acl: [{ userId: utils.users.editor2._id, write: true }]
-    });
-    assert(!body1.error);
-
-    const body2 = await utils.get('editor2', `/api/queries/${query._id}`);
-    assert(body2.query);
-
-    const body3 = await utils.put('editor2', `/api/queries/${query._id}`, {
-      ...createQueryBody,
-      acl: [{ userId: utils.users.editor2._id, write: true }]
+      name: 'test query2',
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { userId: utils.users.editor2._id, write: false }
+      ]
     });
     assert(!body3.error);
+
+    // Editor 2 can read at this point
+    const body4 = await utils.get('editor2', `/api/queries/${query._id}`);
+    assert(!body4.error);
+
+    // But not write
+    const body5 = await utils.put('editor2', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { groupId: '__EVERYONE__', write: false },
+        { userId: utils.users.editor2._id, write: false }
+      ]
+    });
+    assert(body5.error);
+
+    // Add write access for editor 2
+    const body6 = await utils.put('editor', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      name: 'test query2',
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { groupId: '__EVERYONE__', write: false },
+        { userId: utils.users.editor2._id, write: true }
+      ]
+    });
+    assert(!body6.error);
+  });
+
+  it('honors max matching permission only', async function() {
+    const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      name: 'test query2',
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { groupId: '__EVERYONE__', write: false },
+        { userId: utils.users.editor2._id, write: false }
+      ]
+    });
+    assert(!body1.error);
+
+    const body2 = await utils.put(
+      'editor2',
+      `/api/queries/${query._id}`,
+      createQueryBody
+    );
+    assert(body2.error);
+
+    const body3 = await utils.put('editor', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      name: 'test query2',
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { groupId: '__EVERYONE__', write: true },
+        { userId: utils.users.editor2._id, write: false }
+      ]
+    });
+    assert(!body3.error);
+
+    const body4 = await utils.put(
+      'editor2',
+      `/api/queries/${query._id}`,
+      createQueryBody
+    );
+    assert(!body4.error);
+  });
+
+  it('ACL userId permissions work as expected', async function() {
+    const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      name: 'test query2',
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { userId: utils.users.editor2._id, write: false }
+      ]
+    });
+    assert(!body1.error);
+
+    const body2 = await utils.get('editor2', `/api/queries/${query._id}`);
+    assert(!body2.error);
+
+    const body3 = await utils.put('editor2', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { groupId: '__EVERYONE__', write: false },
+        { userId: utils.users.editor2._id, write: false }
+      ]
+    });
+    assert(body3.error);
+
+    // Now use editor to give access, editor 2 should be update to update
+    const body4 = await utils.put('editor', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      name: 'test query2',
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { userId: utils.users.editor2._id, write: true }
+      ]
+    });
+    assert(!body4.error);
+
+    const body5 = await utils.put('editor2', `/api/queries/${query._id}`, {
+      ...createQueryBody,
+      acl: [
+        { userId: 'fakeUser', write: true },
+        { userEmail: 'fakeEmail', write: true },
+        { groupId: 'fakeGroup', write: true },
+        { userId: utils.users.editor2._id, write: false }
+      ]
+    });
+    assert(!body5.error);
+
+    const delBody = await utils.del('editor2', `/api/queries/${query._id}`);
+    assert(delBody.error);
   });
 
   it('Admin is exempt from query ACL', async function() {
@@ -134,7 +250,7 @@ describe('api/queries', function() {
     assert(!body3.error);
   });
 
-  it('acl userEmail gives access like expected', async function() {
+  it('ACL userEmail gives access like expected', async function() {
     const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
       ...createQueryBody,
       acl: [{ userEmail: 'editor2@test.com', write: true }]
@@ -161,7 +277,7 @@ describe('api/queries', function() {
     assert.strictEqual(body3.query.canDelete, false);
   });
 
-  it('groupId __EVERYONE__ gives access like expected', async function() {
+  it('ACL groupId __EVERYONE__ gives access like expected', async function() {
     const body1 = await utils.put('editor', `/api/queries/${query._id}`, {
       ...createQueryBody,
       acl: [{ groupId: consts.EVERYONE_ID, write: true }]
@@ -182,10 +298,6 @@ describe('api/queries', function() {
     assert.strictEqual(body3.query.canRead, true);
     assert.strictEqual(body3.query.canWrite, false);
     assert.strictEqual(body3.query.canDelete, false);
-  });
-
-  it('Requires authentication', function() {
-    return utils.get(null, `/api/queries/${query._id}`, 302);
   });
 
   it('Owner can delete query', async function() {

--- a/server/test/fixtures/seedData/queries/seed-query-1.json
+++ b/server/test/fixtures/seedData/queries/seed-query-1.json
@@ -6,7 +6,15 @@
   "createdBy": "admin@sqlpad.com",
   "acl": [
     {
-      "userId": "__EVERYONE__",
+      "userId": "some-userId-in-sqlpad",
+      "write": false
+    },
+    {
+      "userEmail": "someone@sqlpad.com",
+      "write": true
+    },
+    {
+      "groupId": "__EVERYONE__",
       "write": true
     }
   ]

--- a/server/test/lib/seedDataPath.js
+++ b/server/test/lib/seedDataPath.js
@@ -10,6 +10,10 @@ describe('seedDataPath', function() {
     const queries = await utils.models.queries.findAll();
     assert.strictEqual(queries.length, 2);
     assert(queries.find(q => q._id === 'seed-query-1'));
+    const queryAcls = await utils.models.queryAcl.findAllByQueryId(
+      'seed-query-1'
+    );
+    assert.equal(queryAcls.length, 3);
     const connections = await utils.models.connections.findAll();
     assert.equal(connections.length, 1);
     assert.strictEqual(connections[0]._id, 'seed-connection-1');


### PR DESCRIPTION
Expands Query ACL  implementation to add support for specifying `userEmail` and `groupId`. Also adds some decorations to the query objects returned from REST API to indicate the permissions the user has that is calling GET on `/queries`. 

`userEmail` is being added as it is more config-friendly for seed data than `userId`, which isn't really exposed to end users. `userEmail` is also used as the "foreign key" on queries, as well as the primary lookup for users, so this is somewhat consistent with the rest of SQLPad. 

`groupId` is added to store the special `__EVERYONE__` value, as it isn't a `userId`. This is primarily to help bring clarity to database, and potentially get to a place for `userId` can be a FK to users at some point in the future. 

This PR adds a lot of migrations to make this happen, all broken up into atomic operations. Sequelize's QueryInterface does not support running operations within a transaction, so a failure could leave a migration half implemented if these operations are not broken up.

This is kind of a pain, so we may want to start using hand-written SQL for migrations and run that within a transaction if SQLite supports it. The downside here is we lose on cross-db support if SQLPad eventually is to support other databases like postgres for a backend, but I don't know how realistic that is at this point. (Maybe just focus on SQLite for now?)