### PR TITLE
Add additional logs around query running

### DIFF
--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -3,6 +3,14 @@ const pino = require('pino');
 // Log levels https://github.com/pinojs/pino/issues/123
 const levels = ['fatal', 'error', 'warn', 'info', 'debug', 'silent'];
 
+const defaults = {
+  name: 'sqlpad-app',
+  redact: {
+    paths: ['passhash', '*.passhash'],
+    censor: '******'
+  }
+};
+
 class Logger {
   constructor(logLevel = 'warn') {
     if (!levels.includes(logLevel)) {
@@ -10,7 +18,7 @@ class Logger {
     }
     this.logLevel = logLevel;
     this.logger = pino({
-      name: 'sqlpad-app',
+      ...defaults,
       level: logLevel
     });
   }
@@ -20,7 +28,7 @@ class Logger {
       throw new Error(`Unknown log level ${logLevel}`);
     }
     this.logger = pino({
-      name: 'sqlpad-app',
+      ...defaults,
       level: logLevel
     });
   }

--- a/server/routes/query-result.js
+++ b/server/routes/query-result.js
@@ -53,6 +53,8 @@ router.post('/api/query-result', mustHaveConnectionAccess, async function(
   };
 
   try {
+    // TODO - untangle user error from server error
+    // An expected result should be sent 200, while unexpected 500
     const queryResult = await getQueryResult(req, data);
     return res.send({ queryResult });
   } catch (error) {


### PR DESCRIPTION
Adds additional logs around running queries. 

* Added debug log for rendered connection result. This will likely expose sensitive info
* Adds log of query execution just prior to executing, as well as error for query error. This is in addition to query finishing. If this gets to be too much I'm okay dialing this back