### PR TITLE
Unix ODBC - Capture useful error message

### DIFF
--- a/server/drivers/unixodbc/index.js
+++ b/server/drivers/unixodbc/index.js
@@ -91,6 +91,14 @@ async function runQuery(query, connection) {
       // An error already happened we're just trying to ensure it closed okay
       appLog.error(error, 'error closing connection after error');
     }
+    // unixodb error has additional info about why the error occurred
+    // It has an array of objects with messages.
+    // If that exists try to create a message of everything together and throw that
+    // Otherwise throw what we got
+    if (Array.isArray(error.odbcErrors)) {
+      const message = error.odbcErrors.map(e => e.message).join('; ');
+      throw new Error(message);
+    }
     throw error;
   }
 }

--- a/server/drivers/unixodbc/test.js
+++ b/server/drivers/unixodbc/test.js
@@ -75,4 +75,18 @@ describe('drivers/unixodbc', function() {
         assert.equal(results.rows.length, 2, 'row length');
       });
   });
+
+  it('Throws helpful error', async function() {
+    let error;
+    try {
+      await unixodbc.runQuery('SELECT * FROM fake_table', connection);
+    } catch (e) {
+      error = e;
+    }
+    assert(error);
+    assert(
+      error.message.includes('fake_table'),
+      'Error message has table reference'
+    );
+  });
 });


### PR DESCRIPTION
Update unixodbc implementation to capture useful error message. The error message by odbc returns a property with an array of objects. For now that's getting joined into multiple messages if that occurs. 