### PR TITLE
UnixODBC: Multiple statement support

### DIFF
--- a/client/src/QueryChartOnly.js
+++ b/client/src/QueryChartOnly.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import ExportButton from './common/ExportButton.js';
 import IncompleteDataNotification from './common/IncompleteDataNotification';
+import SuppressedSetNotification from './common/SuppressedSetNotification';
 import SqlpadTauChart from './common/SqlpadTauChart.js';
 import { exportPng } from './common/tauChartRef';
 import fetchJson from './utilities/fetch-json.js';
@@ -38,6 +39,7 @@ function QueryChartOnly({ queryId }) {
     exportPng(queryId, query && query.name);
   };
 
+  const suppressedSet = queryResult ? queryResult.suppressedResultSet : false;
   const incomplete = queryResult ? queryResult.incomplete : false;
   const cacheKey = queryResult ? queryResult.cacheKey : null;
 
@@ -54,6 +56,7 @@ function QueryChartOnly({ queryId }) {
       <div style={{ height: '50px' }}>
         <span style={{ fontSize: '1.5rem' }}>{query ? query.name : ''}</span>
         <div style={{ float: 'right' }}>
+          {suppressedSet && <SuppressedSetNotification />}
           {incomplete && <IncompleteDataNotification />}
           <ExportButton
             cacheKey={cacheKey}

--- a/client/src/QueryTableOnly.js
+++ b/client/src/QueryTableOnly.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import ExportButton from './common/ExportButton.js';
 import IncompleteDataNotification from './common/IncompleteDataNotification';
+import SuppressedSetNotification from './common/SuppressedSetNotification';
 import QueryResultContainer from './common/QueryResultContainer.js';
 import fetchJson from './utilities/fetch-json.js';
 
@@ -36,6 +37,7 @@ function QueryTableOnly({ queryId }) {
     runQuery(queryId);
   }, [queryId]);
 
+  const suppressedSet = queryResult ? queryResult.suppressedResultSet : false;
   const incomplete = queryResult ? queryResult.incomplete : false;
   const cacheKey = queryResult ? queryResult.cacheKey : null;
 
@@ -52,6 +54,7 @@ function QueryTableOnly({ queryId }) {
       <div style={{ height: '50px' }}>
         <span style={{ fontSize: '1.5rem' }}>{query ? query.name : ''}</span>
         <div style={{ float: 'right' }}>
+          {suppressedSet && <SuppressedSetNotification />}
           {incomplete && <IncompleteDataNotification />}
           <ExportButton cacheKey={cacheKey} />
         </div>

--- a/client/src/common/DataNotification.js
+++ b/client/src/common/DataNotification.js
@@ -1,0 +1,21 @@
+import AlertIcon from 'mdi-react/AlertIcon';
+import React from 'react';
+import Text from './Text';
+import Tooltip from './Tooltip';
+import styles from './DataNotification.module.css';
+
+function DataNotification({ tooltip, children }) {
+  return (
+    <Tooltip label={tooltip}>
+      {/* span use in place of wrapping Text with forwardRef needed by Tooltip */}
+      <span>
+        <Text className={styles.text} type="danger">
+          <AlertIcon size={18} className={styles.AlertIcon} />
+          {children}
+        </Text>
+      </span>
+    </Tooltip>
+  );
+}
+
+export default DataNotification;

--- a/client/src/common/DataNotification.module.css
+++ b/client/src/common/DataNotification.module.css
@@ -1,5 +1,6 @@
 .text {
   margin-right: 0.5rem;
+  white-space: nowrap;
 }
 
 .AlertIcon {

--- a/client/src/common/IncompleteDataNotification.js
+++ b/client/src/common/IncompleteDataNotification.js
@@ -1,23 +1,14 @@
-import AlertIcon from 'mdi-react/AlertIcon';
 import React from 'react';
-import Text from './Text';
-import Tooltip from './Tooltip';
-import styles from './IncompleteDataNotification.module.css';
+import DataNotification from './DataNotification';
 
 function IncompleteDataNotification() {
   return (
-    <Tooltip
-      label="Return fewer rows or increase query result max rows in
-        configuration."
+    <DataNotification
+      tooltip="Return fewer rows or increase query result max rows in
+    configuration."
     >
-      {/* span use in place of wrapping Text with forwardRef needed by Tooltip */}
-      <span>
-        <Text className={styles.text} type="danger">
-          <AlertIcon size={18} className={styles.AlertIcon} />
-          Incomplete
-        </Text>
-      </span>
-    </Tooltip>
+      Incomplete
+    </DataNotification>
   );
 }
 

--- a/client/src/common/SuppressedSetNotification.js
+++ b/client/src/common/SuppressedSetNotification.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import DataNotification from './DataNotification';
+
+function SuppressedSetNotification() {
+  return (
+    <DataNotification tooltip="Multiple statements ran, but only last result is shown">
+      Showing last result
+    </DataNotification>
+  );
+}
+
+export default SuppressedSetNotification;

--- a/client/src/queryEditor/QueryResultHeader.js
+++ b/client/src/queryEditor/QueryResultHeader.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { connect } from 'unistore/react';
 import IncompleteDataNotification from '../common/IncompleteDataNotification';
+import SuppressedSetNotification from '../common/SuppressedSetNotification';
 import SecondsTimer from '../common/SecondsTimer.js';
 import styles from './QueryResultHeader.module.css';
 
@@ -33,6 +34,7 @@ function QueryResultHeader({
     queryResult && queryResult.rows ? queryResult.rows.length : '';
 
   const incomplete = queryResult ? queryResult.incomplete : false;
+  const suppressedSet = queryResult ? queryResult.suppressedResultSet : false;
 
   const csvDownloadLink = `/download-results/${cacheKey}.csv`;
   const xlsxDownloadLink = `/download-results/${cacheKey}.xlsx`;
@@ -93,6 +95,7 @@ function QueryResultHeader({
         </span>
       </div>
 
+      {suppressedSet && <SuppressedSetNotification />}
       {incomplete && <IncompleteDataNotification />}
     </div>
   );

--- a/client/src/queryHistory/QueryHistoryResultHeader.js
+++ b/client/src/queryHistory/QueryHistoryResultHeader.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import IncompleteDataNotification from '../common/IncompleteDataNotification';
+import SuppressedSetNotification from '../common/SuppressedSetNotification';
 import SecondsTimer from '../common/SecondsTimer.js';
 import styles from './QueryHistoryResultHeader.module.css';
 
@@ -26,12 +27,14 @@ function QueryHistoryResultHeader({
     queryResult && queryResult.rows ? queryResult.rows.length : '';
 
   const incomplete = queryResult ? queryResult.incomplete : false;
+  const suppressedSet = queryResult ? queryResult.suppressedResultSet : false;
 
   return (
     <div className={styles.toolbar}>
       <div className={styles.toolbarItem}>{serverSec} seconds</div>
       <div className={styles.toolbarItem}>{rowCount} rows</div>
 
+      {suppressedSet && <SuppressedSetNotification />}
       {incomplete && <IncompleteDataNotification />}
     </div>
   );

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -184,7 +184,7 @@ async function runQuery(query, connection, user) {
     throw error;
   }
 
-  let { rows, incomplete } = results;
+  let { rows, incomplete, suppressedResultSet } = results;
 
   if (!Array.isArray(rows)) {
     appLog.warn(
@@ -201,6 +201,7 @@ async function runQuery(query, connection, user) {
   }
 
   finalResult.incomplete = Boolean(incomplete);
+  finalResult.suppressedResultSet = Boolean(suppressedResultSet);
   finalResult.rows = rows;
   finalResult.stopTime = new Date();
   finalResult.queryRunTime = finalResult.stopTime - finalResult.startTime;
@@ -212,7 +213,9 @@ async function runQuery(query, connection, user) {
       ...queryContext,
       stopTime: finalResult.stopTime,
       queryRunTime: finalResult.queryRunTime,
-      rowCount: rows.length
+      rowCount: rows.length,
+      incomplete: finalResult.incomplete,
+      suppressedResultSet: finalResult.suppressedResultSet
     },
     'Query finished'
   );

--- a/server/drivers/unixodbc/index.js
+++ b/server/drivers/unixodbc/index.js
@@ -1,5 +1,6 @@
 const odbc = require('odbc');
 const appLog = require('../../lib/appLog');
+const splitSql = require('../../lib/splitSql');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'unixodbc';
@@ -53,8 +54,38 @@ async function runQuery(query, connection) {
   let connectionInstance;
   try {
     let incomplete = false;
+    let suppressedResultSet = false;
     connectionInstance = await odbc.connect(cn);
-    const queryResult = await connectionInstance.query(query);
+    const queries = splitSql(query);
+
+    let queryResult;
+    let lastResult;
+
+    for (const query of queries) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await connectionInstance.query(query);
+
+      // If result has columns it is a candidate for lastQueryResultWithRows
+      // Until SQLPad has capability to show multiple result sets we are showing the last one with results
+      if (result.columns) {
+        // If queryResult was already set we're suppressing a result set
+        // Eventually we'll show all results but not at this point
+        if (queryResult) {
+          suppressedResultSet = true;
+        }
+
+        queryResult = result;
+      }
+
+      // Keep reference to result as last result
+      lastResult = result;
+    }
+
+    // If queryResult was never populated because none of the queries returned results, use last result
+    if (!queryResult) {
+      queryResult = lastResult;
+    }
+
     await connectionInstance.close();
 
     // Format data correctly
@@ -79,7 +110,7 @@ async function runQuery(query, connection) {
       }
     }
 
-    return { rows, incomplete };
+    return { rows, incomplete, suppressedResultSet };
   } catch (error) {
     appLog.error(error);
     try {

--- a/server/drivers/unixodbc/test.js
+++ b/server/drivers/unixodbc/test.js
@@ -15,10 +15,10 @@ const connection = {
 };
 const test_schema_name = 'dba'; // sqlite3 does not really have owner
 
-const createTable = 'CREATE TABLE test (id integer);'; // NOTE test(s) will fail if table already exists, expect empty database
-const insert1 = 'INSERT INTO test (id) VALUES (1);';
-const insert2 = 'INSERT INTO test (id) VALUES (2);';
-const insert3 = 'INSERT INTO test (id) VALUES (3);';
+const createTable = 'CREATE TABLE test (id INTEGER, name TEXT );'; // NOTE test(s) will fail if table already exists, expect empty database
+const insert1 = "INSERT INTO test (id, name) VALUES (1, 'one');";
+const insert2 = "INSERT INTO test (id, name) VALUES (2, 'two');";
+const insert3 = "INSERT INTO test (id, name) VALUES (3, 'three');";
 
 // TODO test more datatypes:
 //   * integer (different sizes
@@ -74,6 +74,18 @@ describe('drivers/unixodbc', function() {
         assert(results.incomplete, 'incomplete');
         assert.equal(results.rows.length, 2, 'row length');
       });
+  });
+
+  it('Runs multiple statements', function() {
+    const query = `
+      SELECT id FROM test;
+      SELECT name from test;
+      SELECT * FROM test;
+    `;
+    return unixodbc.runQuery(query, connection).then(results => {
+      assert(results.incomplete, 'incomplete');
+      assert.equal(results.rows.length, 2, 'row length');
+    });
   });
 
   it('Throws helpful error', async function() {

--- a/server/drivers/unixodbc/test.js
+++ b/server/drivers/unixodbc/test.js
@@ -80,11 +80,16 @@ describe('drivers/unixodbc', function() {
     const query = `
       SELECT id FROM test;
       SELECT name from test;
-      SELECT * FROM test;
+      SELECT * FROM test WHERE id = 2
     `;
     return unixodbc.runQuery(query, connection).then(results => {
-      assert(results.incomplete, 'incomplete');
-      assert.equal(results.rows.length, 2, 'row length');
+      // incomplete indicates truncated results
+      // suppressedResultSet indicates missing set
+      assert.strictEqual(results.suppressedResultSet, true);
+      assert.strictEqual(results.incomplete, false);
+      assert.equal(results.rows.length, 1, 'row length');
+      assert.strictEqual(results.rows[0].id, 2);
+      assert.strictEqual(results.rows[0].name, 'two');
     });
   });
 

--- a/server/lib/splitSql.js
+++ b/server/lib/splitSql.js
@@ -1,0 +1,52 @@
+/**
+ * Split a chunk of SQL text into multiple statements based on ; separator.
+ * This honors SQL comments without requiring a SQL parser
+ * @param {string} sql
+ */
+function splitSql(sql) {
+  if (typeof sql !== 'string') {
+    throw new Error('sql expected to be string');
+  }
+
+  const queries = [];
+
+  const lines = sql.split('\n');
+
+  let currentQuery = '';
+  let inBlockComment = false;
+
+  lines.forEach(line => {
+    const chars = line.split('');
+    let inLineComment = false;
+    for (let i = 0; i < chars.length; i++) {
+      const char = chars[i];
+      const next = chars[i + 1] || '';
+      const both = char + next;
+      // if we got two dashes this and rest of line is a comment
+      if (!inLineComment && both === '--') {
+        inLineComment = true;
+      }
+
+      if (!inBlockComment && both === '/*') {
+        inBlockComment = true;
+      } else if (inBlockComment && both === '*/') {
+        inBlockComment = false;
+      }
+
+      // add the letter to current query
+      currentQuery += char;
+
+      // If we reach a separator and not in comment,
+      // Add current query to queries and reset current query
+      if (char === ';' && !inBlockComment && !inLineComment) {
+        queries.push(currentQuery.trim());
+        currentQuery = '';
+      }
+    }
+    currentQuery += '\n';
+  });
+
+  return queries;
+}
+
+module.exports = splitSql;

--- a/server/lib/splitSql.js
+++ b/server/lib/splitSql.js
@@ -46,6 +46,10 @@ function splitSql(sql) {
     currentQuery += '\n';
   });
 
+  if (currentQuery.trim() !== '') {
+    queries.push(currentQuery.trim());
+  }
+
   return queries;
 }
 

--- a/server/test/lib/splitSql.js
+++ b/server/test/lib/splitSql.js
@@ -1,6 +1,16 @@
 const assert = require('assert');
 const splitSql = require('../../lib/splitSql');
 
+const singleNoSeparator = `
+SELECT value 
+FROM some_table
+`.trim();
+
+const singleWithSeparator = `
+SELECT value 
+FROM some_table;
+`.trim();
+
 const noComments = `
 SELECT value FROM some_table;
 SELECT value FROM another_table;
@@ -28,6 +38,18 @@ FROM
 const comments = q1 + q2;
 
 describe('lib/splitSql', function() {
+  it('handles single query without separator', function() {
+    const queries = splitSql(singleNoSeparator);
+    assert.strictEqual(queries.length, 1);
+    assert.strictEqual(queries[0], singleNoSeparator);
+  });
+
+  it('handles single query with separator', function() {
+    const queries = splitSql(singleWithSeparator);
+    assert.strictEqual(queries.length, 1);
+    assert.strictEqual(queries[0], singleWithSeparator);
+  });
+
   it('handles queries without comments', function() {
     const queries = splitSql(noComments);
     assert.strictEqual(queries.length, 2);

--- a/server/test/lib/splitSql.js
+++ b/server/test/lib/splitSql.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const splitSql = require('../../lib/splitSql');
+
+const noComments = `
+SELECT value FROM some_table;
+SELECT value FROM another_table;
+`.trim();
+
+const q1 = `
+-- this is a comment; it has;stuff
+SELECT value FROM some_table;
+`.trim();
+
+const q2 = `
+/* this query is commented out SELECT SOMETHING ELSE; */
+/* And this one too
+look even an unlikely comment starter again /*
+SELECT * FROM not a query; --SELECT * FROM not a query;
+*/
+
+SELECT 
+  value 
+  --SELECT * FROM not a query;
+FROM 
+  another_table;
+`.trim();
+
+const comments = q1 + q2;
+
+describe('lib/splitSql', function() {
+  it('handles queries without comments', function() {
+    const queries = splitSql(noComments);
+    assert.strictEqual(queries.length, 2);
+    assert.strictEqual(queries[0], 'SELECT value FROM some_table;');
+    assert.strictEqual(queries[1], 'SELECT value FROM another_table;');
+  });
+  it('handles comples comments', function() {
+    const queries = splitSql(comments);
+    assert.strictEqual(queries.length, 2);
+    assert.strictEqual(queries[0], q1);
+    assert.strictEqual(queries[1], q2);
+  });
+});


### PR DESCRIPTION
Adds multiple statement/batch query support to the unix odbc driver implementation. This is accomplished by splitting the batch SQL into statements using the query separator `;`. Each statement is executed sequentially using a single connection to the database.

The query result from the last statement that had rows returned is sent to the client. All statements are run, unless there is an error, in which case running statements in the batch stops and the underlying connection is closed.

This adds a `suppressedResultSet ` indicator to drivers.runQuery for cases like this, as long as a corresponding indicator in the UI similar to incomplete indicator.

<img width="1066" alt="Screen Shot 2020-02-28 at 8 40 47 PM" src="https://user-images.githubusercontent.com/303966/75599606-33c90000-5a6c-11ea-896e-a3275b5f0ac9.png">

Long term the plan is to show multiple result sets in SQLPad. This is just a step towards getting there. Supporting large query batches may require redesigns to the query REST API (or at the very least setting smaller row-limits per query).