### PR TITLE
Add SQLite driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ db/
 dbtest/
 node_modules/
 sqlpad.tar.gz
+server/drivers/sqlite/sqlpad_test_sqlite.db

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -11,6 +11,7 @@ const drivers = {
   postgres: require('./postgres'),
   presto: require('./presto'),
   snowflake: require('./snowflake'),
+  sqlite: require('./sqlite'),
   sqlserver: require('./sqlserver'),
   vertica: require('./vertica')
 };

--- a/server/drivers/sqlite/index.js
+++ b/server/drivers/sqlite/index.js
@@ -1,0 +1,186 @@
+const sqlite3 = require('sqlite3');
+const appLog = require('../../lib/appLog');
+const splitSql = require('../../lib/splitSql');
+const { formatSchemaQueryResults } = require('../utils');
+
+const id = 'sqlite';
+const name = 'SQLite';
+
+const fields = [
+  {
+    key: 'filename',
+    formType: 'TEXT',
+    label: 'Filename / path' // empty string is anonymous disk backed. :memory: is in memory
+  },
+  {
+    key: 'readonly',
+    formType: 'CHECKBOX',
+    label: 'Read only'
+  }
+];
+
+class Client {
+  constructor(connection) {
+    this.connection = connection;
+    this.db = null;
+  }
+
+  async connect() {
+    if (this.db) {
+      throw new Error('Client already connected');
+    }
+    const { filename, readonly } = this.connection;
+    // If read only is selected we'll use that otherwise fall back to default
+    // By default sqlite3 driver will open with OPEN_READWRITE | OPEN_CREATE
+    // The mode can't be sent in as NULL/undefined to trigger this fallback behavior,
+    // so instead we'll make separate calls here
+
+    if (readonly) {
+      return new Promise((resolve, reject) => {
+        this.db = new sqlite3.Database(filename, sqlite3.OPEN_READONLY, err => {
+          if (err) {
+            this.db = null;
+            return reject(err);
+          }
+          return resolve();
+        });
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      this.db = new sqlite3.Database(filename, err => {
+        if (err) {
+          this.db = null;
+          return reject(err);
+        }
+        return resolve();
+      });
+    });
+  }
+
+  async disconnect() {
+    if (this.db) {
+      const db = this.db;
+      this.db = null;
+
+      return new Promise((resolve, reject) => {
+        db.close(err => {
+          if (err) {
+            appLog.error(err, 'Error ending sqlite db');
+            return reject(err);
+          }
+          return resolve();
+        });
+      });
+    }
+  }
+
+  /**
+   * Run query and return the results
+   *
+   * Instead of taking the ODBC approach where a result set is suppressed and the last SELECT set is shown,
+   * The SQLite implementation shows a jumbled mix of results
+   * The reason for this is because we can't tell what was a successful SELECT query vs INSERT/DELETE
+   * as they all return an array of row objects
+   * @param {string} query - string of SQL to execute
+   */
+  async runQuery(query) {
+    let incomplete = false;
+    let suppressedResultSet = false;
+    let rows = [];
+
+    const { maxRows } = this.connection;
+    const queries = splitSql(query);
+
+    for (const query of queries) {
+      // eslint-disable-next-line no-await-in-loop
+      const innerRows = await dbAllAsync(this.db, query);
+      rows = rows.concat(innerRows);
+    }
+
+    if (rows.length > maxRows) {
+      rows = rows.slice(0, maxRows);
+      incomplete = true;
+    }
+
+    return { rows, incomplete, suppressedResultSet };
+  }
+}
+
+function dbAllAsync(db, query) {
+  return new Promise((resolve, reject) => {
+    db.all(query, (err, rows) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(rows);
+    });
+  });
+}
+
+/**
+ * Run query for connection
+ * Should return { rows, incomplete }
+ * @param {string} query
+ * @param {object} connection
+ */
+async function runQuery(query, connection) {
+  const db = new Client(connection);
+  await db.connect();
+  try {
+    const result = await db.runQuery(query);
+    await db.disconnect();
+    return result;
+  } catch (error) {
+    await db.disconnect();
+    throw error;
+  }
+}
+
+/**
+ * Test connectivity of connection
+ * @param {*} connection
+ */
+function testConnection(connection) {
+  const query = "SELECT 'success' AS TestQuery;";
+  return runQuery(query, connection);
+}
+
+/**
+ * Get schema for connection
+ * @param {*} connection
+ */
+async function getSchema(connection) {
+  const db = new Client(connection);
+  await db.connect();
+  try {
+    // For SQLite get tables, then iterate over and get columns for each
+    const queryResult = await db.runQuery(`
+      SELECT
+        'sqlite' as table_schema,
+        name as table_name,
+        'unknown' as column_name,
+        'unknown' as data_type
+      FROM 
+        sqlite_master
+      WHERE 
+        type = 'table';
+    `);
+    // TODO add the pragma calls to get columns
+    await db.disconnect();
+    return formatSchemaQueryResults(queryResult);
+  } catch (error) {
+    await db.disconnect();
+    throw error;
+  }
+}
+
+module.exports = {
+  Client,
+  id,
+  name,
+  fields,
+  getSchema,
+  runQuery,
+  testConnection
+};

--- a/server/drivers/sqlite/index.js
+++ b/server/drivers/sqlite/index.js
@@ -164,9 +164,9 @@ async function getSchema(connection) {
       FROM 
         sqlite_master
     `);
-    // TODO add the pragma calls to get columns
 
-    // For each table row, call PRAGMA to get info, and merge the results back into the main query result
+    // For each table row, call PRAGMA to get info,
+    // and use the combined results for the schema results
     const columnRows = [];
     for (const tableRow of queryResult.rows) {
       const { table_name } = tableRow;

--- a/server/drivers/sqlite/test.js
+++ b/server/drivers/sqlite/test.js
@@ -6,7 +6,7 @@ const connection = {
 };
 
 const dropTable = 'DROP TABLE IF EXISTS sqlpad_test;';
-const createTable = 'CREATE TABLE sqlpad_test (id INTEGER, name TEXT );'; // NOTE test(s) will fail if table already exists, expect empty database
+const createTable = 'CREATE TABLE sqlpad_test (id INTEGER, name TEXT );';
 const insert1 = "INSERT INTO sqlpad_test (id, name) VALUES (1, 'one');";
 const insert2 = "INSERT INTO sqlpad_test (id, name) VALUES (2, 'two');";
 const insert3 = "INSERT INTO sqlpad_test (id, name) VALUES (3, 'three');";

--- a/server/drivers/sqlite/test.js
+++ b/server/drivers/sqlite/test.js
@@ -5,8 +5,6 @@ const connection = {
   filename: './sqlpad_test_sqlite.db'
 };
 
-const test_schema_name = 'sqlite';
-
 const dropTable = 'DROP TABLE IF EXISTS sqlpad_test;';
 const createTable = 'CREATE TABLE sqlpad_test (id INTEGER, name TEXT );'; // NOTE test(s) will fail if table already exists, expect empty database
 const insert1 = "INSERT INTO sqlpad_test (id, name) VALUES (1, 'one');";
@@ -30,14 +28,11 @@ describe('drivers/sqlite', function() {
   it('getSchema()', async function() {
     const schemaInfo = await sqlite3.getSchema(connection);
 
-    assert(schemaInfo[test_schema_name], test_schema_name);
-    assert(
-      schemaInfo[test_schema_name].sqlpad_test,
-      test_schema_name + '.sqlpad_test'
-    );
-    const columns = schemaInfo[test_schema_name].sqlpad_test;
+    assert(schemaInfo.main);
+    assert(schemaInfo.main.sqlpad_test, 'main.sqlpad_test');
+    const columns = schemaInfo.main.sqlpad_test;
     assert.equal(columns.length, 1, 'columns.length');
-    assert.equal(columns[0].table_schema, test_schema_name, 'table_schema');
+    assert.equal(columns[0].table_schema, 'main', 'table_schema');
     assert.equal(columns[0].table_name, 'sqlpad_test', 'table_name');
     // column metadata not available in sqlite3
     assert.equal(columns[0].column_name, 'unknown', 'column_name');

--- a/server/drivers/sqlite/test.js
+++ b/server/drivers/sqlite/test.js
@@ -1,0 +1,123 @@
+const assert = require('assert');
+const sqlite3 = require('./index.js');
+
+const connection = {
+  filename: './sqlpad_test_sqlite.db'
+};
+
+const test_schema_name = 'sqlite';
+
+const dropTable = 'DROP TABLE IF EXISTS sqlpad_test;';
+const createTable = 'CREATE TABLE sqlpad_test (id INTEGER, name TEXT );'; // NOTE test(s) will fail if table already exists, expect empty database
+const insert1 = "INSERT INTO sqlpad_test (id, name) VALUES (1, 'one');";
+const insert2 = "INSERT INTO sqlpad_test (id, name) VALUES (2, 'two');";
+const insert3 = "INSERT INTO sqlpad_test (id, name) VALUES (3, 'three');";
+
+describe('drivers/sqlite', function() {
+  before(async function() {
+    this.timeout(10000);
+    await sqlite3.runQuery(dropTable, connection);
+    await sqlite3.runQuery(createTable, connection);
+    await sqlite3.runQuery(insert1, connection);
+    await sqlite3.runQuery(insert2, connection);
+    await sqlite3.runQuery(insert3, connection);
+  });
+
+  it('tests connection', function() {
+    return sqlite3.testConnection(connection);
+  });
+
+  it('getSchema()', async function() {
+    const schemaInfo = await sqlite3.getSchema(connection);
+
+    assert(schemaInfo[test_schema_name], test_schema_name);
+    assert(
+      schemaInfo[test_schema_name].sqlpad_test,
+      test_schema_name + '.sqlpad_test'
+    );
+    const columns = schemaInfo[test_schema_name].sqlpad_test;
+    assert.equal(columns.length, 1, 'columns.length');
+    assert.equal(columns[0].table_schema, test_schema_name, 'table_schema');
+    assert.equal(columns[0].table_name, 'sqlpad_test', 'table_name');
+    // column metadata not available in sqlite3
+    assert.equal(columns[0].column_name, 'unknown', 'column_name');
+    assert.equal(columns[0].data_type, 'unknown', 'data_type');
+  });
+
+  it('runQuery under limit', async function() {
+    const results = await sqlite3.runQuery(
+      'SELECT * FROM sqlpad_test WHERE id = 1;',
+      connection
+    );
+    assert(!results.incomplete, 'not incomplete');
+    assert.equal(results.rows.length, 1, 'row length');
+  });
+
+  it('runQuery over limit', async function() {
+    const connectionWithMaxRows = { ...connection, maxRows: 2 };
+    const results = await sqlite3.runQuery(
+      'SELECT * FROM sqlpad_test;',
+      connectionWithMaxRows
+    );
+    assert(results.incomplete, 'incomplete');
+    assert.equal(results.rows.length, 2, 'row length');
+  });
+
+  it('Runs multiple statements', async function() {
+    const query = `
+      SELECT id FROM sqlpad_test;
+      SELECT name FROM sqlpad_test;
+      SELECT * FROM sqlpad_test WHERE id = 2
+    `;
+    const results = await sqlite3.runQuery(query, connection);
+    // Instead of taking the ODBC approach where a result set is suppressed and the last SELECT set is shown,
+    // The SQLite implementation shows a jumbled mix of results
+    // The reason for this is because we can't tell what was a successful SELECT query vs INSERT/DELETE
+    // as they all return an array of row objects
+    assert.strictEqual(results.suppressedResultSet, false);
+    assert.strictEqual(results.incomplete, false);
+    assert.equal(results.rows.length, 7, 'row length');
+  });
+
+  it('Throws helpful error', async function() {
+    let error;
+    try {
+      await sqlite3.runQuery('SELECT * FROM fake_table', connection);
+    } catch (e) {
+      error = e;
+    }
+    assert(error);
+    assert(
+      error.message.includes('fake_table'),
+      'Error message has table reference'
+    );
+  });
+
+  it('Client cannot connect more than once', async function() {
+    const client = new sqlite3.Client(connection);
+    await client.connect();
+    await assert.rejects(client.connect());
+    await client.disconnect();
+  });
+
+  it('Client handles multiple disconnects', async function() {
+    const client = new sqlite3.Client(connection);
+    await client.connect();
+    await client.disconnect();
+    await client.disconnect();
+  });
+
+  it('Client handles multiple runQuery calls', async function() {
+    const client = new sqlite3.Client(connection);
+    await client.connect();
+
+    const results1 = await client.runQuery('SELECT * FROM sqlpad_test');
+    assert.equal(results1.incomplete, false);
+    assert.equal(results1.rows.length, 3);
+    const results2 = await client.runQuery('SELECT * FROM sqlpad_test');
+    assert.equal(results2.incomplete, false);
+    assert.equal(results2.rows.length, 3);
+
+    await client.disconnect();
+  });
+});

--- a/server/drivers/sqlite/test.sh
+++ b/server/drivers/sqlite/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+test_db_name=/tmp/tmp_sqlpad.db
+rm ./sqlpad_test_sqlite.db
+
+npx mocha ./test.js
+

--- a/server/drivers/sqlite/test.sh
+++ b/server/drivers/sqlite/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-test_db_name=/tmp/tmp_sqlpad.db
 rm ./sqlpad_test_sqlite.db
 
 npx mocha ./test.js


### PR DESCRIPTION
Adds SQLite driver using the native nodejs sqlite3 module. 

This is probably not too exciting for most people but this brings 2 really fun benefits:

* The "mock" driver can be retired and SQLPad can be tested/developed against small SQLite databases, meaning interactive dev with no docker containers
* SQLPad can query its own sqlite database (not much there yet, but eventually all data models will move there)

![SQLPad - sqlite3 support](https://user-images.githubusercontent.com/303966/76174673-c48f9200-6176-11ea-81b8-c57dabc30603.jpg)
