### PR TITLE
Fix schema cache when using connection templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dbtest/
 node_modules/
 sqlpad.tar.gz
 server/drivers/sqlite/sqlpad_test_sqlite.db
+server/test/artifacts

--- a/server/lib/connection-client.js
+++ b/server/lib/connection-client.js
@@ -228,6 +228,24 @@ class ConnectionClient {
     };
     return this.driver.getSchema(connectionMaxed);
   }
+
+  /**
+   * A given connection may no longer return the same result given user template support
+   * To ensure schema is appropriately cached an ID must be derived from the resulting connection for a user
+   * Its possible and likely that a given connection will be the same for a few users,
+   * so we don't want to cache this on (connectionId, userId) pairing.
+   * Instead we'll use a hash of connection after template rendering
+   */
+  getSchemaId() {
+    const keyValuesString = Object.keys(this.connection)
+      .sort()
+      .map(key => {
+        return `${key}:${this.connection[key]}`;
+      })
+      .join('::');
+    // TODO FIXME XXX uuid5 hash keyValuesString with connection namespace
+    return keyValuesString;
+  }
 }
 
 module.exports = ConnectionClient;

--- a/server/lib/connection-client.js
+++ b/server/lib/connection-client.js
@@ -1,4 +1,5 @@
-const { v4: uuidv4 } = require('uuid');
+const { v4: uuidv4, v5: uuidv5 } = require('uuid');
+const consts = require('./consts');
 const drivers = require('../drivers');
 const renderConnection = require('./render-connection');
 const appLog = require('./appLog');
@@ -236,15 +237,17 @@ class ConnectionClient {
    * so we don't want to cache this on (connectionId, userId) pairing.
    * Instead we'll use a hash of connection after template rendering
    */
-  getSchemaId() {
+  getSchemaCacheId() {
     const keyValuesString = Object.keys(this.connection)
       .sort()
       .map(key => {
         return `${key}:${this.connection[key]}`;
       })
       .join('::');
-    // TODO FIXME XXX uuid5 hash keyValuesString with connection namespace
-    return keyValuesString;
+
+    return (
+      'schemacache:' + uuidv5(keyValuesString, consts.CONNECTION_HASH_NAMESPACE)
+    );
   }
 }
 

--- a/server/lib/consts.js
+++ b/server/lib/consts.js
@@ -2,7 +2,8 @@ const consts = {
   EVERY_CONNECTION_ID: '__EVERY_CONNECTION__',
   EVERY_CONNECTION_NAME: 'Every Connection',
   EVERYONE_ID: '__EVERYONE__',
-  EVERYONE_EMAIL: 'Everyone'
+  EVERYONE_EMAIL: 'Everyone',
+  CONNECTION_HASH_NAMESPACE: '3dffe1b8-5a91-4db7-8dfe-6c8a91a5eb6b'
 };
 
 module.exports = Object.freeze(consts);

--- a/server/models/schemaInfo.js
+++ b/server/models/schemaInfo.js
@@ -1,7 +1,3 @@
-function getCacheKey(connectionId) {
-  return 'schemaCache:' + connectionId;
-}
-
 class SchemaInfo {
   /**
    * @param {*} nedb
@@ -15,12 +11,11 @@ class SchemaInfo {
   }
 
   /**
-   * Get schemaInfo for connection id
-   * @param {string} connectionId
+   * Get schemaInfo for schema id
+   * @param {string} schemaCacheId
    */
-  async getSchemaInfo(connectionId) {
-    const cacheKey = getCacheKey(connectionId);
-    const doc = await this.nedb.cache.findOne({ cacheKey });
+  async getSchemaInfo(schemaCacheId) {
+    const doc = await this.nedb.cache.findOne({ cacheKey: schemaCacheId });
 
     if (!doc) {
       return;
@@ -41,11 +36,11 @@ class SchemaInfo {
    * Save schemaInfo to cache db object
    * Schema needs to be stringified as JSON
    * Column names could have dots in name (incompatible with nedb)
-   * @param {string} connectionId
+   * @param {string} schemaCacheId
    * @param {object} schemaInfo
    */
-  async saveSchemaInfo(connectionId, schemaInfo) {
-    const cacheKey = getCacheKey(connectionId);
+  async saveSchemaInfo(schemaCacheId, schemaInfo) {
+    const cacheKey = schemaCacheId;
     if (schemaInfo && Object.keys(schemaInfo).length) {
       const schema = JSON.stringify(schemaInfo);
       const doc = {

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "prepublishOnly": "cd .. && ./scripts/build.sh",
     "start": "node-dev server.js --config \"./config.dev.ini\" | pino-pretty",
-    "test": "rimraf ../dbtest && mocha test --timeout 10000 --recursive --exit",
+    "test": "mocha test --timeout 10000 --recursive --exit",
     "fixlint": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\""
   },

--- a/server/routes/schema-info.js
+++ b/server/routes/schema-info.js
@@ -20,16 +20,18 @@ async function getSchemaInfo(req, res) {
       throw new Error('Connection not found');
     }
 
-    let schemaInfo = await models.schemaInfo.getSchemaInfo(connectionId);
+    const connectionClient = new ConnectionClient(conn, user);
+    const schemaCacheId = connectionClient.getSchemaCacheId();
+
+    let schemaInfo = await models.schemaInfo.getSchemaInfo(schemaCacheId);
 
     if (schemaInfo && !reload) {
       return res.json({ schemaInfo });
     }
 
-    const connectionClient = new ConnectionClient(conn, user);
     schemaInfo = await connectionClient.getSchema();
     if (Object.keys(schemaInfo).length) {
-      await models.schemaInfo.saveSchemaInfo(connectionId, schemaInfo);
+      await models.schemaInfo.saveSchemaInfo(schemaCacheId, schemaInfo);
     }
     return res.json({ schemaInfo });
   } catch (error) {

--- a/server/routes/schema-info.js
+++ b/server/routes/schema-info.js
@@ -1,42 +1,49 @@
+require('../typedefs');
 const router = require('express').Router();
 const mustHaveConnectionAccess = require('../middleware/must-have-connection-access.js');
 const sendError = require('../lib/sendError');
 const ConnectionClient = require('../lib/connection-client');
 
+/**
+ * @param {import('express').Request & Req} req
+ * @param {*} res
+ */
+async function getSchemaInfo(req, res) {
+  const { models, user } = req;
+  const { connectionId } = req.params;
+  const reload = req.query.reload === 'true';
+
+  try {
+    const conn = await models.connections.findOneById(connectionId);
+
+    if (!conn) {
+      throw new Error('Connection not found');
+    }
+
+    let schemaInfo = await models.schemaInfo.getSchemaInfo(connectionId);
+
+    if (schemaInfo && !reload) {
+      return res.json({ schemaInfo });
+    }
+
+    const connectionClient = new ConnectionClient(conn, user);
+    schemaInfo = await connectionClient.getSchema();
+    if (Object.keys(schemaInfo).length) {
+      await models.schemaInfo.saveSchemaInfo(connectionId, schemaInfo);
+    }
+    return res.json({ schemaInfo });
+  } catch (error) {
+    if (error.message === 'Connection not found') {
+      return sendError(res, error);
+    }
+    sendError(res, error, 'Problem getting schema info');
+  }
+}
+
 router.get(
   '/api/schema-info/:connectionId',
   mustHaveConnectionAccess,
-  async function(req, res) {
-    const { models, user } = req;
-    const { connectionId } = req.params;
-    const reload = req.query.reload === 'true';
-
-    try {
-      const conn = await models.connections.findOneById(connectionId);
-
-      if (!conn) {
-        throw new Error('Connection not found');
-      }
-
-      let schemaInfo = await models.schemaInfo.getSchemaInfo(connectionId);
-
-      if (schemaInfo && !reload) {
-        return res.json({ schemaInfo });
-      }
-
-      const connectionClient = new ConnectionClient(conn, user);
-      schemaInfo = await connectionClient.getSchema();
-      if (Object.keys(schemaInfo).length) {
-        await models.schemaInfo.saveSchemaInfo(connectionId, schemaInfo);
-      }
-      return res.json({ schemaInfo });
-    } catch (error) {
-      if (error.message === 'Connection not found') {
-        return sendError(res, error);
-      }
-      sendError(res, error, 'Problem getting schema info');
-    }
-  }
+  getSchemaInfo
 );
 
 module.exports = router;

--- a/server/test/api/schema-info.js
+++ b/server/test/api/schema-info.js
@@ -54,8 +54,22 @@ describe('api/schema-info', function() {
   });
 
   it('Gets schema-info honoring connection templates', async function() {
-    const body = await utils.get('user1', `/api/schema-info/${connection._id}`);
-    assert(!body.error, 'Expect no error');
-    assert(body.schemaInfo, 'body.schemaInfo');
+    const body1 = await utils.get(
+      'user1',
+      `/api/schema-info/${connection._id}`
+    );
+    assert(!body1.error, 'Expect no error');
+    assert(body1.schemaInfo, 'body.schemaInfo');
+    assert(body1.schemaInfo.main.user1, 'user1 table exists');
+    assert(!body1.schemaInfo.main.user2, 'user2 table does not exist');
+
+    const body2 = await utils.get(
+      'user2',
+      `/api/schema-info/${connection._id}`
+    );
+    assert(!body2.error, 'Expect no error');
+    assert(body2.schemaInfo, 'body.schemaInfo');
+    assert(!body2.schemaInfo.main.user1, 'user1 table does not exist');
+    assert(body2.schemaInfo.main.user2, 'user2 table exists');
   });
 });

--- a/server/test/api/schema-info.js
+++ b/server/test/api/schema-info.js
@@ -1,27 +1,60 @@
 const assert = require('assert');
 const TestUtils = require('../utils');
+const ConnectionClient = require('../../lib/connection-client');
 
 describe('api/schema-info', function() {
+  this.timeout(10000);
   const utils = new TestUtils();
   let connection;
+  let user1;
+  let user2;
 
   before(async function() {
     await utils.init(true);
+
+    // Create some users to use to ensure dynamic connection is cached properly
+    user1 = await utils.addUserApiHelper('user1', {
+      email: 'user1@sqlpad.com',
+      password: 'user1',
+      role: 'admin',
+      name: 'user1',
+      data: {
+        dbfilename: 'user1.sqlite'
+      }
+    });
+
+    user2 = await utils.addUserApiHelper('user2', {
+      email: 'user2@sqlpad.com',
+      password: 'user2',
+      role: 'admin',
+      name: 'user2',
+      data: {
+        dbfilename: 'user2.sqlite'
+      }
+    });
+
+    // Create a connection that looks to user data for db connection info
+    // While this is the same connection, the underlying database is different
     const body = await utils.post('admin', '/api/connections', {
-      driver: 'mock',
-      name: 'sqlpad',
-      host: 'localhost',
-      database: 'sqlpad',
-      username: 'sqlpad',
-      password: 'sqlpad',
-      wait: 0
+      driver: 'sqlite',
+      name: 'sqlite-test',
+      filename: './test/artifacts/{{user.data.dbfilename}}'
     });
     assert(!body.error, 'no error');
     connection = body.connection;
+
+    // With user 1 create a table
+    // Then with user 2 create a different table
+    // Later ensure each user sees the correct schema
+    const user1CC = new ConnectionClient(connection, user1);
+    await user1CC.runQuery(`CREATE TABLE user1 (id INT, name TEXT)`);
+
+    const user2CC = new ConnectionClient(connection, user2);
+    await user2CC.runQuery(`CREATE TABLE user2 (id INT, name TEXT)`);
   });
 
-  it('Gets schema-info', async function() {
-    const body = await utils.get('admin', `/api/schema-info/${connection._id}`);
+  it('Gets schema-info honoring connection templates', async function() {
+    const body = await utils.get('user1', `/api/schema-info/${connection._id}`);
     assert(!body.error, 'Expect no error');
     assert(body.schemaInfo, 'body.schemaInfo');
   });

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -11,8 +11,10 @@ const makeApp = require('../app');
 const migrate = require('../lib/migrate');
 const loadSeedData = require('../lib/loadSeedData');
 
+const TEST_ARTIFACTS_DIR = path.join(__dirname, '/artifacts');
+
 function clearArtifacts() {
-  mkdirp.sync(path.join(__dirname, '/artifacts'));
+  mkdirp.sync(TEST_ARTIFACTS_DIR);
   return new Promise((resolve, reject) => {
     return rimraf(path.join(__dirname, '/artifacts/*'), err => {
       if (err) {
@@ -30,7 +32,7 @@ class TestUtils {
         debug: true,
         // Despite being in-memory, still need a file path for cache and session files
         // Eventually these will be moved to sqlite and we can be fully-in-memory
-        dbPath: '../dbtest',
+        dbPath: TEST_ARTIFACTS_DIR,
         dbInMemory: true,
         ...args
       },

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -35,7 +35,7 @@ class TestUtils {
         ...args
       },
       {
-        SQLPAD_APP_LOG_LEVEL: 'error',
+        SQLPAD_APP_LOG_LEVEL: 'silent',
         SQLPAD_WEB_LOG_LEVEL: 'silent',
         ...env
       }

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const { v4: uuidv4 } = require('uuid');
 const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 const path = require('path');
 const request = require('supertest');
 const Config = require('../lib/config');
@@ -11,8 +12,9 @@ const migrate = require('../lib/migrate');
 const loadSeedData = require('../lib/loadSeedData');
 
 function clearArtifacts() {
+  mkdirp.sync(path.join(__dirname, '/artifacts'));
   return new Promise((resolve, reject) => {
-    return rimraf(path.join(__dirname, '/artifacts'), err => {
+    return rimraf(path.join(__dirname, '/artifacts/*'), err => {
       if (err) {
         return reject(err);
       }


### PR DESCRIPTION
With the introduction of connection templates, it is possible that the schemas could vary depending on the user data used on the connection. 

To ensure users see the correct schema, the schema info cache is stored under a hash of the connection after the values have been replaced with user data values. This allows for reusing the schema cache across users if the underlying "rendered" connection for the user is the same, and avoids each user having their own cache of schema unnecessarily.