### PR TITLE
Multi transaction support UX

### DIFF
--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -42,14 +42,12 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
       if (json.error) {
         message.error(json.error);
       } else {
-        // connection.inactivityTimeout is milliseconds
+        // connection.idleTimeout is milliseconds
         // Convert to minutes for a more user-friendly experience
-        const inactivityTimeout =
-          json.connection && parseInt(json.connection.inactivityTimeout, 10);
-        if (inactivityTimeout) {
-          json.connection.inactivityTimeout = Math.round(
-            inactivityTimeout / 1000 / 60
-          );
+        const idleTimeout =
+          json.connection && parseInt(json.connection.idleTimeout, 10);
+        if (idleTimeout) {
+          json.connection.idleTimeout = Math.round(idleTimeout / 1000 / 60);
         }
         setConnectionEdits(json.connection);
       }
@@ -86,10 +84,10 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
 
     setSaving(true);
 
-    // connectionEdits.inactivityTimeout is storing minutes, but needs to send milliseconds
-    const inactivityTimeout = parseInt(connectionEdits.inactivityTimeout, 10);
-    if (inactivityTimeout) {
-      connectionEdits.inactivityTimeout = inactivityTimeout * 60 * 1000;
+    // connectionEdits.idleTimeout is storing minutes, but needs to send milliseconds
+    const idleTimeout = parseInt(connectionEdits.idleTimeout, 10);
+    if (idleTimeout) {
+      connectionEdits.idleTimeout = idleTimeout * 60 * 1000;
     }
 
     let json;
@@ -151,14 +149,11 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
         );
 
         fieldsJsx.push(
-          <HorizontalFormItem
-            key={'inactivityTimeout'}
-            label={'Inactivity timeout (minutes)'}
-          >
+          <HorizontalFormItem key="idleTimeout" label="Idle timeout (minutes)">
             <Input
-              name="inactivityTimeout"
+              name="idleTimeout"
               type="number"
-              value={connectionEdits.inactivityTimeout || ''}
+              value={connectionEdits.idleTimeout || ''}
               onChange={e => setConnectionValue(e.target.name, e.target.value)}
             />
             <FormExplain>

--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -137,13 +137,12 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
               }
             />
             <label htmlFor={mstKey} style={{ marginLeft: 8 }}>
-              Enable multi-statement transaction mode
+              Enable multi-statement transaction support
             </label>
             <FormExplain>
-              When using multi-statement transaction mode a persistent database
-              connection will be opened and used for query executions, allowing
-              things like opening transactions and creating temp tables across
-              query executions.
+              When enabled a persistent database connection will be opened and
+              used for query executions, allowing things like opening
+              transactions and creating temp tables across query executions.
             </FormExplain>
           </HorizontalFormItem>
         );

--- a/client/src/queryEditor/Shortcuts.js
+++ b/client/src/queryEditor/Shortcuts.js
@@ -1,9 +1,15 @@
 import keymaster from 'keymaster';
 import { useEffect } from 'react';
 import { connect } from 'unistore/react';
+import { connectConnectionClient } from '../stores/connections';
 import { formatQuery, runQuery, saveQuery } from '../stores/queries';
 
-function Shortcuts({ saveQuery, runQuery, formatQuery }) {
+function Shortcuts({
+  connectConnectionClient,
+  formatQuery,
+  runQuery,
+  saveQuery
+}) {
   useEffect(() => {
     // keymaster doesn't fire on input/textarea events by default
     // since we are only using command/ctrl shortcuts,
@@ -14,7 +20,7 @@ function Shortcuts({ saveQuery, runQuery, formatQuery }) {
       return false;
     });
     keymaster('ctrl+return, command+return', e => {
-      runQuery();
+      connectConnectionClient().then(() => runQuery());
       return false;
     });
     keymaster('shift+return', e => {
@@ -27,12 +33,13 @@ function Shortcuts({ saveQuery, runQuery, formatQuery }) {
       keymaster.unbind('ctrl+s, command+s');
       keymaster.unbind('shift+return');
     };
-  }, [saveQuery, runQuery, formatQuery]);
+  }, [saveQuery, runQuery, connectConnectionClient, formatQuery]);
 
   return null;
 }
 
 export default connect(null, store => ({
+  connectConnectionClient: connectConnectionClient(store),
   formatQuery,
   runQuery: runQuery(store),
   saveQuery: saveQuery(store)

--- a/client/src/queryEditor/toolbar/ToolbarConnectionClientButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarConnectionClientButton.js
@@ -1,13 +1,12 @@
+import ConnectedIcon from 'mdi-react/ServerNetworkIcon';
+import DisconnectedIcon from 'mdi-react/ServerNetworkOffIcon';
 import React, { useState } from 'react';
 import { connect } from 'unistore/react';
-import Button from '../../common/Button';
+import IconButton from '../../common/IconButton';
 import {
   connectConnectionClient,
   disconnectConnectionClient
 } from '../../stores/connections';
-import IconButton from '../../common/IconButton';
-import ConnectedIcon from 'mdi-react/ServerNetworkIcon';
-import DisconnectedIcon from 'mdi-react/ServerNetworkOffIcon';
 
 function ToolbarConnectionClientButton({
   connectionClient,

--- a/client/src/queryEditor/toolbar/ToolbarConnectionClientButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarConnectionClientButton.js
@@ -5,6 +5,9 @@ import {
   connectConnectionClient,
   disconnectConnectionClient
 } from '../../stores/connections';
+import IconButton from '../../common/IconButton';
+import ConnectedIcon from 'mdi-react/ServerNetworkIcon';
+import DisconnectedIcon from 'mdi-react/ServerNetworkOffIcon';
 
 function ToolbarConnectionClientButton({
   connectionClient,
@@ -25,6 +28,7 @@ function ToolbarConnectionClientButton({
     setFetching(false);
   }
 
+  // If no connections or one isn't selected don't render anything
   if (!connections || connections.length === 0 || !selectedConnectionId) {
     return null;
   }
@@ -32,18 +36,25 @@ function ToolbarConnectionClientButton({
   const connection = connections.find(
     connection => connection._id === selectedConnectionId
   );
-  if (!connection || !connection.supportsConnectionClient) {
+
+  const supportedAndEnabled =
+    connection &&
+    connection.supportsConnectionClient &&
+    connection.multiStatementTransactionEnabled;
+
+  if (!supportedAndEnabled) {
     return null;
   }
 
   return (
-    <Button
-      tooltip="Connected keeps a single connection open, auto opens and closes for each query"
-      disabled={fetching}
+    <IconButton
       onClick={handleClick}
+      tooltip={
+        connectionClient ? 'Disconnect from database' : 'Connect to database'
+      }
     >
-      {connectionClient ? 'Connected' : 'Auto'}
-    </Button>
+      {connectionClient ? <ConnectedIcon /> : <DisconnectedIcon />}
+    </IconButton>
   );
 }
 

--- a/client/src/queryEditor/toolbar/ToolbarConnectionClientButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarConnectionClientButton.js
@@ -49,6 +49,7 @@ function ToolbarConnectionClientButton({
   return (
     <IconButton
       onClick={handleClick}
+      disabled={fetching}
       tooltip={
         connectionClient ? 'Disconnect from database' : 'Connect to database'
       }

--- a/client/src/queryEditor/toolbar/ToolbarRunButton.js
+++ b/client/src/queryEditor/toolbar/ToolbarRunButton.js
@@ -2,21 +2,31 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'unistore/react';
 import Button from '../../common/Button';
+import { connectConnectionClient } from '../../stores/connections';
 import { runQuery } from '../../stores/queries';
 
 function mapStateToProps(state) {
+  const { isRunning } = state;
   return {
-    isRunning: state.isRunning
+    isRunning
   };
 }
 
 const ConnectedToolbarRunButton = connect(mapStateToProps, store => ({
+  connectConnectionClient: connectConnectionClient(store),
   runQuery: runQuery(store)
 }))(React.memo(ToolbarRunButton));
 
-function ToolbarRunButton({ isRunning, runQuery }) {
+function ToolbarRunButton({ isRunning, connectConnectionClient, runQuery }) {
   return (
-    <Button variant="primary" onClick={() => runQuery()} disabled={isRunning}>
+    <Button
+      variant="primary"
+      onClick={async () => {
+        await connectConnectionClient();
+        runQuery();
+      }}
+      disabled={isRunning}
+    >
       Run
     </Button>
   );

--- a/client/src/stores/connections.js
+++ b/client/src/stores/connections.js
@@ -30,11 +30,30 @@ export async function initSelectedConnection(state) {
 }
 
 /**
- * Open a client connection for the currently selected connection
+ * Open a connection client for the currently selected connection if supported
  * @param {*} state
  */
 export const connectConnectionClient = store => async state => {
-  const { selectedConnectionId } = state;
+  const { connectionClient, connections, selectedConnectionId } = state;
+
+  // If a connectionClient is already open, or connections or selected connection id doesn't exist, do nothing
+  if (connectionClient || !connections || !selectedConnectionId) {
+    return;
+  }
+
+  const connection = connections.find(
+    connection => connection._id === selectedConnectionId
+  );
+
+  const supportedAndEnabled =
+    connection &&
+    connection.supportsConnectionClient &&
+    connection.multiStatementTransactionEnabled;
+
+  if (!supportedAndEnabled) {
+    return;
+  }
+
   const json = await fetchJson('POST', '/api/connection-clients', {
     connectionId: selectedConnectionId
   });

--- a/server/lib/connection-client.js
+++ b/server/lib/connection-client.js
@@ -89,7 +89,7 @@ class ConnectionClient {
 
     const ONE_HOUR_MS = 1000 * 60 * 60;
     const inactivityTimeoutMs =
-      parseInt(this.connection.inactivityTimeoutMs, 10) || ONE_HOUR_MS;
+      parseInt(this.connection.inactivityTimeout, 10) || ONE_HOUR_MS;
 
     this.cleanupInterval = setInterval(() => {
       const now = new Date();

--- a/server/lib/connection-client.js
+++ b/server/lib/connection-client.js
@@ -46,7 +46,7 @@ class ConnectionClient {
 
   /**
    * Updates lastKeepAliveAt to indicate a request was made to keep this connection alive.
-   * This may need to actually make a db call if drivers implement an automatic disconnect after some period of inactivity
+   * This may need to actually make a db call if drivers implement an automatic disconnect after some period of idle
    */
   keepAlive() {
     if (this.isConnected()) {
@@ -88,8 +88,8 @@ class ConnectionClient {
     this.keepAlive();
 
     const ONE_HOUR_MS = 1000 * 60 * 60;
-    const inactivityTimeoutMs =
-      parseInt(this.connection.inactivityTimeout, 10) || ONE_HOUR_MS;
+    const idleTimeoutMs =
+      parseInt(this.connection.idleTimeout, 10) || ONE_HOUR_MS;
 
     this.cleanupInterval = setInterval(() => {
       const now = new Date();
@@ -109,7 +109,7 @@ class ConnectionClient {
 
       if (
         sinceLastKeepAliveMs > keepAliveTimeoutMs ||
-        sinceLastActivityMs > inactivityTimeoutMs
+        sinceLastActivityMs > idleTimeoutMs
       ) {
         this.disconnect().catch(error => appLog.error(error));
       }

--- a/server/lib/validate-connection.js
+++ b/server/lib/validate-connection.js
@@ -35,7 +35,7 @@ function validateConnection(connection) {
     'createdDate',
     'modifiedDate',
     'multiStatementTransactionEnabled',
-    'inactivityTimeout'
+    'idleTimeout'
   ];
   if (!connection.name) {
     throw new Error('connection.name required');

--- a/server/lib/validate-connection.js
+++ b/server/lib/validate-connection.js
@@ -28,7 +28,15 @@ function ensureBoolean(value) {
  * @param {object} connection
  */
 function validateConnection(connection) {
-  const coreFields = ['_id', 'name', 'driver', 'createdDate', 'modifiedDate'];
+  const coreFields = [
+    '_id',
+    'name',
+    'driver',
+    'createdDate',
+    'modifiedDate',
+    'multiStatementTransactionEnabled',
+    'inactivityTimeout'
+  ];
   if (!connection.name) {
     throw new Error('connection.name required');
   }

--- a/server/models/connectionClients.js
+++ b/server/models/connectionClients.js
@@ -46,7 +46,7 @@ class ConnectionClients {
   async createNew(connection, user) {
     const connectionClient = new ConnectionClient(connection, user);
     await connectionClient.connect();
-    connectionClient.scheduleKeepAliveInterval();
+    connectionClient.scheduleCleanupInterval();
     this.connectionClients.push(connectionClient);
   }
 

--- a/server/models/connectionClients.js
+++ b/server/models/connectionClients.js
@@ -46,8 +46,8 @@ class ConnectionClients {
   async createNew(connection, user) {
     const connectionClient = new ConnectionClient(connection, user);
     await connectionClient.connect();
+    connectionClient.scheduleKeepAliveInterval();
     this.connectionClients.push(connectionClient);
-    return connectionClient;
   }
 
   /**

--- a/server/models/connectionClients.js
+++ b/server/models/connectionClients.js
@@ -48,6 +48,7 @@ class ConnectionClients {
     await connectionClient.connect();
     connectionClient.scheduleCleanupInterval();
     this.connectionClients.push(connectionClient);
+    return this.getOneById(connectionClient.id);
   }
 
   /**

--- a/server/routes/connection-clients.js
+++ b/server/routes/connection-clients.js
@@ -148,7 +148,13 @@ async function keepAliveConnectionClient(req, res) {
       return res.status(403).json({ error: 'Forbidden' });
     }
 
-    connectionClient.keepAlive();
+    const keptAlive = connectionClient.keepAlive();
+    if (!keptAlive) {
+      // remove from in-memory store and respond with nothing
+      // disconnect here is not necessary, but should be safe
+      await models.connectionClients.disconnectForId(params.connectionClientId);
+      return res.json({});
+    }
 
     const data = {
       connectionClient: {

--- a/server/test/api/connection-clients.js
+++ b/server/test/api/connection-clients.js
@@ -1,7 +1,7 @@
 const assert = require('assert').strict;
 const TestUtils = require('../utils');
 
-describe('api/connection-accesses', function() {
+describe('api/connection-clients', function() {
   const utils = new TestUtils();
   let connection1;
   let connectionClient1;
@@ -15,7 +15,9 @@ describe('api/connection-accesses', function() {
       database: 'sqlpad',
       username: 'sqlpad',
       password: 'sqlpad',
-      wait: 10
+      wait: 10,
+      inactivityTimeout: 4000,
+      multiStatementTransactionEnabled: true
     });
     connection1 = connBody.connection;
   });

--- a/server/test/api/connection-clients.js
+++ b/server/test/api/connection-clients.js
@@ -16,7 +16,7 @@ describe('api/connection-clients', function() {
       username: 'sqlpad',
       password: 'sqlpad',
       wait: 10,
-      inactivityTimeout: 4000,
+      idleTimeout: 4000,
       multiStatementTransactionEnabled: true
     });
     connection1 = connBody.connection;

--- a/server/test/lib/connection-clients.js
+++ b/server/test/lib/connection-clients.js
@@ -58,7 +58,7 @@ describe('lib/connection-clients', function() {
     connectionClient.scheduleCleanupInterval(400, 100);
     assert(connectionClient.isConnected());
 
-    await wait(500);
+    await wait(600);
     assert(!connectionClient.isConnected());
   });
 

--- a/server/test/lib/connection-clients.js
+++ b/server/test/lib/connection-clients.js
@@ -1,0 +1,109 @@
+const assert = require('assert').strict;
+const path = require('path');
+const TestUtils = require('../utils');
+const ConnectionClient = require('../../lib/connection-client');
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('lib/connection-clients', function() {
+  const utils = new TestUtils();
+  let connection1;
+
+  before(async function() {
+    await utils.init(true);
+
+    const connBody = await utils.post('admin', '/api/connections', {
+      driver: 'sqlite',
+      name: 'connection-client-test',
+      filename: path.join(
+        __dirname,
+        '../artifacts/connection-client-test.sqlite'
+      ),
+      inactivityTimeout: 1000,
+      multiStatementTransactionEnabled: true
+    });
+
+    connection1 = connBody.connection;
+  });
+
+  it('Keep-alive keeps it alive', async function() {
+    const connectionClient = new ConnectionClient(
+      connection1,
+      utils.users.admin
+    );
+    assert(connectionClient);
+
+    await connectionClient.connect();
+    connectionClient.scheduleCleanupInterval(400, 100);
+    assert(connectionClient.isConnected());
+
+    await wait(200);
+    connectionClient.keepAlive();
+    await wait(200);
+    connectionClient.keepAlive();
+    await wait(200);
+    assert(connectionClient.isConnected());
+  });
+
+  it('Without keep alive it closes', async function() {
+    const connectionClient = new ConnectionClient(
+      connection1,
+      utils.users.admin
+    );
+    assert(connectionClient);
+
+    await connectionClient.connect();
+    connectionClient.scheduleCleanupInterval(400, 100);
+    assert(connectionClient.isConnected());
+
+    await wait(500);
+    assert(!connectionClient.isConnected());
+  });
+
+  it('Stays-open with activity', async function() {
+    const connectionClient = new ConnectionClient(
+      connection1,
+      utils.users.admin
+    );
+    assert(connectionClient);
+
+    await connectionClient.connect();
+    connectionClient.scheduleCleanupInterval(400, 100);
+    assert(connectionClient.isConnected());
+
+    await wait(300);
+    connectionClient.keepAlive();
+    await wait(300);
+    connectionClient.keepAlive();
+    await connectionClient.runQuery('SELECT 1 AS val');
+    await wait(300);
+    connectionClient.keepAlive();
+    await wait(300);
+    connectionClient.keepAlive();
+    assert(connectionClient.isConnected());
+  });
+
+  it('Closes without activity', async function() {
+    const connectionClient = new ConnectionClient(
+      connection1,
+      utils.users.admin
+    );
+    assert(connectionClient);
+
+    await connectionClient.connect();
+    connectionClient.scheduleCleanupInterval(400, 100);
+    assert(connectionClient.isConnected());
+
+    await wait(300);
+    connectionClient.keepAlive();
+    await wait(300);
+    connectionClient.keepAlive();
+    await wait(300);
+    connectionClient.keepAlive();
+    await wait(300);
+    connectionClient.keepAlive();
+    assert(!connectionClient.isConnected());
+  });
+});

--- a/server/test/lib/connection-clients.js
+++ b/server/test/lib/connection-clients.js
@@ -21,7 +21,7 @@ describe('lib/connection-clients', function() {
         __dirname,
         '../artifacts/connection-client-test.sqlite'
       ),
-      inactivityTimeout: 1000,
+      idleTimeout: 1000,
       multiStatementTransactionEnabled: true
     });
 


### PR DESCRIPTION
This PR makes a few UX changes to the "persistent" connection client support.

This functionality is presented to the user as "multi-statement transaction" mode.

Connections that support this capability now need to opt-in to it by having it enabled. If enabled, users will see a connected/disconnected icon next to the connection dropdown. Running a query automatically connects the underlying client. In addition to the original keep-alive timeout that closes the connection if the user closes the browser tab, an "idle" timeout has been added that will close the connection after some amount of inactivity, regardless of whether the browser tab is open. This idle timeout is configurable by SQLPad admins. 

If the user would like, they may connect/disconnect manually by clicking the connection icon to toggle the status.

![SQLPad connected](https://user-images.githubusercontent.com/303966/76273832-dfccd100-624c-11ea-947b-a5e50b9e8d3f.jpg)
![SQLPad disconnected](https://user-images.githubusercontent.com/303966/76273834-e0656780-624c-11ea-9f1e-80978a8bb8a5.jpg)
![SQLPad multi-statement](https://user-images.githubusercontent.com/303966/76273835-e0656780-624c-11ea-8b8b-8304e37e24f4.jpg)
