### PR TITLE
Change Idle timeout to seconds 

### DIFF
--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -42,12 +42,12 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
       if (json.error) {
         message.error(json.error);
       } else {
-        // connection.idleTimeout is milliseconds
+        // connection.idleTimeout is seconds
         // Convert to minutes for a more user-friendly experience
         const idleTimeout =
           json.connection && parseInt(json.connection.idleTimeout, 10);
         if (idleTimeout) {
-          json.connection.idleTimeout = Math.round(idleTimeout / 1000 / 60);
+          json.connection.idleTimeoutMinutes = Math.round(idleTimeout / 60);
         }
         setConnectionEdits(json.connection);
       }
@@ -84,10 +84,10 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
 
     setSaving(true);
 
-    // connectionEdits.idleTimeout is storing minutes, but needs to send milliseconds
-    const idleTimeout = parseInt(connectionEdits.idleTimeout, 10);
-    if (idleTimeout) {
-      connectionEdits.idleTimeout = idleTimeout * 60 * 1000;
+    // connectionEdits.idleTimeoutMinutes needs to be converted to seconds
+    const idleTimeoutMinutes = parseInt(connectionEdits.idleTimeoutMinutes, 10);
+    if (idleTimeoutMinutes) {
+      connectionEdits.idleTimeout = idleTimeoutMinutes * 60;
     }
 
     let json;
@@ -148,11 +148,14 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
         );
 
         fieldsJsx.push(
-          <HorizontalFormItem key="idleTimeout" label="Idle timeout (minutes)">
+          <HorizontalFormItem
+            key="idleTimeoutMinutes"
+            label="Idle timeout (minutes)"
+          >
             <Input
-              name="idleTimeout"
+              name="idleTimeoutMinutes"
               type="number"
-              value={connectionEdits.idleTimeout || ''}
+              value={connectionEdits.idleTimeoutMinutes || ''}
               onChange={e => setConnectionValue(e.target.name, e.target.value)}
             />
             <FormExplain>

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -6,6 +6,16 @@ When a user write's a query, they'll pick a connection to use to run it. This co
 
 Admins can create connections in the UI, but connections can also be created in a JSON or INI config file, via a complicated environment variable convention, or via experimental seed data files.
 
+## Multi-Statement Transaction Support
+
+!> This feature is under-development, and only available in `latest` or future `4.2+` release
+
+Multi-statement transaction support adds the ability for a user to use the same underlying connection across query executions. This allows things like opening a transaction, running queries, and rolling the transaction back or comitting the transaction across query runs. It also opens up the ability to create and use temp tables that are generally scoped per connection session.
+
+Multi-statement transaction support is opt-in based on connection configuration. If a connection uses a driver and multi-statement transaction support is not enabled, the connection falls back to the legacy SQLPad behavior of opening a new connection for each query execution, then immediately closing it following the query.
+
+Work is under way to add multi-statement transaction support to drivers that benefit from the addition. At this time SQLite, Postgres, and ODBC drivers support this approach.
+
 ## Defining Connections via Configuration
 
 ?> As of 3.2.0 connections may be defined via application configuration.
@@ -159,6 +169,8 @@ When using JSON file, provide `<connectionId>` as a key under `connections`.
   <tbody>
     <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
     <tr><td>driver</td><td>Must be <code>postgres</code></td><td>text</td></tr>
+    <tr><td>multiStatementTransactionEnabled</td><td>Reuse db connection across query executions</td><td>boolean</td></tr>
+    <tr><td>idleTimeout</td><td>Seconds to allow connection to be idle before closing</td><td>number</td></tr>
     <tr><td>host</td><td>Host/Server/IP Address</td><td>text</td></tr>
     <tr><td>port</td><td>Port (optional)</td><td>text</td></tr>
     <tr><td>database</td><td>Database</td><td>text</td></tr>
@@ -319,6 +331,8 @@ When using JSON file, provide `<connectionId>` as a key under `connections`.
   <tbody>
     <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
     <tr><td>driver</td><td>Must be <code>sqlite</code></td><td>text</td></tr>
+    <tr><td>multiStatementTransactionEnabled</td><td>Reuse db connection across query executions</td><td>boolean</td></tr>
+    <tr><td>idleTimeout</td><td>Seconds to allow connection to be idle before closing</td><td>number</td></tr>
     <tr><td>filename</td><td>Path to file</td><td>text</td></tr>
     <tr><td>readonly</td><td>Open file in read only mode</td><td>boolean</td></tr>
   </tbody>
@@ -361,6 +375,8 @@ ORDER BY
   <tbody>
     <tr><td>name</td><td>Name of connection</td><td>text</td></tr>
     <tr><td>driver</td><td>Must be <code>unixodbc</code></td><td>text</td></tr>
+    <tr><td>multiStatementTransactionEnabled</td><td>Reuse db connection across query executions</td><td>boolean</td></tr>
+    <tr><td>idleTimeout</td><td>Seconds to allow connection to be idle before closing</td><td>number</td></tr>
     <tr><td>connection_string</td><td>ODBC connection string</td><td>text</td></tr>
     <tr><td>schema_sql</td><td>Database SQL to lookup schema (optional, if omitted default to checking INFORMATION_SCHEMA)</td><td>text</td></tr>
     <tr><td>username</td><td>Username (optional). Will be added to connect_string as <code>Uid</code> key</td><td>text</td></tr>

--- a/server/lib/connection-client.js
+++ b/server/lib/connection-client.js
@@ -80,16 +80,17 @@ class ConnectionClient {
 
   /**
    * Set up a poll to check on keep alive and activity requests
-   * and disconnect if keep alive has not been updated within range of keepAliveTimeoutMs
+   * and disconnect if keep alive has not been updated within range of keepAliveTimeoutMs or idleTimeout (seconds)
    * @param {number} [keepAliveTimeoutMs] - max amount of time to allow from keep alive ping before closing
    * @param {number} [intervalMs] - interval ms to check keep alive time
    */
   scheduleCleanupInterval(keepAliveTimeoutMs = 30000, intervalMs = 10000) {
     this.keepAlive();
 
-    const ONE_HOUR_MS = 1000 * 60 * 60;
-    const idleTimeoutMs =
-      parseInt(this.connection.idleTimeout, 10) || ONE_HOUR_MS;
+    const ONE_HOUR_SECONDS = 60 * 60;
+    const idleTimeoutSeconds =
+      parseInt(this.connection.idleTimeout, 10) || ONE_HOUR_SECONDS;
+    const idleTimeoutMs = idleTimeoutSeconds * 1000;
 
     this.cleanupInterval = setInterval(() => {
       const now = new Date();

--- a/server/test/api/connection-clients.js
+++ b/server/test/api/connection-clients.js
@@ -16,7 +16,7 @@ describe('api/connection-clients', function() {
       username: 'sqlpad',
       password: 'sqlpad',
       wait: 10,
-      idleTimeout: 4000,
+      idleTimeout: 4,
       multiStatementTransactionEnabled: true
     });
     connection1 = connBody.connection;

--- a/server/test/lib/connection-clients.js
+++ b/server/test/lib/connection-clients.js
@@ -21,7 +21,7 @@ describe('lib/connection-clients', function() {
         __dirname,
         '../artifacts/connection-client-test.sqlite'
       ),
-      idleTimeout: 1000,
+      idleTimeout: 1,
       multiStatementTransactionEnabled: true
     });
 


### PR DESCRIPTION
Updates idleTimeout to seconds instead of milliseconds. This is more user-friendly when defining connections via configuration, and falls in line with that used for connection accesses duration.