### PR TITLE
Enhance postgres docker compose example

### DIFF
--- a/docker-examples/mssql-docker-compose/docker-compose.yml
+++ b/docker-examples/mssql-docker-compose/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - MSSQL_SA_PASSWORD=SuperP4ssw0rd!
       - MSSQL_PID=Express
   sqlpad:
-    image: 'sqlpad/sqlpad:latest'
+    # Use Dockerfile at root of this project
+    build: ../../
     hostname: 'sqlpad'
     ports:
       - '3000:3000'

--- a/docker-examples/postgres-docker-compose/README.md
+++ b/docker-examples/postgres-docker-compose/README.md
@@ -6,9 +6,10 @@ Open command line in this directory containing the docker-compose file then type
 
 ```sh
 # pull/download docker images in compose file
-# This will be done automatically, but can be useful to
-# ensure images are up-to-date if using ":latest" tag for SQLPad like this example does
 docker-compose pull
+
+# Because sqlpad uses a docker file instead of an image on docker hub, it must be built
+docker-compose build
 
 # Then to start sqlpad and postgres do
 docker-compose up

--- a/docker-examples/postgres-docker-compose/config.json
+++ b/docker-examples/postgres-docker-compose/config.json
@@ -1,0 +1,20 @@
+{
+  "debug": true,
+  "admin": "admin@sqlpad.com",
+  "adminPassword": "admin",
+  "appLogLevel": "info",
+  "webLogLevel": "warn",
+  "seedDataPath": "/etc/sqlpad/seed-data",
+  "connections": {
+    "pg-demo": {
+      "name": "Postgres demo",
+      "driver": "postgres",
+      "host": "postgres",
+      "database": "sqlpad",
+      "username": "sqlpad",
+      "password": "sqlpad",
+      "multiStatementTransactionEnabled": true,
+      "idleTimeoutSeconds": 86400
+    }
+  }
+}

--- a/docker-examples/postgres-docker-compose/docker-compose.yml
+++ b/docker-examples/postgres-docker-compose/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3'
 services:
-  db:
+  postgres:
     image: postgres
     restart: always
     environment:
       POSTGRES_USER: sqlpad
       POSTGRES_PASSWORD: sqlpad
+    volumes:
+      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
 
   sqlpad:
     # Use Dockerfile at root of this project
@@ -14,9 +16,7 @@ services:
     ports:
       - '3000:3000'
     environment:
-      - SQLPAD_DEBUG=TRUE
+      SQLPAD_CONFIG: /etc/sqlpad/config.json
     volumes:
-      # This maps /var/lib/sqlpad directory inside sqlpad container to a directory docker host (your laptop, desktop, etc)
-      # This allows your SQLPad data to exist across container shutdowns
-      # For this to work, the path here `~/docker-volumes` must be shared with docker
-      - ~/docker-volumes/sqlpad-postgres:/var/lib/sqlpad
+      - ./config.json:/etc/sqlpad/config.json
+      - ./seed-data:/etc/sqlpad/seed-data

--- a/docker-examples/postgres-docker-compose/docker-compose.yml
+++ b/docker-examples/postgres-docker-compose/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       POSTGRES_PASSWORD: sqlpad
 
   sqlpad:
-    image: 'sqlpad/sqlpad:latest'
+    # Use Dockerfile at root of this project
+    build: ../../
     hostname: 'sqlpad'
     ports:
       - '3000:3000'

--- a/docker-examples/postgres-docker-compose/docker-entrypoint-initdb.d/pgdata.sh
+++ b/docker-examples/postgres-docker-compose/docker-entrypoint-initdb.d/pgdata.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE TABLE test (id int, name text);
+    INSERT INTO test (id, name) VALUES (1, 'one'), (2, 'two');
+EOSQL

--- a/docker-examples/postgres-docker-compose/seed-data/queries/query-1.json
+++ b/docker-examples/postgres-docker-compose/seed-data/queries/query-1.json
@@ -1,0 +1,13 @@
+{
+  "id": "seed-query-1",
+  "name": "Seed query 1",
+  "connectionId": "pg-demo",
+  "queryText": "SELECT * FROM some_table",
+  "createdBy": "admin@sqlpad.com",
+  "acl": [
+    {
+      "groupId": "__EVERYONE__",
+      "write": false
+    }
+  ]
+}

--- a/docker-examples/postgres-docker-compose/seed-data/queries/query-2.json
+++ b/docker-examples/postgres-docker-compose/seed-data/queries/query-2.json
@@ -1,0 +1,13 @@
+{
+  "id": "seed-query-2",
+  "name": "Shared prebuilt query",
+  "connectionId": "pg-demo",
+  "queryText": "-- This is a shared query by a user that does not exist\n\nSELECT * FROM test",
+  "createdBy": "not-real-user-but-that-is-okay-for-now@sqlpad.com",
+  "acl": [
+    {
+      "groupId": "__EVERYONE__",
+      "write": false
+    }
+  ]
+}


### PR DESCRIPTION
Expands on postgres example to add the following
* Use repo's Dockerfile to build SQLPad from repo
* Use JSON config file, specified via environment variable and mounted into container
* Use seed data for queries