### PR TITLE
Add timestamp to logging

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const express = require('express');
 const helmet = require('helmet');
+const pino = require('pino');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 const appLog = require('./lib/app-log');
@@ -28,6 +29,7 @@ function makeApp(config, models) {
 
   const expressPino = require('express-pino-logger')({
     level: webLogLevel,
+    timestamp: pino.stdTimeFunctions.isoTime,
     name: 'sqlpad-web',
     // express-pino-logger logs all the headers by default
     // Removing these for now but open to adding them back in based on feedback

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -5,6 +5,7 @@ const levels = ['fatal', 'error', 'warn', 'info', 'debug', 'silent'];
 
 const defaults = {
   name: 'sqlpad-app',
+  timestamp: pino.stdTimeFunctions.isoTime,
   redact: {
     paths: ['passhash', '*.passhash'],
     censor: '******'


### PR DESCRIPTION
Adds timestamp to app and web logs using ISO 8601-formatted time in UTC.