### PR TITLE
Add Docker multi-staged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,68 @@
-FROM node:12.3.1-alpine
+FROM node:12.16.1-alpine AS build
+
+RUN apk add --update --no-cache \
+    python \
+    make \
+    g++
+
+WORKDIR /sqlpad
+
+# By copying just the package files and installing node layers, 
+# we can take advantage of caching
+# SQLPad is really 3 node projects though
+# * root directory for linting
+# * client/ for web front end
+# * server/ for server (and what eventually holds built front end)
+COPY ./package* ./
+COPY ./client/package* ./client
+COPY ./server/package* ./server
+
+# Install dependencies
+RUN npm ci
+RUN npm ci --prefix client
+RUN npm ci --prefix server
+
+# Copy rest of the project into docker
+COPY . .
+
+# Build front-end and copy files into server public dir
+RUN npm run build --prefix && \
+    rm -rf server/public && \
+    mkdir server/public && \
+    cp -r client/build/* server/public
+
+# Build test db used for dev, debugging and running tests
+RUN node server/generate-test-db-fixture.js
+
+# Run tests and linting to validate build
+RUN npm run test --prefix server
+RUN npm run lint
+
+# Remove any dev dependencies from server
+# We don't care about root or client directories 
+# as they are not going to be copied to next stage
+RUN npm prune --production
+
+# Start another stage with a fresh node
+# Copy the server directory that has all the necessary node modules + front end build
+
+FROM node:12.16.1-alpine
+
+WORKDIR /usr/app
+
+COPY --from=build /sqlpad/server ./server
+COPY --from=build /sqlpad/docker-entrypoint .
+COPY --from=build /sqlpad/Dockerfile .
 
 ENV NODE_ENV production
 EXPOSE 3000
 ENTRYPOINT ["/docker-entrypoint"]
 
-WORKDIR /sqlpad
+# Things to think about for future docker builds
+# Should nginx be used to front sqlpad?
+# Should ODBC drivers be installed? (add your own at this point if you are modifying)
+# Should a healthcheck be added?
 
-COPY . .
-
-RUN scripts/build.sh && \
-    npm cache clean --force && \
-    cp -r /sqlpad/server /usr/app && \
-    cp /sqlpad/docker-entrypoint / && \
-    chmod +x /docker-entrypoint && \
-    rm -rf /sqlpad
+RUN ["chmod", "+x", "/docker-entrypoint"]
 
 WORKDIR /var/lib/sqlpad

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /sqlpad
 # * client/ for web front end
 # * server/ for server (and what eventually holds built front end)
 COPY ./package* ./
-COPY ./client/package* ./client
-COPY ./server/package* ./server
+COPY ./client/package* ./client/
+COPY ./server/package* ./server/
 
 # Install dependencies
 RUN npm ci
@@ -26,7 +26,7 @@ RUN npm ci --prefix server
 COPY . .
 
 # Build front-end and copy files into server public dir
-RUN npm run build --prefix && \
+RUN npm run build --prefix client && \
     rm -rf server/public && \
     mkdir server/public && \
     cp -r client/build/* server/public
@@ -41,27 +41,31 @@ RUN npm run lint
 # Remove any dev dependencies from server
 # We don't care about root or client directories 
 # as they are not going to be copied to next stage
+WORKDIR /sqlpad/server
 RUN npm prune --production
 
 # Start another stage with a fresh node
 # Copy the server directory that has all the necessary node modules + front end build
-
 FROM node:12.16.1-alpine
 
 WORKDIR /usr/app
 
-COPY --from=build /sqlpad/server ./server
-COPY --from=build /sqlpad/docker-entrypoint .
-COPY --from=build /sqlpad/Dockerfile .
+COPY --from=build /sqlpad/docker-entrypoint /
+COPY --from=build /sqlpad/server .
 
 ENV NODE_ENV production
 EXPOSE 3000
 ENTRYPOINT ["/docker-entrypoint"]
 
 # Things to think about for future docker builds
+# Perhaps add a healthcheck?
 # Should nginx be used to front sqlpad?
-# Should ODBC drivers be installed? (add your own at this point if you are modifying)
-# Should a healthcheck be added?
+#
+# Should ODBC drivers be installed? (once ODBC is compiling that is)
+# 
+# If you are wanting to use ODBC in docker build, 
+# fork this, make sure it compiles unixodbc driver in first stage, 
+# and add specific ODBC drivers here in this stage
 
 RUN ["chmod", "+x", "/docker-entrypoint"]
 


### PR DESCRIPTION
Updates Dockerfile to use a multi-staged build and updates the node version to use latest v12. 

Using this approach we're able to more efficiently take advantage of caching during build time. 

We're also able to install whatever dependencies we need in first stage, then copy the final result out into the second stage. This makes it much easier to slim down the build size instead of trying to uninstall everything that was added and is no longer necessary.

This build now also runs linting and test cases.

All this and it has managed to shave a few MBs from total size... from 184MB to 169MB.

Doing some investigating, the 169MB is made up of about 100MB SQLPad, 90MB of that being `node_modules`.  (Kind of curious how small the image would be if it was built with https://github.com/zeit/pkg)