### PR TITLE
Replace users.save for create and update methods

### DIFF
--- a/server/auth-strategies/auth-proxy.js
+++ b/server/auth-strategies/auth-proxy.js
@@ -58,7 +58,7 @@ async function authProxyStrategy(req, done) {
 
       if (!_.isEqual(headerUser, existingForCompare)) {
         _.merge(existingUser, headerUser);
-        existingUser = await models.users.save(existingUser);
+        existingUser = await models.users.update(existingUser);
       }
       return done(null, existingUser);
     }
@@ -71,7 +71,7 @@ async function authProxyStrategy(req, done) {
       }
 
       // Auto create the user
-      const newUser = await models.users.save(headerUser);
+      const newUser = await models.users.create(headerUser);
       return done(null, newUser);
     }
 

--- a/server/auth-strategies/google.js
+++ b/server/auth-strategies/google.js
@@ -27,13 +27,13 @@ async function passportGoogleStrategyHandler(
 
     if (user) {
       user.signupDate = new Date();
-      const newUser = await models.users.save(user);
+      const newUser = await models.users.update(user);
       newUser.id = newUser._id;
       return done(null, newUser);
     }
     const whitelistedDomains = config.get('whitelistedDomains');
     if (openAdminRegistration || checkWhitelist(whitelistedDomains, email)) {
-      const newUser = await models.users.save({
+      const newUser = await models.users.create({
         email,
         role: openAdminRegistration ? 'admin' : 'editor',
         signupDate: new Date()

--- a/server/drivers/bigquery/test.js
+++ b/server/drivers/bigquery/test.js
@@ -35,6 +35,7 @@ describe('drivers/bigquery', function() {
           done();
         });
     } else {
+      // eslint-disable-next-line no-console
       console.log(
         'Define BIGQUERY_TEST_GCP_PROJECT_ID, BIGQUERY_TEST_DATASET_NAME, BIGQUERY_TEST_CREDENTIALS_FILE, and BIGQUERY_TEST_DATASET_LOCATION to run the bigquery driver tests'
       );

--- a/server/routes/forgot-password.js
+++ b/server/routes/forgot-password.js
@@ -25,7 +25,7 @@ router.post('/api/forgot-password', async function(req, res) {
 
     user.passwordResetId = uuidv4();
 
-    await models.users.save(user);
+    await models.users.update(user);
 
     // Send email, but do not block response
     const resetPath = `/password-reset/${user.passwordResetId}`;

--- a/server/routes/password-reset.js
+++ b/server/routes/password-reset.js
@@ -20,7 +20,7 @@ router.post('/api/password-reset/:passwordResetId', async function(req, res) {
     }
     user.password = req.body.password;
     user.passwordResetId = '';
-    await models.users.save(user);
+    await models.users.update(user);
     return res.json({});
   } catch (error) {
     sendError(res, error, 'Problem querying user database');

--- a/server/routes/signup.js
+++ b/server/routes/signup.js
@@ -29,7 +29,7 @@ async function handleSignup(req, res, next) {
     if (user) {
       user.password = req.body.password;
       user.signupDate = new Date();
-      await models.users.save(user);
+      await models.users.update(user);
       return next();
     }
 
@@ -39,7 +39,7 @@ async function handleSignup(req, res, next) {
       adminRegistrationOpen ||
       checkWhitelist(whitelistedDomains, req.body.email)
     ) {
-      user = await models.users.save({
+      user = await models.users.create({
         email: req.body.email,
         password: req.body.password,
         role: adminRegistrationOpen ? 'admin' : 'editor',

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -23,6 +23,7 @@ router.post('/api/users', mustBeAdmin, async function(req, res) {
       return sendError(res, null, 'User already exists');
     }
 
+    // Only accept certain fields
     user = await models.users.create({
       email: req.body.email.toLowerCase(),
       role: req.body.role,
@@ -52,10 +53,25 @@ router.put('/api/users/:_id', mustBeAdmin, async function(req, res) {
       return sendError(res, null, 'user not found');
     }
 
-    delete body._id;
-    const data = { ...updateUser, ...body };
+    // this route could handle potentially different kinds of updates
+    // only update user properties that are explicitly allowed to be updated and present
+    if (body.role != null) {
+      updateUser.role = body.role;
+    }
+    if (body.passwordResetId != null) {
+      updateUser.passwordResetId = body.passwordResetId;
+    }
+    if (body.name) {
+      updateUser.name = body.name;
+    }
+    if (body.email) {
+      updateUser.email = body.email.toLowerCase();
+    }
+    if (body.data) {
+      updateUser.data = body.data;
+    }
 
-    const updatedUser = await models.users.update(data);
+    const updatedUser = await models.users.update(updateUser);
     return res.json({ user: updatedUser });
   } catch (error) {
     sendError(res, error, 'Problem saving user');

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -22,9 +22,12 @@ router.post('/api/users', mustBeAdmin, async function(req, res) {
     if (user) {
       return sendError(res, null, 'User already exists');
     }
-    user = await models.users.save({
+
+    user = await models.users.create({
       email: req.body.email.toLowerCase(),
-      role: req.body.role
+      role: req.body.role,
+      name: req.body.name,
+      data: req.body.data
     });
 
     const email = makeEmail(req.config);
@@ -48,15 +51,11 @@ router.put('/api/users/:_id', mustBeAdmin, async function(req, res) {
     if (!updateUser) {
       return sendError(res, null, 'user not found');
     }
-    // this route could handle potentially different kinds of updates
-    // only update user properties that are explicitly provided in body
-    if (body.role != null) {
-      updateUser.role = body.role;
-    }
-    if (body.passwordResetId != null) {
-      updateUser.passwordResetId = body.passwordResetId;
-    }
-    const updatedUser = await models.users.save(updateUser);
+
+    delete body._id;
+    const data = { ...updateUser, ...body };
+
+    const updatedUser = await models.users.update(data);
     return res.json({ user: updatedUser });
   } catch (error) {
     sendError(res, error, 'Problem saving user');

--- a/server/test/api/password-reset.js
+++ b/server/test/api/password-reset.js
@@ -9,7 +9,7 @@ describe('api/password-reset', function() {
     const user = await utils.models.users.findOneByEmail('admin@test.com');
     const passwordResetId = uuidv4();
     user.passwordResetId = passwordResetId;
-    await utils.models.users.save(user);
+    await utils.models.users.update(user);
     return passwordResetId;
   }
 

--- a/server/test/api/users.js
+++ b/server/test/api/users.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { v4: uuidv4 } = require('uuid');
 const TestUtils = require('../utils');
 
 describe('api/users', function() {
@@ -45,9 +46,11 @@ describe('api/users', function() {
   });
 
   it('Updates user', async function() {
+    const passwordResetId = uuidv4();
     const body = await utils.put('admin', `/api/users/${user._id}`, {
       role: 'admin',
       name: 'test',
+      passwordResetId,
       data: {
         test: true
       }
@@ -56,6 +59,7 @@ describe('api/users', function() {
     assert.equal(body.user.role, 'admin');
     assert.equal(body.user.email, 'user1@test.com');
     assert.equal(body.user.name, 'test');
+    assert.equal(body.user.passwordResetId, passwordResetId);
     assert.equal(body.user.data.test, true);
     assert(new Date(body.user.modifiedDate) > new Date(user.modifiedDate));
   });

--- a/server/test/api/users.js
+++ b/server/test/api/users.js
@@ -19,13 +19,24 @@ describe('api/users', function() {
   it('Creates user', async function() {
     const body = await utils.post('admin', '/api/users', {
       email: 'user1@test.com',
-      role: 'editor'
+      name: 'user1',
+      role: 'editor',
+      data: {
+        create: true
+      }
     });
 
     assert(!body.error, 'no error');
-    assert(body.user._id, 'has _id');
-    assert.equal(body.user.email, 'user1@test.com');
+
     user = body.user;
+
+    assert(user._id, 'has _id');
+    assert.equal(user.email, 'user1@test.com');
+    assert.equal(user.name, 'user1');
+    assert.equal(user.role, 'editor');
+    assert.equal(user.data.create, true);
+    assert(user.modifiedDate);
+    assert(user.createdDate);
   });
 
   it('Gets list of users', async function() {
@@ -35,10 +46,18 @@ describe('api/users', function() {
 
   it('Updates user', async function() {
     const body = await utils.put('admin', `/api/users/${user._id}`, {
-      role: 'admin'
+      role: 'admin',
+      name: 'test',
+      data: {
+        test: true
+      }
     });
     assert(!body.error, 'no error');
     assert.equal(body.user.role, 'admin');
+    assert.equal(body.user.email, 'user1@test.com');
+    assert.equal(body.user.name, 'test');
+    assert.equal(body.user.data.test, true);
+    assert(new Date(body.user.modifiedDate) > new Date(user.modifiedDate));
   });
 
   it('Requires authentication', function() {

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -97,7 +97,7 @@ class TestUtils {
   }
 
   async addUserApiHelper(key, user) {
-    const newUser = await this.models.users.save(user);
+    const newUser = await this.models.users.create(user);
     // If user already exists, update the _id, otherwise add new one (using the original data)
     if (this.users[key]) {
       this.users[key]._id = newUser._id;


### PR DESCRIPTION
A long time ago I thought a save that handled both creates and updates was a good way to go, but it makes certain things harder, especially when both `_id` and `email` are unique.

This also adds a bit to user API test cases, and updates the API to allow the adding and updating of more fields.