### PR TITLE
Fix Drawer CSS

### DIFF
--- a/client/src/common/Drawer.module.css
+++ b/client/src/common/Drawer.module.css
@@ -2,16 +2,14 @@
   height: 100vh;
   margin: 0;
   padding: 0;
-  overflow: auto;
+  overflow: hidden;
   position: absolute;
-  display: flex;
-  flex-direction: column;
   box-shadow: var(--box-shadow-2);
 }
 
 .titleWrapper {
   box-sizing: border-box;
-  flex: 0 0 45px;
+  height: 44px;
   font-size: 1.3rem;
   border-bottom: var(--border);
   display: flex;
@@ -23,8 +21,13 @@
 }
 
 .dialogBody {
-  display: flex;
-  flex-direction: column;
-  height: calc(100vh - 45px);
+  height: calc(100vh - 44px);
+  /* 
+   TODO move this padding into a separate component for dialog body, 
+   used as needed for each specific drawer 
+   Another component can be introduced for an "Actions" component that sits outside the body, 
+   with body being scrollable and grows
+  */
   padding: 16px;
+  overflow-y: auto;
 }

--- a/client/src/common/Drawer.module.css
+++ b/client/src/common/Drawer.module.css
@@ -25,6 +25,6 @@
 .dialogBody {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: calc(100vh - 45px);
   padding: 16px;
 }

--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -262,88 +262,84 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
   }
 
   return (
-    <div style={{ height: '100%' }}>
-      <form
-        onSubmit={saveConnection}
-        autoComplete="off"
+    <form
+      onSubmit={saveConnection}
+      autoComplete="off"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%'
+      }}
+    >
+      <div style={{ overflowY: 'auto', flexGrow: 1 }}>
+        <HorizontalFormItem label="Connection name">
+          <Input
+            name="name"
+            value={name}
+            error={!name}
+            onChange={e => setConnectionValue(e.target.name, e.target.value)}
+          />
+        </HorizontalFormItem>
+        <HorizontalFormItem label="Driver">
+          <Select
+            name="driver"
+            value={driver}
+            error={!driver}
+            onChange={event => setConnectionValue('driver', event.target.value)}
+          >
+            {driverSelectOptions}
+          </Select>
+        </HorizontalFormItem>
+
+        {renderDriverFields()}
+      </div>
+      <div
         style={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%'
+          borderTop: '1px solid #e8e8e8',
+          paddingTop: '22px',
+          textAlign: 'right'
         }}
       >
-        <div style={{ overflowY: 'auto', flexGrow: 1, height: '100%' }}>
-          <HorizontalFormItem label="Connection name">
-            <Input
-              name="name"
-              value={name}
-              error={!name}
-              onChange={e => setConnectionValue(e.target.name, e.target.value)}
-            />
-          </HorizontalFormItem>
-          <HorizontalFormItem label="Driver">
-            <Select
-              name="driver"
-              value={driver}
-              error={!driver}
-              onChange={event =>
-                setConnectionValue('driver', event.target.value)
-              }
-            >
-              {driverSelectOptions}
-            </Select>
-          </HorizontalFormItem>
-
-          {renderDriverFields()}
-        </div>
-        <div
-          style={{
-            borderTop: '1px solid #e8e8e8',
-            paddingTop: '22px',
-            textAlign: 'right'
-          }}
+        <Button
+          htmlType="submit"
+          style={{ width: 120 }}
+          variant="primary"
+          onClick={saveConnection}
+          disabled={saving}
         >
-          <Button
-            htmlType="submit"
-            style={{ width: 120 }}
-            variant="primary"
-            onClick={saveConnection}
-            disabled={saving}
-          >
-            {saving ? 'Saving...' : 'Save'}
-          </Button>{' '}
-          <Button
-            style={{ width: 120 }}
-            onClick={testConnection}
-            disabled={testing}
-          >
-            {testing ? 'Testing...' : 'Test'}
-            {!testing && testSuccess && (
-              <SuccessIcon
-                style={{
-                  marginLeft: 8,
-                  height: 18,
-                  width: 18,
-                  marginBottom: -4
-                }}
-                color="#52c41a"
-              />
-            )}
-            {!testing && testFailed && (
-              <CloseCircleOutlineIcon
-                style={{
-                  marginLeft: 8,
-                  height: 18,
-                  width: 18,
-                  marginBottom: -4
-                }}
-                color="#eb2f96"
-              />
-            )}
-          </Button>
-        </div>
-      </form>
-    </div>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>{' '}
+        <Button
+          style={{ width: 120 }}
+          onClick={testConnection}
+          disabled={testing}
+        >
+          {testing ? 'Testing...' : 'Test'}
+          {!testing && testSuccess && (
+            <SuccessIcon
+              style={{
+                marginLeft: 8,
+                height: 18,
+                width: 18,
+                marginBottom: -4
+              }}
+              color="#52c41a"
+            />
+          )}
+          {!testing && testFailed && (
+            <CloseCircleOutlineIcon
+              style={{
+                marginLeft: 8,
+                height: 18,
+                width: 18,
+                marginBottom: -4
+              }}
+              color="#eb2f96"
+            />
+          )}
+        </Button>
+      </div>
+    </form>
   );
 }
 

--- a/client/src/connections/ConnectionList.js
+++ b/client/src/connections/ConnectionList.js
@@ -75,9 +75,59 @@ function ConnectionList({
     return connection;
   });
 
+  const listItems = decoratedConnections.map(item => {
+    let description = '';
+    if (item.user) {
+      description = item.user + '@';
+    }
+    description += [item.displayHost, item.displayDatabase, item.displaySchema]
+      .filter(part => part && part.trim())
+      .join(' / ');
+
+    const actions = [];
+
+    if (currentUser.role === 'admin' && item.editable) {
+      actions.push(
+        <Button
+          key="edit"
+          style={{ marginLeft: 8 }}
+          onClick={() => editConnection(item)}
+        >
+          edit
+        </Button>
+      );
+      actions.push(
+        <DeleteConfirmButton
+          key="delete"
+          confirmMessage="Delete connection?"
+          onConfirm={e => deleteConnection(item._id)}
+          style={{ marginLeft: 8 }}
+        >
+          Delete
+        </DeleteConfirmButton>
+      );
+    }
+
+    return (
+      <ListItem key={item._id}>
+        <div style={{ flexGrow: 1, padding: 8 }}>
+          {item.name}
+          <br />
+          <Text type="secondary">{description}</Text>
+        </div>
+        {actions}
+      </ListItem>
+    );
+  });
+
   return (
-    <>
-      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end'
+        }}
+      >
         <Button
           style={{ width: 135 }}
           variant="primary"
@@ -86,55 +136,7 @@ function ConnectionList({
           Add connection
         </Button>
       </div>
-      {decoratedConnections.map(item => {
-        let description = '';
-        if (item.user) {
-          description = item.user + '@';
-        }
-        description += [
-          item.displayHost,
-          item.displayDatabase,
-          item.displaySchema
-        ]
-          .filter(part => part && part.trim())
-          .join(' / ');
-
-        const actions = [];
-
-        if (currentUser.role === 'admin' && item.editable) {
-          actions.push(
-            <Button
-              key="edit"
-              style={{ marginLeft: 8 }}
-              onClick={() => editConnection(item)}
-            >
-              edit
-            </Button>
-          );
-          actions.push(
-            <DeleteConfirmButton
-              key="delete"
-              confirmMessage="Delete connection?"
-              onConfirm={e => deleteConnection(item._id)}
-              style={{ marginLeft: 8 }}
-            >
-              Delete
-            </DeleteConfirmButton>
-          );
-        }
-
-        return (
-          <ListItem key={item._id}>
-            <div style={{ flexGrow: 1, padding: 8 }}>
-              {item.name}
-              <br />
-              <Text type="secondary">{description}</Text>
-            </div>
-            {actions}
-          </ListItem>
-        );
-      })}
-
+      <div style={{ flexGrow: 1 }}>{listItems}</div>
       <ConnectionEditDrawer
         connectionId={connectionId}
         visible={showEdit}
@@ -142,7 +144,7 @@ function ConnectionList({
         onConnectionSaved={handleConnectionSaved}
         placement="left"
       />
-    </>
+    </div>
   );
 }
 

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -197,82 +197,84 @@ function QueryListDrawer({
       onClose={handleClose}
       placement="left"
     >
-      <div className={styles.filterContainer}>
-        <div className={styles.filterRow}>
-          <Select
-            style={{ width: 140, marginRight: 8, flex: '0 0 auto' }}
-            value={creatorSearch}
-            onChange={e => setCreatorSearch(e.target.value)}
-          >
-            <option value={MY_QUERIES}>My queries</option>
-            <option value={SHARED}>Shared with me</option>
-            <option value={ALL}>All</option>
-          </Select>
-          <Select
-            style={{ marginRight: 8 }}
-            value={connectionId}
-            onChange={e => setConnectionId(e.target.value)}
-          >
-            <option value="">All connections</option>
-            {connections.map(connection => {
-              return (
-                <option key={connection._id} value={connection._id}>
-                  {connection.name}
-                </option>
-              );
-            })}
-          </Select>
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <div className={styles.filterContainer}>
+          <div className={styles.filterRow}>
+            <Select
+              style={{ width: 140, marginRight: 8, flex: '0 0 auto' }}
+              value={creatorSearch}
+              onChange={e => setCreatorSearch(e.target.value)}
+            >
+              <option value={MY_QUERIES}>My queries</option>
+              <option value={SHARED}>Shared with me</option>
+              <option value={ALL}>All</option>
+            </Select>
+            <Select
+              style={{ marginRight: 8 }}
+              value={connectionId}
+              onChange={e => setConnectionId(e.target.value)}
+            >
+              <option value="">All connections</option>
+              {connections.map(connection => {
+                return (
+                  <option key={connection._id} value={connection._id}>
+                    {connection.name}
+                  </option>
+                );
+              })}
+            </Select>
 
-          <Select
-            style={{ width: 170, flex: '0 0 auto' }}
-            value={sort}
-            onChange={e => setSort(e.target.value)}
-          >
-            <option value="SAVE_DATE">Order by last saved</option>
-            <option value="NAME">Order by name</option>
-          </Select>
+            <Select
+              style={{ width: 170, flex: '0 0 auto' }}
+              value={sort}
+              onChange={e => setSort(e.target.value)}
+            >
+              <option value="SAVE_DATE">Order by last saved</option>
+              <option value="NAME">Order by name</option>
+            </Select>
+          </div>
+
+          <MultiSelect
+            selectedItems={searches}
+            options={availableSearches}
+            onChange={items => setSearches(items)}
+            placeholder="search"
+          />
         </div>
 
-        <MultiSelect
-          selectedItems={searches}
-          options={availableSearches}
-          onChange={items => setSearches(items)}
-          placeholder="search"
-        />
-      </div>
-
-      <Measure
-        bounds
-        onResize={contentRect => {
-          setDimensions(contentRect.bounds);
-        }}
-      >
-        {({ measureRef }) => (
-          <div
-            ref={measureRef}
-            style={{
-              display: 'flex',
-              width: '100%',
-              height: '100%'
-            }}
-          >
-            <List
-              // position absolute takes list out of flow,
-              // preventing some weird react-measure behavior in Firefox
-              style={{ position: 'absolute' }}
-              height={dimensions.height}
-              itemCount={filteredQueries.length}
-              itemSize={60}
-              width={dimensions.width}
-              overscanCount={2}
+        <Measure
+          bounds
+          onResize={contentRect => {
+            setDimensions(contentRect.bounds);
+          }}
+        >
+          {({ measureRef }) => (
+            <div
+              ref={measureRef}
+              style={{
+                display: 'flex',
+                width: '100%',
+                height: '100%'
+              }}
             >
-              {Row}
-            </List>
-          </div>
-        )}
-      </Measure>
+              <List
+                // position absolute takes list out of flow,
+                // preventing some weird react-measure behavior in Firefox
+                style={{ position: 'absolute' }}
+                height={dimensions.height}
+                itemCount={filteredQueries.length}
+                itemSize={60}
+                width={dimensions.width}
+                overscanCount={2}
+              >
+                {Row}
+              </List>
+            </div>
+          )}
+        </Measure>
 
-      <QueryPreview query={preview} />
+        <QueryPreview query={preview} />
+      </div>
     </Drawer>
   );
 }


### PR DESCRIPTION
Fixes display of connection edit drawer for long forms to ensure that save and test buttons are always visible at bottom of the screen, while body of form elements scroll.

Thinking about future layout components that could be added to ensure a consistent behavior across drawers... (perhaps there's a DrawerActions components that will always remain visible, and DrawerBody that has flexes and is scrollable.