### PR TITLE
Add config item deprecations

### DIFF
--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -62,17 +62,23 @@ const configItems = [
   {
     key: 'certPassphrase',
     envVar: 'CERT_PASSPHRASE',
-    default: ''
+    default: '',
+    deprecated:
+      'To be removed in v6. Delegate SSL to reverse proxy instead https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/production/delegatetoproxy.md'
   },
   {
     key: 'keyPath',
     envVar: 'KEY_PATH',
-    default: ''
+    default: '',
+    deprecated:
+      'To be removed in v6. Delegate SSL to reverse proxy instead https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/production/delegatetoproxy.md'
   },
   {
     key: 'certPath',
     envVar: 'CERT_PATH',
-    default: ''
+    default: '',
+    deprecated:
+      'To be removed in v6. Delegate SSL to reverse proxy instead https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/production/delegatetoproxy.md'
   },
   {
     key: 'admin',
@@ -87,7 +93,8 @@ const configItems = [
   {
     key: 'debug',
     envVar: 'SQLPAD_DEBUG',
-    default: false
+    default: false,
+    deprecated: 'To be removed in v5. Set app/web log levels to debug instead.'
   },
   {
     key: 'googleClientId',
@@ -142,7 +149,9 @@ const configItems = [
   {
     key: 'tableChartLinksRequireAuth',
     envVar: 'SQLPAD_TABLE_CHART_LINKS_REQUIRE_AUTH',
-    default: true
+    default: true,
+    deprecated:
+      'To be removed in v5. Use reverse-proxy and alternative auth mechanism such as auth-proxy to authenticate user passively instead (or request per-query public sharing links be created in GitHub).'
   },
   {
     key: 'smtpFrom',

--- a/server/lib/config/from-file.js
+++ b/server/lib/config/from-file.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const ini = require('ini');
-const configItems = require('./config-items');
 
 /**
  * Reads and parses config file.
@@ -9,7 +8,6 @@ const configItems = require('./config-items');
  */
 function fromFile(configFilePath) {
   let parsedFile = {};
-  const warnings = [];
 
   if (fs.existsSync(configFilePath)) {
     const fileText = fs.readFileSync(configFilePath, { encoding: 'utf8' });
@@ -23,25 +21,9 @@ function fromFile(configFilePath) {
         throw new Error(`Error parsing config file ${configFilePath}`);
       }
     }
-
-    // Validate that the config file uses the keys defined in configItems
-    // Prior to SQLPad 3 the saved config file was a JSON result of what minimist parsed from argv
-    // This means that there could be cliFlag's in the json ie `cert-passphrase` or `dir` for dbPath
-    // These are no longer supported from a file
-    Object.keys(parsedFile)
-      // connections is a special key that we will ignore for now
-      // It will define connections by id and is not to have a warning message
-      .filter(key => key !== 'connections')
-      .forEach(key => {
-        const configItem = configItems.find(item => item.key === key);
-        if (!configItem) {
-          let warningMessage = `Config key ${key} in file ${configFilePath} not recognized.`;
-          warnings.push(warningMessage);
-        }
-      });
   }
 
-  return [parsedFile, warnings];
+  return parsedFile;
 }
 
 module.exports = fromFile;

--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -66,7 +66,12 @@ class Config {
     // Connections key is filtered out from consideration here because it is special and dynamic
     // When dealing with unknown keys, the unknown key will only ever come from a file or CLI.
     // Config from environment vars will only ever be plucked from the known list of config items
-    Object.keys(this.all)
+    const userProvidedConfigs = {
+      ...this.envConfig,
+      ...this.fileConfig,
+      ...this.cliConfig
+    };
+    Object.keys(userProvidedConfigs)
       .filter(key => key !== 'connections')
       .forEach(key => {
         const configItem = configItems.find(item => item.key === key);
@@ -84,7 +89,7 @@ class Config {
 
         if (configItem.deprecated) {
           warnings.push(
-            `DEPRECATED CONFIG: key ${configItem.key} / env var ${configItem.envVar}. ${configItem.deprecated}`
+            `DEPRECATED CONFIG: ${configItem.key} / ${configItem.envVar}. ${configItem.deprecated}`
           );
         }
       });

--- a/server/test/lib/config.js
+++ b/server/test/lib/config.js
@@ -56,7 +56,7 @@ describe('lib/config/fromFile', function() {
     assert.equal(Object.keys(config).length, 3, '3 items');
   });
 
-  it('Warns for old JSON', function() {
+  it('Warns for old config file', function() {
     const config = new Config(
       { config: path.join(__dirname, '../fixtures/old-config.json') },
       {}
@@ -64,10 +64,23 @@ describe('lib/config/fromFile', function() {
 
     const validations = config.getValidations();
     assert(validations.warnings);
-    const found = validations.warnings.find(warning =>
-      `${warning}`.includes('Config key cert-passphrase')
+    const found = validations.warnings.find(
+      warning =>
+        warning.includes('cert-passphrase') &&
+        warning.includes('NOT RECOGNIZED')
     );
     assert(found, 'has warning about old key');
+  });
+
+  it('Warns for deprecated config', function() {
+    const config = new Config({ certPath: 'is going away' }, {});
+
+    const validations = config.getValidations();
+    assert(validations.warnings);
+    const found = validations.warnings.find(
+      warning => warning.includes('certPath') && warning.includes('DEPRECATED')
+    );
+    assert(found, 'has deprecated key warning');
   });
 });
 

--- a/server/test/lib/config.js
+++ b/server/test/lib/config.js
@@ -36,12 +36,12 @@ describe('lib/config/from-cli', function() {
 
 describe('lib/config/fromFile', function() {
   it('handles missing file', function() {
-    const [config] = fromFile(path.join(__dirname, '/missing.ini'));
+    const config = fromFile(path.join(__dirname, '/missing.ini'));
     assert.equal(Object.keys(config).length, 0, 'empty object');
   });
 
   it('reads INI', function() {
-    const [config] = fromFile(path.join(__dirname, '../fixtures/config.ini'));
+    const config = fromFile(path.join(__dirname, '../fixtures/config.ini'));
     assert.equal(config.dbPath, 'dbPath', 'dbPath');
     assert.equal(config.baseUrl, 'baseUrl', 'baseUrl');
     assert.equal(config.certPassphrase, 'certPassphrase', 'certPassphrase');
@@ -49,7 +49,7 @@ describe('lib/config/fromFile', function() {
   });
 
   it('reads JSON', function() {
-    const [config] = fromFile(path.join(__dirname, '../fixtures/config.json'));
+    const config = fromFile(path.join(__dirname, '../fixtures/config.json'));
     assert.equal(config.dbPath, 'dbPath', 'dbPath');
     assert.equal(config.baseUrl, 'baseUrl', 'baseUrl');
     assert.equal(config.certPassphrase, 'certPassphrase', 'certPassphrase');
@@ -57,11 +57,17 @@ describe('lib/config/fromFile', function() {
   });
 
   it('Warns for old JSON', function() {
-    const [config, warnings] = fromFile(
-      path.join(__dirname, '../fixtures/old-config.json')
+    const config = new Config(
+      { config: path.join(__dirname, '../fixtures/old-config.json') },
+      {}
     );
-    assert(config);
-    assert.equal(warnings.length, 1, 'has warnings');
+
+    const validations = config.getValidations();
+    assert(validations.warnings);
+    const found = validations.warnings.find(warning =>
+      `${warning}`.includes('Config key cert-passphrase')
+    );
+    assert(found, 'has warning about old key');
   });
 });
 


### PR DESCRIPTION
Fixes #536 

Adds ability to deprecate some configuration items, and adds some to that list. When a config item is deprecated, the warning message specified is printed to console on application startup.

Deprecates the following: 
* `tableChartLinksRequireAuth`
* `debug`
* `keyPath`
* `certPath`
* `certPassphrase`