### PR TITLE
Log error and prevent application start for unknown config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## In development (v5)
+
+#### Breaking
+
+- `debug` config option removed. Use `appLogLevel` set to `debug` instead.
+
 ## 4.2.0
 
 ### April 6, 2020

--- a/server/app.js
+++ b/server/app.js
@@ -63,9 +63,6 @@ function makeApp(config, models) {
     next();
   });
 
-  const expressEnv = config.get('debug') ? 'development' : 'production';
-  app.set('env', expressEnv);
-
   app.use(expressPino);
   app.use(favicon(path.join(__dirname, '/public/favicon.ico')));
   app.use(bodyParser.json());

--- a/server/config.dev.ini
+++ b/server/config.dev.ini
@@ -1,7 +1,6 @@
 ; INI config file for dev setup
 port = 3010
 baseUrl = "/sqlpad"
-debug = true
 dbPath = ../db
 appLogLevel = debug
 webLogLevel = debug

--- a/server/lib/cli-flow.js
+++ b/server/lib/cli-flow.js
@@ -12,8 +12,8 @@ SQLPad version:  ${packageJson.version}
 
 CLI examples: 
 
-  sqlpad --dbPath ../db --port 3010 --debug --baseUrl /sqlpad
-  node server.js --dbPath ../db --port 3010 --debug --baseUrl /sqlpad
+  sqlpad --dbPath ../db --port 3010 --baseUrl /sqlpad
+  node server.js --dbPath ../db --port 3010 --baseUrl /sqlpad
   node server.js --config path/to/file.json
   node server.js --config path/to/file.ini
 

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -91,12 +91,6 @@ const configItems = [
     default: ''
   },
   {
-    key: 'debug',
-    envVar: 'SQLPAD_DEBUG',
-    default: false,
-    deprecated: 'To be removed in v5. Set app/web log levels to debug instead.'
-  },
-  {
     key: 'googleClientId',
     envVar: 'GOOGLE_CLIENT_ID',
     default: ''

--- a/server/lib/config/removed-env.js
+++ b/server/lib/config/removed-env.js
@@ -1,0 +1,3 @@
+// This tracks environment variables that used to be supported but no longer are
+// This is to assist erroring for old config no longer supported
+module.exports = ['SQLPAD_DEBUG'];

--- a/server/server.js
+++ b/server/server.js
@@ -22,14 +22,15 @@ appLog.setLevel(config.get('appLogLevel'));
 appLog.debug(config.get(), 'Final config values');
 appLog.debug(config.getConnections(), 'Connections from config');
 
-makeDb(config);
-
+// Validate configuration and warn/error as appropriate
 const configValidations = config.getValidations();
 configValidations.warnings.map(warning => appLog.warn(warning));
 if (configValidations.errors.length > 0) {
   configValidations.errors.forEach(error => appLog.error(error));
   process.exit(1);
 }
+
+makeDb(config);
 
 const baseUrl = config.get('baseUrl');
 const ip = config.get('ip');

--- a/server/test/lib/config.js
+++ b/server/test/lib/config.js
@@ -56,20 +56,39 @@ describe('lib/config/fromFile', function() {
     assert.equal(Object.keys(config).length, 3, '3 items');
   });
 
-  it('Warns for old config file', function() {
+  it('Errors for old config file key', function() {
     const config = new Config(
       { config: path.join(__dirname, '../fixtures/old-config.json') },
       {}
     );
-
     const validations = config.getValidations();
-    assert(validations.warnings);
-    const found = validations.warnings.find(
-      warning =>
-        warning.includes('cert-passphrase') &&
-        warning.includes('NOT RECOGNIZED')
+    assert(validations.errors);
+    const found = validations.errors.find(
+      error =>
+        error.includes('cert-passphrase') && error.includes('NOT RECOGNIZED')
     );
-    assert(found, 'has warning about old key');
+    assert(found, 'has error about old key');
+  });
+
+  it('Errors for old cli flag', function() {
+    const config = new Config({ debug: true }, {});
+    const validations = config.getValidations();
+    assert(validations.errors);
+    const found = validations.errors.find(
+      error => error.includes('debug') && error.includes('NOT RECOGNIZED')
+    );
+    assert(found, 'has error about old key');
+  });
+
+  it('Errors for old env var', function() {
+    const config = new Config({}, { SQLPAD_DEBUG: 'true' });
+    const validations = config.getValidations();
+    assert(validations.errors);
+    const found = validations.errors.find(
+      error =>
+        error.includes('SQLPAD_DEBUG') && error.includes('NOT RECOGNIZED')
+    );
+    assert(found, 'has error about old key');
   });
 
   it('Warns for deprecated config', function() {

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -29,7 +29,6 @@ class TestUtils {
   constructor(args = {}) {
     const config = new Config(
       {
-        debug: true,
         // Despite being in-memory, still need a file path for cache and session files
         // Eventually these will be moved to sqlite and we can be fully-in-memory
         dbPath: TEST_ARTIFACTS_DIR,


### PR DESCRIPTION
Logs error message and prevents application start for unknown config. 

For config files, any key not in config-items or `connections` logs an error message. For environment variables, a list of old env vars is used to track variables that were in use at one point but no longer are. For CLI flags, anything other than a few extra flags (`v`, `version`, `h`, `help`) or keys defined in config items logs an error.

If this becomes too strict these errors can be logged as warnings (or perhaps instead a list of previously used keys is kept and those are looked for specifically)

This PR removes the `debug` flag, which is effectively unused and unnecessary at this point. 