### PR TITLE
Send array of objects for /api/query-history

### DIFF
--- a/client/src/common/QueryResultDataTable.js
+++ b/client/src/common/QueryResultDataTable.js
@@ -102,7 +102,8 @@ class QueryResultDataTable extends React.PureComponent {
       queryResult.fields.forEach(field => {
         if (!columnWidths[field]) {
           const fieldMeta = queryResult.meta[field];
-          let valueLength = fieldMeta.maxValueLength || 10;
+          // (This length is number of characters -- it later gets assigned ~ 20px per char)
+          let valueLength = fieldMeta.maxValueLength || 8;
 
           if (field.length > valueLength) {
             valueLength = field.length;

--- a/client/src/common/QueryResultDataTable.js
+++ b/client/src/common/QueryResultDataTable.js
@@ -102,7 +102,7 @@ class QueryResultDataTable extends React.PureComponent {
       queryResult.fields.forEach(field => {
         if (!columnWidths[field]) {
           const fieldMeta = queryResult.meta[field];
-          let valueLength = fieldMeta.maxValueLength;
+          let valueLength = fieldMeta.maxValueLength || 10;
 
           if (field.length > valueLength) {
             valueLength = field.length;

--- a/server/routes/query-history.js
+++ b/server/routes/query-history.js
@@ -1,50 +1,26 @@
 const router = require('express').Router();
-const { v4: uuidv4 } = require('uuid');
-const getMeta = require('../lib/get-meta');
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const urlFilterToNeDbFilter = require('../lib/url-filter-to-nedb-filter');
 const wrap = require('../lib/wrap');
 
-// TODO v5 - change this to an array of items?
 router.get(
   '/api/query-history',
   mustBeAuthenticated,
   wrap(async function(req, res) {
     const { models } = req;
 
-    const queryHistory = {
-      id: uuidv4(),
-      cacheKey: null,
-      startTime: new Date(),
-      stopTime: null,
-      queryRunTime: null,
-      fields: [],
-      incomplete: false,
-      meta: {},
-      rows: []
-    };
-
     // Convert URL filter to NeDB compatible filter object
     const dbFilter = urlFilterToNeDbFilter(req.query.filter);
     const dbQueryHistory = await models.queryHistory.findByFilter(dbFilter);
 
-    dbQueryHistory.map(q => {
+    const rows = dbQueryHistory.map(q => {
       delete q._id;
       delete q.userId;
       delete q.connectionId;
       return q;
     });
 
-    queryHistory.incomplete =
-      dbQueryHistory.length >= req.config.get('queryHistoryResultMaxRows');
-    queryHistory.rows = dbQueryHistory;
-    queryHistory.stopTime = new Date();
-    queryHistory.queryRunTime =
-      dbQueryHistory.stopTime - dbQueryHistory.startTime;
-    queryHistory.meta = getMeta(dbQueryHistory);
-    queryHistory.fields = Object.keys(queryHistory.meta);
-
-    return res.utils.data(queryHistory);
+    return res.utils.data(rows);
   })
 );
 

--- a/server/test/api/query-history.js
+++ b/server/test/api/query-history.js
@@ -94,9 +94,8 @@ describe('api/query-history', function() {
 
   it('Gets array of 0 items', async function() {
     const body = await utils.get('admin', '/api/query-history');
-    assert(Array.isArray(body.rows), 'queryHistory is an array');
-    assert.equal(body.incomplete, false, 'Complete');
-    assert.equal(body.rows.length, 0, '0 length');
+    TestUtils.validateListSuccessBody(body);
+    assert.equal(body.length, 0, '0 length');
   });
 
   it('Gets array of 4 items', async function() {
@@ -118,8 +117,7 @@ describe('api/query-history', function() {
 
     // Check if every query stored in query history
     const body = await utils.get('admin', '/api/query-history');
-    assert.equal(body.incomplete, false, 'Complete');
-    assert.equal(body.rows.length, 4, '4 length');
+    assert.equal(body.length, 4, '4 length');
 
     // Check if every history entry has every required key
     const historyObjectKeys = [
@@ -137,14 +135,14 @@ describe('api/query-history', function() {
     ];
 
     // First and second two history items (reverse ordered) needs to free text query with queryId and queryName
-    assert.deepEqual(Object.keys(body.rows[3]), historyObjectKeys);
-    assert.deepEqual(Object.keys(body.rows[2]), historyObjectKeys);
+    assert.deepEqual(Object.keys(body[3]), historyObjectKeys);
+    assert.deepEqual(Object.keys(body[2]), historyObjectKeys);
 
     // Third and fourth history items (reverse ordered) needs to saved text query with no queryId and queryName
     historyObjectKeys.splice(historyObjectKeys.indexOf('queryId'), 1);
     historyObjectKeys.splice(historyObjectKeys.indexOf('queryName'), 1);
-    assert.deepEqual(Object.keys(body.rows[1]), historyObjectKeys);
-    assert.deepEqual(Object.keys(body.rows[0]), historyObjectKeys);
+    assert.deepEqual(Object.keys(body[1]), historyObjectKeys);
+    assert.deepEqual(Object.keys(body[0]), historyObjectKeys);
   });
 
   it('Gets filtered array of 2 items', async function() {
@@ -153,8 +151,6 @@ describe('api/query-history', function() {
       'admin',
       '/api/query-history?filter=queryText|regex|QUERY2'
     );
-    assert(Array.isArray(body.rows), 'data is an array');
-    assert.equal(body.incomplete, false, 'Complete');
-    assert.equal(body.rows.length, 2, '2 length');
+    assert.equal(body.length, 2, '2 length');
   });
 });


### PR DESCRIPTION
This tweaks the `/api/query-history` route to send an array of objects instead of a query result object. This is done in an effort to get more APIs following a common convention for the v5 API work started in #609 

The format of the data is adjusted client-side to make it look like a query result object so that we can reuse the table. Not all the variables are being decorated (like start time, incomplete, etc). I wasn't sure if time spent for the query or the incomplete indicator was needed? 

Another minor tweak added was a set height for the grid. Not sure why the flex column stuff isn't working. I always get confused or lost when multiple levels of flexbox are used in column direction.

Here's what the history looks like

![query-history-fixed](https://user-images.githubusercontent.com/303966/79177625-e52bb700-7dc8-11ea-845c-cd55f47cebdb.jpg)
