### PR TITLE
Handle string literals when splitting SQL queries

### DIFF
--- a/server/lib/split-sql.js
+++ b/server/lib/split-sql.js
@@ -18,10 +18,12 @@ function splitSql(sql) {
   lines.forEach(line => {
     const chars = line.split('');
     let inLineComment = false;
+    let inStringLiteral = false;
     for (let i = 0; i < chars.length; i++) {
       const char = chars[i];
       const next = chars[i + 1] || '';
       const both = char + next;
+
       // if we got two dashes this and rest of line is a comment
       if (!inLineComment && both === '--') {
         inLineComment = true;
@@ -33,12 +35,20 @@ function splitSql(sql) {
         inBlockComment = false;
       }
 
+      const inComment = inLineComment || inBlockComment;
+
+      // If not in a comment and string literal starting/ending and is not escaped
+      // toggle string literal
+      if (!inComment && char === "'") {
+        inStringLiteral = !inStringLiteral;
+      }
+
       // add the letter to current query
       currentQuery += char;
 
       // If we reach a separator and not in comment,
       // Add current query to queries and reset current query
-      if (char === ';' && !inBlockComment && !inLineComment) {
+      if (char === ';' && !inComment && !inStringLiteral) {
         queries.push(currentQuery.trim());
         currentQuery = '';
       }

--- a/server/test/lib/split-sql.js
+++ b/server/test/lib/split-sql.js
@@ -67,7 +67,7 @@ describe('lib/splitSql', function() {
 
   it('handles escaped string literals', function() {
     const query = `
-      SELECT 'little bobby ''tables''' AS quoted_string;
+      SELECT 'little bobby ;'';tables;''' AS quoted_string;
     `.trim();
 
     const queries = splitSql(query);

--- a/server/test/lib/split-sql.js
+++ b/server/test/lib/split-sql.js
@@ -1,62 +1,53 @@
 const assert = require('assert');
 const splitSql = require('../../lib/split-sql');
 
-const singleNoSeparator = `
-SELECT value 
-FROM some_table
-`.trim();
-
-const singleWithSeparator = `
-SELECT value 
-FROM some_table;
-`.trim();
-
-const noComments = `
-SELECT value FROM some_table;
-SELECT value FROM another_table;
-`.trim();
-
-const q1 = `
--- this is a comment; it has;stuff
-SELECT value FROM some_table;
-`.trim();
-
-const q2 = `
-/* this query is commented out SELECT SOMETHING ELSE; */
-/* And this one too
-look even an unlikely comment starter again /*
-SELECT * FROM not a query; --SELECT * FROM not a query;
-*/
-
-SELECT 
-  value 
-  --SELECT * FROM not a query;
-FROM 
-  another_table;
-`.trim();
-
-const comments = q1 + q2;
-
 describe('lib/splitSql', function() {
   it('handles single query without separator', function() {
-    const queries = splitSql(singleNoSeparator);
+    const query = 'SELECT value FROM some_table';
+    const queries = splitSql(query);
     assert.strictEqual(queries.length, 1);
-    assert.strictEqual(queries[0], singleNoSeparator);
+    assert.strictEqual(queries[0], query);
   });
 
   it('handles single query with separator', function() {
-    const queries = splitSql(singleWithSeparator);
+    const query = 'SELECT value FROM some_table;';
+    const queries = splitSql(query);
     assert.strictEqual(queries.length, 1);
-    assert.strictEqual(queries[0], singleWithSeparator);
+    assert.strictEqual(queries[0], query);
   });
 
   it('handles queries without comments', function() {
+    const q1 = 'SELECT value FROM some_table;';
+    const q2 = 'SELECT value FROM another_table;';
+    const noComments = `${q1}\n${q2}`;
     const queries = splitSql(noComments);
     assert.strictEqual(queries.length, 2);
-    assert.strictEqual(queries[0], 'SELECT value FROM some_table;');
-    assert.strictEqual(queries[1], 'SELECT value FROM another_table;');
+    assert.strictEqual(queries[0], q1);
+    assert.strictEqual(queries[1], q2);
   });
+
   it('handles complex comments', function() {
+    const q1 = `
+      -- this is a comment; it has;stuff
+      SELECT value FROM some_table;
+    `.trim();
+
+    const q2 = `
+      /* this query is commented out SELECT SOMETHING ELSE; */
+      /* And this one too
+      look even an unlikely comment starter again /*
+      SELECT * FROM not a query; --SELECT * FROM not a query;
+      */
+
+      SELECT 
+        value 
+        --SELECT * FROM not a query;
+      FROM 
+        another_table;
+    `.trim();
+
+    const comments = q1 + '\n' + q2;
+
     const queries = splitSql(comments);
     assert.strictEqual(queries.length, 2);
     assert.strictEqual(queries[0], q1);

--- a/server/test/lib/split-sql.js
+++ b/server/test/lib/split-sql.js
@@ -56,10 +56,31 @@ describe('lib/splitSql', function() {
     assert.strictEqual(queries[0], 'SELECT value FROM some_table;');
     assert.strictEqual(queries[1], 'SELECT value FROM another_table;');
   });
-  it('handles comples comments', function() {
+  it('handles complex comments', function() {
     const queries = splitSql(comments);
     assert.strictEqual(queries.length, 2);
     assert.strictEqual(queries[0], q1);
     assert.strictEqual(queries[1], q2);
+  });
+
+  it('handles string literals', function() {
+    const stringLiteral = `
+      SELECT listagg(DISTINCT t.field, '; ') AS my_agg
+      FROM some_table t
+    `.trim();
+
+    const queries = splitSql(stringLiteral);
+    assert.strictEqual(queries.length, 1);
+    assert.strictEqual(queries[0], stringLiteral);
+  });
+
+  it('handles escaped string literals', function() {
+    const query = `
+      SELECT 'little bobby ''tables''' AS quoted_string;
+    `.trim();
+
+    const queries = splitSql(query);
+    assert.strictEqual(queries.length, 1);
+    assert.strictEqual(queries[0], query);
   });
 });


### PR DESCRIPTION
The splitSql utility detected comments, but failed to check string literals. 

This fix adds support for regular single quote strings, as well as escaping via double-quotes. 

For example:

```sql
SELECT 'little bobby ''tables;''' AS name;
```

This implementation will likely need to get more advanced with specific string escaping in other databases, but I'm hoping these can be gradually added as necessary.