### PR TITLE
Set default connection via configuration

### DIFF
--- a/client/src/Authenticated.js
+++ b/client/src/Authenticated.js
@@ -1,25 +1,24 @@
-import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'unistore/react';
-import { refreshAppContext } from './stores/config';
 import { Redirect } from 'react-router-dom';
+import initApp from './stores/initApp';
 
-function Authenticated({ children, currentUser, refreshAppContext }) {
+function Authenticated({ children, currentUser, initApp, initialized }) {
   useEffect(() => {
-    refreshAppContext();
-  }, [refreshAppContext]);
+    initApp();
+  }, [initApp]);
 
   if (!currentUser) {
     return <Redirect to={{ pathname: '/signin' }} />;
   }
 
+  if (!initialized) {
+    return null;
+  }
+
   return children;
 }
 
-Authenticated.propTypes = {
-  admin: PropTypes.bool
-};
-
-export default connect(['currentUser'], {
-  refreshAppContext
+export default connect(['currentUser', 'initialized'], {
+  initApp
 })(Authenticated);

--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -16,21 +16,12 @@ import QueryEditor from './queryEditor/QueryEditor.js';
 import QueryTableOnly from './QueryTableOnly.js';
 import SignIn from './SignIn.js';
 import SignUp from './SignUp.js';
-import { refreshAppContext } from './stores/config';
-import { initSelectedConnection } from './stores/connections';
-import { initSchema } from './stores/schema';
+import initApp from './stores/initApp';
 
-function Routes({
-  config,
-  refreshAppContext,
-  initSchema,
-  initSelectedConnection
-}) {
+function Routes({ config, initApp }) {
   useEffect(() => {
-    refreshAppContext();
-    initSchema();
-    initSelectedConnection();
-  }, [refreshAppContext, initSchema, initSelectedConnection]);
+    initApp();
+  }, [initApp]);
 
   if (!config) {
     return null;
@@ -94,7 +85,5 @@ function Routes({
 }
 
 export default connect(['config'], {
-  refreshAppContext,
-  initSchema,
-  initSelectedConnection
+  initApp
 })(Routes);

--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -16,12 +16,12 @@ import QueryEditor from './queryEditor/QueryEditor.js';
 import QueryTableOnly from './QueryTableOnly.js';
 import SignIn from './SignIn.js';
 import SignUp from './SignUp.js';
-import initApp from './stores/initApp';
+import { refreshAppContext } from './stores/config';
 
-function Routes({ config, initApp }) {
+function Routes({ config, refreshAppContext }) {
   useEffect(() => {
-    initApp();
-  }, [initApp]);
+    refreshAppContext();
+  }, [refreshAppContext]);
 
   if (!config) {
     return null;
@@ -85,5 +85,5 @@ function Routes({ config, initApp }) {
 }
 
 export default connect(['config'], {
-  initApp
+  refreshAppContext
 })(Routes);

--- a/client/src/stores/connections.js
+++ b/client/src/stores/connections.js
@@ -18,17 +18,6 @@ export const initialState = {
   connectionsLoading: false
 };
 
-export async function initSelectedConnection(state) {
-  const selectedConnectionId = await localforage.getItem(
-    'selectedConnectionId'
-  );
-  if (typeof selectedConnectionId === 'string') {
-    return {
-      selectedConnectionId
-    };
-  }
-}
-
 /**
  * Open a connection client for the currently selected connection if supported
  * @param {*} state

--- a/client/src/stores/initApp.js
+++ b/client/src/stores/initApp.js
@@ -1,0 +1,28 @@
+import localforage from 'localforage';
+import message from '../common/message';
+import { refreshAppContext } from './config';
+
+export default async function initApp() {
+  try {
+    const [showSchema, selectedConnectionId, appContext] = await Promise.all([
+      localforage.getItem('showSchema'),
+      localforage.getItem('selectedConnectionId'),
+      refreshAppContext()
+    ]);
+
+    const update = appContext || {};
+
+    if (typeof selectedConnectionId === 'string') {
+      update.selectedConnectionId = selectedConnectionId;
+    }
+
+    if (typeof showSchema === 'boolean') {
+      update.showSchema = showSchema;
+    }
+
+    return update;
+  } catch (error) {
+    console.error(error);
+    message.error('Error initializing application');
+  }
+}

--- a/client/src/stores/initApp.js
+++ b/client/src/stores/initApp.js
@@ -1,19 +1,59 @@
 import localforage from 'localforage';
 import message from '../common/message';
 import { refreshAppContext } from './config';
+import fetchJson from '../utilities/fetch-json';
+import sortBy from 'lodash/sortBy';
 
-export default async function initApp() {
+window.localforage = localforage;
+
+function sortConnections(connections) {
+  return sortBy(connections, [connection => connection.name.toLowerCase()]);
+}
+
+const initApp = async state => {
   try {
-    const [showSchema, selectedConnectionId, appContext] = await Promise.all([
+    let [
+      showSchema,
+      selectedConnectionId,
+      appContext,
+      connectionsResponse
+    ] = await Promise.all([
       localforage.getItem('showSchema'),
       localforage.getItem('selectedConnectionId'),
-      refreshAppContext()
+      refreshAppContext(),
+      fetchJson('GET', '/api/connections/')
     ]);
 
-    const update = appContext || {};
+    const connections = sortConnections(connectionsResponse.connections || []);
+
+    if (!appContext) {
+      appContext = {};
+    }
+
+    const update = {
+      initialized: true,
+      ...appContext,
+      connections,
+      connectionsLastUpdated: new Date()
+    };
+
+    console.log(connectionsResponse);
+
+    const { defaultConnectionId } = appContext.config || {};
+    if (defaultConnectionId) {
+      const foundDefault = connections.find(c => c._id === defaultConnectionId);
+      if (Boolean(foundDefault)) {
+        update.selectedConnectionId = defaultConnectionId;
+      }
+    }
 
     if (typeof selectedConnectionId === 'string') {
-      update.selectedConnectionId = selectedConnectionId;
+      const selectedConnection = connections.find(
+        c => c._id === selectedConnectionId
+      );
+      if (Boolean(selectedConnection)) {
+        update.selectedConnectionId = selectedConnectionId;
+      }
     }
 
     if (typeof showSchema === 'boolean') {
@@ -25,4 +65,6 @@ export default async function initApp() {
     console.error(error);
     message.error('Error initializing application');
   }
-}
+};
+
+export default initApp;

--- a/client/src/stores/schema.js
+++ b/client/src/stores/schema.js
@@ -8,15 +8,6 @@ export const initialState = {
   schema: {} // schema.<connectionId>.loading / schemaInfo / lastUpdated
 };
 
-export async function initSchema() {
-  const showSchema = await localforage.getItem('showSchema');
-  if (typeof showSchema === 'boolean') {
-    return {
-      showSchema
-    };
-  }
-}
-
 export function toggleSchema(state) {
   const showSchema = !state.showSchema;
   localforage

--- a/config-example.ini
+++ b/config-example.ini
@@ -28,6 +28,9 @@ dbPath=""
 ; Add a variety of logging to console while running SQLPad
 debug="false"
 
+; Default connection to select on SQLPad load if connection not previousy selected.
+defaultConnectionId=''
+
 ; Set to TRUE to disable authentication altogether.
 disableAuth="false"
 

--- a/config-example.json
+++ b/config-example.json
@@ -9,6 +9,7 @@
   "cookieSecret": "secret-used-to-sign-cookies-please-set-and-make-strong",
   "dbPath": "",
   "debug": false,
+  "defaultConnectionId": "",
   "disableAuth": false,
   "disableUserpassAuth": false,
   "editorWordWrap": false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,13 @@ Add a variety of logging to console while running SQLPad
 - Key: `debug`
 - Env: `SQLPAD_DEBUG`
 
+## defaultConnectionId
+
+Default connection to select on SQLPad load if connection not previousy selected. Once selected, connection selections are cached locally in the browser.
+
+- key: `defaultConnectionId`
+- Env: `SQLPAD_DEFAULT_CONNECTION_ID`
+
 ## disableAuth
 
 Set to TRUE to disable authentication altogether.

--- a/server/config.dev.ini
+++ b/server/config.dev.ini
@@ -6,6 +6,7 @@ dbPath = ../db
 appLogLevel = debug
 webLogLevel = debug
 serviceTokenSecret = secr3t
+defaultConnectionId = devdbdriverid123
 
 [connections.devdbdriverid123]
 driver = sqlite

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -97,6 +97,11 @@ const configItems = [
     deprecated: 'To be removed in v5. Set app/web log levels to debug instead.'
   },
   {
+    key: 'defaultConnectionId',
+    envVar: 'SQLPAD_DEFAULT_CONNECTION_ID',
+    default: ''
+  },
+  {
     key: 'googleClientId',
     envVar: 'GOOGLE_CLIENT_ID',
     default: ''
@@ -270,11 +275,6 @@ const configItems = [
   {
     key: 'authProxyHeaders',
     envVar: 'SQLPAD_AUTH_PROXY_HEADERS',
-    default: ''
-  },
-  {
-    key: 'defaultConnectionId',
-    envVar: 'SQLPAD_DEFAULT_CONNECTION_ID',
     default: ''
   }
 ];

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -271,6 +271,11 @@ const configItems = [
     key: 'authProxyHeaders',
     envVar: 'SQLPAD_AUTH_PROXY_HEADERS',
     default: ''
+  },
+  {
+    key: 'defaultConnectionId',
+    envVar: 'SQLPAD_DEFAULT_CONNECTION_ID',
+    default: ''
   }
 ];
 

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -22,14 +22,15 @@ router.get('*/api/app', async (req, res) => {
       adminRegistrationOpen,
       currentUser,
       config: {
-        publicUrl: config.get('publicUrl'),
         allowCsvDownload: config.get('allowCsvDownload'),
-        editorWordWrap: config.get('editorWordWrap'),
         baseUrl: config.get('baseUrl'),
-        smtpConfigured: config.smtpConfigured(),
+        defaultConnectionId: config.get('defaultConnectionId'),
+        editorWordWrap: config.get('editorWordWrap'),
         googleAuthConfigured: config.googleAuthConfigured(),
         localAuthConfigured: !config.get('disableUserpassAuth'),
-        samlConfigured: Boolean(config.get('samlEntryPoint'))
+        publicUrl: config.get('publicUrl'),
+        samlConfigured: Boolean(config.get('samlEntryPoint')),
+        smtpConfigured: config.smtpConfigured()
       },
       version: packageJson.version
     });


### PR DESCRIPTION
Allows a default connection to be set via configuration and reworks the application init logic a bit to better maintain this stuff. If a user selects a connection and that connection is cached, that is used instead. 

Both initial connections are checked to ensure they are valid connections as well, which helps when switching between local sqlpads if you do such a thing (common during dev probably)