### PR TITLE
Default queries filter to all queries instead of my queries

### DIFF
--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -102,7 +102,7 @@ function QueryListDrawer({
 }) {
   const [preview, setPreview] = useState(null);
   const [searches, setSearches] = useState([]);
-  const [creatorSearch, setCreatorSearch] = useState(MY_QUERIES);
+  const [creatorSearch, setCreatorSearch] = useState(ALL);
   const [sort, setSort] = useState('SAVE_DATE');
   const [connectionId, setConnectionId] = useState('');
   const [dimensions, setDimensions] = useState({
@@ -207,7 +207,7 @@ function QueryListDrawer({
             >
               <option value={MY_QUERIES}>My queries</option>
               <option value={SHARED}>Shared with me</option>
-              <option value={ALL}>All</option>
+              <option value={ALL}>All queries</option>
             </Select>
             <Select
               style={{ marginRight: 8 }}


### PR DESCRIPTION
I've gotten some feedback to change this, and giving it some thought I'm kind of torn and can see both sides. 

I don't know which is truly preferred though, and likely won't find out until I make the change and hear otherwise :)

If there are strong feelings for this to stay "my queries" by default, we can introduce another configuration item, or perhaps make this "sticky" and cache the selection in local storage like we do with connection drop down.