### PR TITLE
Schema information fixes and improvements

### DIFF
--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -1,17 +1,13 @@
 import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import SplitPane from 'react-split-pane';
 import { connect } from 'unistore/react';
 import AppHeader from '../app-header/AppHeader';
 import { resizeChart } from '../common/tauChartRef';
 import SchemaSidebar from '../schema/SchemaSidebar.js';
-import {
-  connectConnectionClient,
-  loadConnections
-} from '../stores/connections';
+import { connectConnectionClient } from '../stores/connections';
 import { loadQuery, resetNewQuery } from '../stores/queries';
-import { loadTags } from '../stores/tags';
 import DocumentTitle from './DocumentTitle';
 import QueryEditorChart from './QueryEditorChart';
 import QueryEditorChartToolbar from './QueryEditorChartToolbar';
@@ -21,44 +17,29 @@ import QueryResultHeader from './QueryResultHeader.js';
 import Shortcuts from './Shortcuts';
 import Toolbar from './toolbar/Toolbar';
 import UnsavedQuerySelector from './UnsavedQuerySelector';
+import SchemaInfoLoader from '../schema/SchemaInfoLoader';
 
 const deboucedResearchChart = debounce(resizeChart, 700);
 
 function QueryEditor(props) {
   const {
     connectConnectionClient,
-    loadConnections,
     loadQuery,
-    loadTags,
     queryId,
     resetNewQuery,
     showSchema,
     showVis
   } = props;
 
-  const [initialized, setInitialized] = useState(false);
-
-  useEffect(() => {
-    Promise.all([loadConnections(), loadTags()]).then(() =>
-      setInitialized(true)
-    );
-  }, [loadConnections, loadTags]);
-
   // Once initialized reset or load query on changes accordingly
   useEffect(() => {
-    if (initialized) {
-      if (queryId === 'new') {
-        resetNewQuery();
-        connectConnectionClient();
-      } else {
-        loadQuery(queryId).then(() => connectConnectionClient());
-      }
+    if (queryId === 'new') {
+      resetNewQuery();
+      connectConnectionClient();
+    } else {
+      loadQuery(queryId).then(() => connectConnectionClient());
     }
-  }, [initialized, connectConnectionClient, queryId, resetNewQuery, loadQuery]);
-
-  if (!initialized) {
-    return null;
-  }
+  }, [connectConnectionClient, queryId, resetNewQuery, loadQuery]);
 
   function handleVisPaneResize() {
     deboucedResearchChart(queryId);
@@ -139,14 +120,13 @@ function QueryEditor(props) {
       <UnsavedQuerySelector queryId={queryId} />
       <DocumentTitle queryId={queryId} />
       <Shortcuts />
+      <SchemaInfoLoader />
     </div>
   );
 }
 
 QueryEditor.propTypes = {
-  loadConnections: PropTypes.func.isRequired,
   loadQuery: PropTypes.func.isRequired,
-  loadTags: PropTypes.func.isRequired,
   queryId: PropTypes.string.isRequired,
   resetNewQuery: PropTypes.func.isRequired,
   showSchema: PropTypes.bool,
@@ -167,8 +147,6 @@ function mapStateToProps(state, props) {
 
 export default connect(mapStateToProps, store => ({
   connectConnectionClient: connectConnectionClient(store),
-  loadConnections: loadConnections(store),
   loadQuery,
-  loadTags,
   resetNewQuery
 }))(QueryEditor);

--- a/client/src/schema/SchemaInfoLoader.js
+++ b/client/src/schema/SchemaInfoLoader.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { connect } from 'unistore/react';
+import { loadSchemaInfo } from '../stores/schema';
+
+function mapStateToProps(state, props) {
+  return {
+    connectionId: state.selectedConnectionId
+  };
+}
+
+function mapActions(store) {
+  return {
+    loadSchemaInfo: loadSchemaInfo(store)
+  };
+}
+
+/**
+ * Instead of loading schema on selection,
+ * this is acts as a listener-as-a-component for schema changes.
+ * This is not in the schema sidebar,
+ * because sidebar could be hidden and this is an application-level need
+ * @param {*} props
+ */
+function SchemaInfoLoader({ connectionId, loadSchemaInfo }) {
+  useEffect(() => {
+    if (connectionId) {
+      loadSchemaInfo(connectionId);
+    }
+  }, [connectionId, loadSchemaInfo]);
+
+  return null;
+}
+
+export default connect(mapStateToProps, mapActions)(SchemaInfoLoader);

--- a/client/src/schema/SchemaSidebar.js
+++ b/client/src/schema/SchemaSidebar.js
@@ -1,7 +1,7 @@
 import OpenIcon from 'mdi-react/MenuDownIcon';
 import ClosedIcon from 'mdi-react/MenuRightIcon';
 import RefreshIcon from 'mdi-react/RefreshIcon';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Measure from 'react-measure';
 import { FixedSizeList as List } from 'react-window';
 import { connect } from 'unistore/react';
@@ -50,13 +50,6 @@ function SchemaSidebar({
     width: -1,
     height: -1
   });
-
-  // Load schema on connection changes
-  useEffect(() => {
-    if (connectionId) {
-      loadSchemaInfo(connectionId);
-    }
-  }, [connectionId, loadSchemaInfo]);
 
   const handleRefreshClick = e => {
     e.preventDefault();

--- a/client/src/stores/initApp.js
+++ b/client/src/stores/initApp.js
@@ -13,16 +13,18 @@ function sortConnections(connections) {
 const initApp = async state => {
   try {
     let [
-      showSchema,
       selectedConnectionId,
       appContext,
-      connectionsResponse
+      connectionsResponse,
+      tagsResponse
     ] = await Promise.all([
-      localforage.getItem('showSchema'),
       localforage.getItem('selectedConnectionId'),
       refreshAppContext(),
-      fetchJson('GET', '/api/connections/')
+      fetchJson('GET', '/api/connections/'),
+      fetchJson('GET', '/api/tags')
     ]);
+
+    const availableTags = tagsResponse.tags || [];
 
     const connections = sortConnections(connectionsResponse.connections || []);
 
@@ -32,12 +34,11 @@ const initApp = async state => {
 
     const update = {
       initialized: true,
+      availableTags,
       ...appContext,
       connections,
       connectionsLastUpdated: new Date()
     };
-
-    console.log(connectionsResponse);
 
     const { defaultConnectionId } = appContext.config || {};
     if (defaultConnectionId) {
@@ -54,10 +55,6 @@ const initApp = async state => {
       if (Boolean(selectedConnection)) {
         update.selectedConnectionId = selectedConnectionId;
       }
-    }
-
-    if (typeof showSchema === 'boolean') {
-      update.showSchema = showSchema;
     }
 
     return update;

--- a/client/src/stores/schema.js
+++ b/client/src/stores/schema.js
@@ -1,18 +1,14 @@
-import localforage from 'localforage';
 import message from '../common/message';
 import fetchJson from '../utilities/fetch-json.js';
 import updateCompletions from '../utilities/updateCompletions.js';
 
 export const initialState = {
-  showSchema: false,
+  showSchema: true,
   schema: {} // schema.<connectionId>.loading / schemaInfo / lastUpdated
 };
 
 export function toggleSchema(state) {
   const showSchema = !state.showSchema;
-  localforage
-    .setItem('showSchema', showSchema)
-    .catch(error => message.error(error));
   return {
     showSchema
   };


### PR DESCRIPTION
Loads schema information regardless of whether schema sidebar is shown. This schema information is necessary for auto complete.

This also shows sidebar by default, and removes the caching of sidebar toggle status. Once hidden it'll stay that way for the duration of the tab across new queries and the like, but next visit to SQLPad it'll open again.