### PR TITLE
Fix charts

### DIFF
--- a/client/src/QueryChartOnly.js
+++ b/client/src/QueryChartOnly.js
@@ -68,7 +68,7 @@ function QueryChartOnly({ queryId }) {
         <SqlpadTauChart
           queryId={queryId}
           queryName={query && query.name}
-          chartConfiguration={query && query.chartConfiguration}
+          chartConfiguration={query && query.chart}
           queryResult={queryResult}
           queryError={queryError}
           isRunning={isRunning}

--- a/client/src/common/getTauChartConfig.js
+++ b/client/src/common/getTauChartConfig.js
@@ -24,10 +24,17 @@ const getUnmetFields = (chartType, selectedFieldMap) => {
 };
 
 export default function getTauChartConfig(chartConfiguration, queryResult) {
+  if (!chartConfiguration) {
+    return null;
+  }
   const meta = queryResult ? queryResult.meta : {};
   let dataRows = queryResult ? queryResult.rows : [];
-  const chartType = chartConfiguration && chartConfiguration.chartType;
-  const selectedFields = chartConfiguration && chartConfiguration.fields;
+  const chartType = chartConfiguration.chartType;
+  const selectedFields = chartConfiguration.fields;
+
+  if (!chartType || !selectedFields) {
+    return null;
+  }
 
   const chartDefinition = chartDefinitions.find(
     (def) => def.chartType === chartType

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -137,8 +137,7 @@ function QueryListDrawer({
     const chartUrl = `/query-chart/${query.id}`;
     const queryUrl = `/queries/${query.id}`;
 
-    const hasChart =
-      query && query.chartConfiguration && query.chartConfiguration.chartType;
+    const hasChart = query && query.chart && query.chart.chartType;
 
     return (
       <ListItem

--- a/client/src/queryEditor/ChartInputsContainer.js
+++ b/client/src/queryEditor/ChartInputsContainer.js
@@ -9,14 +9,8 @@ import ChartInputs from './ChartInputs.js';
 function mapStateToProps(state) {
   return {
     queryResult: state.queryResult,
-    chartType:
-      state.query &&
-      state.query.chartConfiguration &&
-      state.query.chartConfiguration.chartType,
-    fields:
-      state.query &&
-      state.query.chartConfiguration &&
-      state.query.chartConfiguration.fields,
+    chartType: state.query && state.query.chart && state.query.chart.chartType,
+    fields: state.query && state.query.chart && state.query.chart.fields,
   };
 }
 

--- a/client/src/queryEditor/ChartTypeSelect.js
+++ b/client/src/queryEditor/ChartTypeSelect.js
@@ -6,10 +6,7 @@ import chartDefinitions from '../utilities/chartDefinitions.js';
 
 function mapStateToProps(state) {
   return {
-    chartType:
-      state.query &&
-      state.query.chartConfiguration &&
-      state.query.chartConfiguration.chartType,
+    chartType: state.query && state.query.chart && state.query.chart.chartType,
   };
 }
 

--- a/client/src/queryEditor/QueryEditor.js
+++ b/client/src/queryEditor/QueryEditor.js
@@ -135,9 +135,7 @@ QueryEditor.propTypes = {
 
 function mapStateToProps(state, props) {
   const showVis =
-    state.query &&
-    state.query.chartConfiguration &&
-    Boolean(state.query.chartConfiguration.chartType);
+    state.query && state.query.chart && Boolean(state.query.chart.chartType);
 
   return {
     showVis,

--- a/client/src/queryEditor/QueryEditorChart.js
+++ b/client/src/queryEditor/QueryEditorChart.js
@@ -7,7 +7,7 @@ function mapStateToProps(state) {
     isRunning: state.isRunning,
     queryError: state.queryError,
     queryResult: state.queryResult,
-    chartConfiguration: state.query && state.query.chartConfiguration,
+    chartConfiguration: state.query && state.query.chart,
   };
 }
 

--- a/client/src/stores/queries.js
+++ b/client/src/stores/queries.js
@@ -14,7 +14,7 @@ export const NEW_QUERY = {
   tags: [],
   connectionId: '',
   queryText: '',
-  chartConfiguration: {
+  chart: {
     chartType: '',
     fields: {}, // key value for chart
   },
@@ -234,12 +234,12 @@ export const handleChartConfigurationFieldsChange = (
   queryResultField
 ) => {
   const { query } = state;
-  const { fields } = query.chartConfiguration;
+  const { fields } = query.chart;
   return {
     query: {
       ...query,
-      chartConfiguration: {
-        ...query.chartConfiguration,
+      chart: {
+        ...query.chart,
         fields: { ...fields, [chartFieldId]: queryResultField },
       },
     },
@@ -252,7 +252,7 @@ export const handleChartTypeChange = (state, chartType) => {
   return {
     query: {
       ...query,
-      chartConfiguration: { ...query.chartConfiguration, chartType },
+      chart: { ...query.chart, chartType },
     },
     unsavedChanges: true,
   };

--- a/server/models/queries.js
+++ b/server/models/queries.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 /*
-"chartConfiguration": {
+"chart": {
     "chartType": "line",
     "fields": {
         "x": "created_month",

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -70,7 +70,7 @@ router.get('/api/queries/:id', mustBeAuthenticated, wrap(getQuery));
  */
 async function createQuery(req, res) {
   const { models, body, user } = req;
-  const { name, tags, connectionId, queryText, chartConfiguration, acl } = body;
+  const { name, tags, connectionId, queryText, chart, acl } = body;
   const { email } = user;
 
   const query = {
@@ -78,7 +78,7 @@ async function createQuery(req, res) {
     tags,
     connectionId,
     queryText,
-    chartConfiguration,
+    chart,
     createdBy: email,
     updatedBy: email,
     acl,
@@ -112,14 +112,14 @@ async function updateQuery(req, res) {
     return res.utils.forbidden();
   }
 
-  const { name, tags, connectionId, queryText, chartConfiguration, acl } = body;
+  const { name, tags, connectionId, queryText, chart, acl } = body;
 
   Object.assign(query, {
     name,
     tags,
     connectionId,
     queryText,
-    chartConfiguration,
+    chart,
     updatedBy: user.email,
     acl,
   });

--- a/server/test/api/queries.js
+++ b/server/test/api/queries.js
@@ -7,7 +7,7 @@ const createQueryBody = {
   tags: ['one', 'two'],
   connectionId: 'someConnectionId',
   queryText: 'SELECT * FROM some_table',
-  chartConfiguration: {
+  chart: {
     chartType: 'line',
     fields: {
       x: 'field1',

--- a/server/test/fixtures/seed-data/queries/seed-query-2.json
+++ b/server/test/fixtures/seed-data/queries/seed-query-2.json
@@ -3,6 +3,5 @@
   "name": "Seed query 2",
   "connectionId": "seed-connection-1",
   "queryText": "SELECT * FROM seed_table",
-  "chartConfiguration": {},
   "createdBy": "admin@sqlpad.com"
 }


### PR DESCRIPTION
Fixes chart loading/saving due to incorrect references to old `query.chartConfiguration` field. With v5 work the field was shortened to `query.chart`.