### PR TITLE
Issue 634 - BigQuery column descriptions

### DIFF
--- a/client/src/common/Tooltip.js
+++ b/client/src/common/Tooltip.js
@@ -2,6 +2,6 @@ import React from 'react';
 import ReachTooltip from '@reach/tooltip';
 import '@reach/tooltip/styles.css';
 
-export default function Tooltip({ children, label }) {
-  return <ReachTooltip label={label}>{children}</ReachTooltip>;
+export default function Tooltip({ children, ...otherProps }) {
+  return <ReachTooltip {...otherProps}>{children}</ReachTooltip>;
 }

--- a/client/src/schema/SchemaSidebar.js
+++ b/client/src/schema/SchemaSidebar.js
@@ -16,6 +16,7 @@ import getSchemaList from './getSchemaList';
 import styles from './SchemaSidebar.module.css';
 import searchSchemaInfo from './searchSchemaInfo';
 import ErrorBlock from '../common/ErrorBlock';
+import Tooltip from '../common/Tooltip';
 
 const ICON_SIZE = 22;
 const ICON_STYLE = { marginBottom: -6, marginRight: -6, marginLeft: -4 };
@@ -101,9 +102,22 @@ function SchemaSidebar({
       );
     }
     if (row.type === 'column') {
-      let secondary = ` ${row.dataType}`;
+      const secondary = [<span key="colType"> {row.dataType}</span>];
+
       if (row.description) {
-        secondary += ` - ${row.description}`;
+        const description = (
+          <Tooltip
+            key="colDesc"
+            label={row.description}
+            style={{
+              'max-width': '300px',
+              'white-space': 'normal',
+            }}
+          >
+            <span className={styles.description}> - {row.description}</span>
+          </Tooltip>
+        );
+        secondary.push(description);
       }
       return (
         <li

--- a/server/drivers/bigquery/index.js
+++ b/server/drivers/bigquery/index.js
@@ -152,6 +152,7 @@ function getSchema(connection) {
             table_name: tableId,
             column_name: field.name,
             data_type: field.type,
+            column_description: field.description,
           });
         }
       }

--- a/server/drivers/utils.js
+++ b/server/drivers/utils.js
@@ -42,6 +42,7 @@ function formatSchemaQueryResults(queryResult) {
           {
             column_name: "the column name",
             data_type: "string"
+            column_description: "an optional description"
           }
         ]
       }


### PR DESCRIPTION
@rickbergfalk So this was simple except that some of our columns require long descriptions that can't be seen fully even when the sidebar is maximized.

You will see that I had to tweak your existing Tooltip component in order to get wrapped text. The underlying Reach UI Tooltip doesn't behave well with long text, but at least it allows style to be passed to it. (The Reach UI Tooltip sets `white-space` to `nowrap` and displays long tooltips truncated on one line ... oh, well.)

Here are a couple of screenshots:

**Basic column description display**:

<img width="316" alt="bigquery-col-desc" src="https://user-images.githubusercontent.com/928642/82383565-17e65200-99fc-11ea-82c6-42316cc97207.png">

** Hovering over the second column description**:

<img width="457" alt="bigquery-col-desc-tooltip" src="https://user-images.githubusercontent.com/928642/82383485-e66d8680-99fb-11ea-8b9c-6359b9ce3031.png">
