### PR TITLE
Sessionless is admin or editor

### DIFF
--- a/config-example.ini
+++ b/config-example.ini
@@ -34,6 +34,10 @@ defaultConnectionId=''
 ; Set to TRUE to disable authentication altogether.
 disableAuth="false"
 
+; Specifies the role associated with users when disableAuth is set to true.
+; Acceptable values: admin, editor
+disableAuthDefaultRole="editor"
+
 ; Set to TRUE to disable built-in user authentication. Use to restrict auth to OAuth only.
 disableUserpassAuth="false"
 

--- a/config-example.json
+++ b/config-example.json
@@ -10,6 +10,7 @@
   "dbPath": "",
   "defaultConnectionId": "",
   "disableAuth": false,
+  "disableAuthDefaultRole": "editor",
   "disableUserpassAuth": false,
   "editorWordWrap": false,
   "googleClientId": "",

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -18,7 +18,9 @@ Local authentication can be disabled by setting `disableUserpassAuth` to `true`.
 
 ?> Available as of `4.2.0`
 
-SQLPad can be configured to run without any configuration at all. This can be enabled by setting `disableAuth` to `true`.
+SQLPad can be configured to run without any authentication at all. This can be enabled by setting `disableAuth` to `true`. 
+
+If enabled, `disableAuthDefaultRole` is used to assign admin or editor role to users. You'd want to configure connections via configuration file or environment variables if `disableAuthDefaultRole` is `editor`.
 
 ## Auth Proxy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,14 @@ Set to TRUE to disable authentication altogether.
 - Key: `disableAuth`
 - Env: `DISABLE_AUTH`
 
+## disableAuthDefaultRole
+
+Specifies the role associated with users when disableAuth is set to true.
+Acceptable values: admin, editor
+
+- Key: `disableAuthDefaultRole`
+- Env: `SQLPAD_DISABLE_AUTH_DEFAULT_ROLE`
+  
 ## disableUserpassAuth
 
 Set to TRUE to disable built-in user authentication. Probably desired when using other auths like OAuth or SAML.

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -126,6 +126,11 @@ const configItems = [
     default: false,
   },
   {
+    key: 'disableAuthDefaultRole',
+    envVar: 'SQLPAD_DISABLE_AUTH_DEFAULT_ROLE',
+    default: 'editor',
+  },
+  {
     key: 'allowCsvDownload',
     envVar: 'SQLPAD_ALLOW_CSV_DOWNLOAD',
     default: true,

--- a/server/middleware/sessionless-auth.js
+++ b/server/middleware/sessionless-auth.js
@@ -46,7 +46,8 @@ function sessionlessAuth(req, res, next) {
   if (config.get('disableAuth')) {
     req.user = {
       id: 'noauth',
-      role: 'admin',
+      role:
+        config.get('disableAuthDefaultRole') === 'admin' ? 'admin' : 'editor',
       email: 'test@example.com',
     };
     return next();


### PR DESCRIPTION
Here's my attempt at solving #645.

So this changes legacy behavior in that that the default is for sessionless users is now "Editor" and not "Admin".

The "history" page is still available which is suboptimal.
