### PR TITLE
Fix incorrect mssql driver docker example

### DIFF
--- a/docker-examples/mssql-docker-compose/config.json
+++ b/docker-examples/mssql-docker-compose/config.json
@@ -6,7 +6,7 @@
   "connections": {
     "sql-server-demo": {
       "name": "sql server demo",
-      "driver": "mssql",
+      "driver": "sqlserver",
       "host": "mssql",
       "database": "master",
       "username": "sa",


### PR DESCRIPTION
[MS SQL's driver is called `sqlserver`, not `mssql`.][1]

Since the actual driver is referred to as "SQL Server" and not "MS SQL", in both the [documentation][1] and [code][2], it might be worth renaming the example from `mssql-docker-compose` to `sqlserver-docker-compose` for better consistency.

As someone who stumbled upon this project and wanted to try it out, without reading too much into it, I sure was fooled. :)

[1]: https://rickbergfalk.github.io/sqlpad/#/connections?id=sql-server
[2]: https://github.com/rickbergfalk/sqlpad/tree/master/server/drivers/sqlserver