### PR TITLE
fix: Docker image was ignoring SQLPAD_DB_PATH

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec node /usr/app/server.js --dbPath /var/lib/sqlpad --port 3000 $@
+exec node /usr/app/server.js --dbPath ${SQLPAD_DB_PATH:-/var/lib/sqlpad} --port 3000 $@


### PR DESCRIPTION
If `SQLPAD_DB_PATH` is not specified, then the default is used