### PR TITLE
enable external DB for backend

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,13 @@ If enabled, runs embedded database `nedb` in memory. `dbPath` is still required 
 - Key: `dbInMemory`
 - Env: `SQLPAD_DB_IN_MEMORY`
 
+## backendDatabaseUri
+
+(Experimental) You can specify an external database to be used instead of the local sqlite database, by specifing a [Sequelize](https://sequelize.org/v5/) connection string. Supported databases are: mysql, mariadb, sqlite3, mssql. Some options can be provided in the connection string. Example: `mariadb://username:password@host:port/databasename?ssl=true`
+
+- Key: `backendDatabaseUri`
+- Env: `SQLPAD_BACKEND_DB_URI`
+
 ## defaultConnectionId
 
 Default connection to select on SQLPad load if connection not previousy selected. Once selected, connection selections are cached locally in the browser.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,9 @@ Thinking SQLPad is for you? Here's a quick rundown of what you'll want to know.
 
 There are 2 options to run SQLPad: Install [Node.js](https://nodejs.org/) and [build and run SQLPad from the git repository](https://github.com/rickbergfalk/sqlpad/blob/master/DEVELOPER-GUIDE.md), or use the [docker images on Docker Hub](https://hub.docker.com/r/sqlpad/sqlpad/).
 
-SQLPad does not rely on any additional servers other than its own self. It uses its own embedded database stored on the local file system (which makes it easy to run, but not so easy to scale up). Today the database is a mix of [nedb](https://github.com/louischatriot/nedb) and [SQLite](https://www.sqlite.org/index.html), with the intention of moving all data into SQLite.
+SQLPad does not require any additional servers other than its own self. It uses its own embedded database stored on the local file system (which makes it easy to run, but not so easy to scale up). Today the database is a mix of [nedb](https://github.com/louischatriot/nedb) and [SQLite](https://www.sqlite.org/index.html), with the intention of moving all data into SQLite.
+
+(Experimental) You can replace the SQLite database with an external database, using the SQLPAD_BACKEND_DB_URI environment variable.
 
 The docker image runs on port 3000 by default and stores its local database files at `/var/lib/sqlpad`. See [docker-examples](https://github.com/rickbergfalk/sqlpad/tree/master/docker-examples) directory for example docker-compose setup with SQL Server.
 

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -241,6 +241,11 @@ const configItems = [
     default: false,
   },
   {
+    key: 'backendDatabaseUri',
+    envVar: 'SQLPAD_BACKEND_DB_URI',
+    default: '',
+  },
+  {
     key: 'seedDataPath',
     envVar: 'SQLPAD_SEED_DATA_PATH',
     default: '',

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -199,6 +199,11 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
+    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -3196,6 +3201,48 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "mariadb": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-2.4.0.tgz",
+      "integrity": "sha512-78zrj9SpF6I3eVWMMkdm+SEfcsMb/uWVKPo7pKhhCfuGywEf3I1dK0ewSTjD0SyTEgSEuWn/H/I4TIErGgYTCQ==",
+      "requires": {
+        "@types/geojson": "^7946.0.7",
+        "@types/node": "^13.9.8",
+        "denque": "^1.4.1",
+        "iconv-lite": "^0.5.1",
+        "long": "^4.0.0",
+        "moment-timezone": "^0.5.31",
+        "please-upgrade-node": "^3.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.10.tgz",
+          "integrity": "sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q=="
+        },
+        "iconv-lite": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
+          "integrity": "sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "long": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "moment-timezone": {
+          "version": "0.5.31",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+          "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+          "requires": {
+            "moment": ">= 2.9.0"
+          }
+        }
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -4538,6 +4585,14 @@
         "find-up": "^2.1.0"
       }
     },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -4925,6 +4980,11 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "send": {
       "version": "0.17.1",

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "ini": "^1.3.5",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
+    "mariadb": "^2.4.0",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "moment": "^2.26.0",

--- a/server/sequelize-db/index.js
+++ b/server/sequelize-db/index.js
@@ -6,16 +6,19 @@ class SequelizeDb {
   constructor(config) {
     this.config = config;
 
-    const sequelize = new Sequelize({
-      dialect: 'sqlite',
+    const connectionUri =
+      config.get('backendDatabaseUri') ||
+      'sqlite:' +
+        (config.get('dbInMemory')
+          ? ':memory:'
+          : path.join(config.get('dbPath'), 'sqlpad.sqlite'));
+
+    const sequelize = new Sequelize(connectionUri, {
       // sequelize may pass more than message,
       // but it appears to be the sequelize object and it is quite excessive
       logging: (message) => {
         appLog.debug(message);
       },
-      storage: config.get('dbInMemory')
-        ? ':memory:'
-        : path.join(config.get('dbPath'), 'sqlpad.sqlite'),
     });
 
     this.sequelize = sequelize;


### PR DESCRIPTION
I started this because of #667 and because I saw many docker apps doing the same and I think it would help scaling.

This PR adds configuration `SQLPAD_BACKEND_DB_URI`/`backendDatabaseUri` where one can specify an external database to be used for storing users, queries, etc, instead of sqlite.

This connecting string works for me

        SQLPAD_BACKEND_DB_URI=mariadb://user:password@hostname:port/dbname?debug=true&ssl=true

I added mariadb driver because it supports `ssl=true` on the connection string. Sequalize uses `mysql2` driver (if the connection string starts with `mysql://`) but I was not able to force ssl which is required in the environment I'm in. 