### PR TITLE
lint in github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+
+name: lint
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm install --prefix client
+      - run: npm install --prefix server
+      - run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ cache:
 install:
   - scripts/build.sh
 script:
-  - npm run lint
   - npm run test --prefix server


### PR DESCRIPTION
This is my attempt at moving the lint action from travis-ci.org to a dedicated github action. The benefit would be that the travis-ci will be able to run in parallel jobs (for tests only); and the linter rejects will be easy to detect on github GUI.