### PR TITLE
Adds ODBC limit_strategies and fix connection form

### DIFF
--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -61,13 +61,23 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
     setConnectionEdits((prev) => ({ ...prev, [key]: value }));
   };
 
+  const setConnectionDataValue = (key, value) => {
+    setConnectionEdits((prev) => {
+      const data = prev.data || {};
+      return {
+        ...prev,
+        data: { ...data, [key]: value },
+      };
+    });
+  };
+
   const testConnection = async () => {
     setTesting(true);
-    const json = await fetchJson(
-      'POST',
-      '/api/test-connection',
-      connectionEdits
-    );
+    const data = connectionEdits.data || {};
+    const json = await fetchJson('POST', '/api/test-connection', {
+      ...connectionEdits,
+      ...data,
+    });
     setTesting(false);
     setTestFailed(json.error ? true : false);
     setTestSuccess(json.error ? false : true);
@@ -167,22 +177,30 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
       }
 
       const { fields } = driver;
+      const connectionEditsData = connectionEdits.data || {};
       const driverInputs = fields.map((field) => {
         if (field.formType === TEXT) {
-          const value = connectionEdits[field.key] || '';
+          const value = connectionEditsData[field.key] || '';
           return (
             <HorizontalFormItem key={field.key} label={field.label}>
               <Input
                 name={field.key}
                 value={value}
                 onChange={(e) =>
-                  setConnectionValue(e.target.name, e.target.value)
+                  setConnectionDataValue(e.target.name, e.target.value)
                 }
               />
+              {field.description && (
+                <FormExplain>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: field.description }}
+                  />
+                </FormExplain>
+              )}
             </HorizontalFormItem>
           );
         } else if (field.formType === PASSWORD) {
-          const value = connectionEdits[field.key] || '';
+          const value = connectionEditsData[field.key] || '';
           // autoComplete='new-password' used to prevent browsers from autofilling username and password
           // Because we dont return a password, Chrome goes ahead and autofills
           return (
@@ -193,13 +211,20 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
                 name={field.key}
                 value={value}
                 onChange={(e) =>
-                  setConnectionValue(e.target.name, e.target.value)
+                  setConnectionDataValue(e.target.name, e.target.value)
                 }
               />
+              {field.description && (
+                <FormExplain>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: field.description }}
+                  />
+                </FormExplain>
+              )}
             </HorizontalFormItem>
           );
         } else if (field.formType === CHECKBOX) {
-          const checked = connectionEdits[field.key] || false;
+          const checked = connectionEditsData[field.key] || false;
           return (
             <HorizontalFormItem key={field.key}>
               <input
@@ -208,16 +233,23 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
                 id={field.key}
                 name={field.key}
                 onChange={(e) =>
-                  setConnectionValue(e.target.name, e.target.checked)
+                  setConnectionDataValue(e.target.name, e.target.checked)
                 }
               />
               <label htmlFor={field.key} style={{ marginLeft: 8 }}>
                 {field.label}
               </label>
+              {field.description && (
+                <FormExplain>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: field.description }}
+                  />
+                </FormExplain>
+              )}
             </HorizontalFormItem>
           );
         } else if (field.formType === TEXTAREA) {
-          const value = connectionEdits[field.key] || '';
+          const value = connectionEditsData[field.key] || '';
           return (
             <HorizontalFormItem key={field.key} label={field.label}>
               <TextArea
@@ -226,9 +258,16 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
                 cols={45}
                 placeholder={field.placeholder}
                 onChange={(e) =>
-                  setConnectionValue(e.target.name, e.target.value)
+                  setConnectionDataValue(e.target.name, e.target.value)
                 }
               />
+              {field.description && (
+                <FormExplain>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: field.description }}
+                  />
+                </FormExplain>
+              )}
             </HorizontalFormItem>
           );
         }

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -466,5 +466,14 @@ ORDER BY
     <tr><td>schema_sql</td><td>Database SQL to lookup schema (optional, if omitted default to checking INFORMATION_SCHEMA)</td><td>text</td></tr>
     <tr><td>username</td><td>Username (optional). Will be added to connect_string as <code>Uid</code> key</td><td>text</td></tr>
     <tr><td>password</td><td>Password (optional). Will be added to connect_string as <code>Pwd</docd> key</td><td>text</td></tr>
+    <tr>
+      <td>limit_strategies</td>
+      <td>Comma separated list of limit strategies used to restrict queries. 
+      These strategies will be used to enforce and inject LIMIT and FETCH FIRST use in SELECT queries.
+      Allowed strategies are <code>limit</code>, <code>fetch</code>, and <code>first</code>.
+      <br/><br/>
+      Example: <code>limit, fetch</code></td>
+      <td>text</td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adds `limit_strategies` option for unix odbc connections. The comma-separated-list of strategies are validated and passed on to [sql-limiter](https://github.com/rickbergfalk/sql-limiter) to enforce a row limit at the SQL level.

This also adds a description property to driver fields. If set, description text is shown below the form.
![connection-form](https://user-images.githubusercontent.com/303966/84090784-50a09800-a9b8-11ea-9ff2-79029e8002bf.jpg)

During this work I also realized what is wrong with #657 and resolved that bug.

closes #657 