### PR TITLE
Display test connection error

### DIFF
--- a/server/routes/test-connection.js
+++ b/server/routes/test-connection.js
@@ -19,7 +19,7 @@ router.post(
       await connectionClient.testConnection();
       res.utils.data();
     } catch (error) {
-      res.utils.error('Test failed');
+      res.utils.error(error);
     }
   })
 );


### PR DESCRIPTION
Displays reason for test connection failure if test fails. The message may return something database related, but it could also return an error message from the driver/api implementation too, which might not make sense to the end user. 

Regardless the error should provide some guidance as to what might need fixing.

![connection-form-error](https://user-images.githubusercontent.com/303966/84108715-75136900-a9e6-11ea-9124-f872377bd078.jpg)

closes #656 