### PR TITLE
hide old error message while testing

### DIFF
--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -347,7 +347,7 @@ function ConnectionForm({ connectionId, onConnectionSaved }) {
 
         {renderDriverFields()}
       </div>
-      {testError && (
+      {!testing && testError && (
         <div>
           <ErrorBlock>{testError}</ErrorBlock>
         </div>


### PR DESCRIPTION
so now when user clicks "Test", the old error message is hidden while the test is being conducted.