### PR TITLE
Use SWR for more GET requests

### DIFF
--- a/client/src/connectionAccesses/ConnectionAccessForm.js
+++ b/client/src/connectionAccesses/ConnectionAccessForm.js
@@ -11,21 +11,21 @@ function ConnectionAccessForm({ onConnectionAccessSaved }) {
   const [connectionAccessEdits, setConnectionAccessEdits] = useState({});
   const [creating, setCreating] = useState(false);
 
-  let { data: connectionsRes } = useSWR('/api/connections');
+  let { data: apiConnections } = useSWR('/api/connections');
   const connections = [
     {
       id: '__EVERY_CONNECTION__',
       name: 'Every Connection',
     },
-  ].concat(connectionsRes ? connectionsRes.data : []);
+  ].concat(apiConnections || []);
 
-  let { data: usersRes } = useSWR('/api/users');
+  let { data: apiUsers } = useSWR('/api/users');
   const users = [
     {
       id: '__EVERYONE__',
       email: 'Everyone',
     },
-  ].concat(usersRes ? usersRes.data : []);
+  ].concat(apiUsers || []);
 
   const setConnectionAccessValue = (key, value) => {
     setConnectionAccessEdits((prev) => ({ ...prev, [key]: value }));

--- a/client/src/connectionAccesses/ConnectionAccessForm.js
+++ b/client/src/connectionAccesses/ConnectionAccessForm.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import useSWR from 'swr';
 import Button from '../common/Button';
 import HorizontalFormItem from '../common/HorizontalFormItem.js';
 import Input from '../common/Input';
@@ -8,45 +9,23 @@ import fetchJson from '../utilities/fetch-json.js';
 
 function ConnectionAccessForm({ onConnectionAccessSaved }) {
   const [connectionAccessEdits, setConnectionAccessEdits] = useState({});
-  const [connections, setConnections] = useState([]);
-  const [users, setUsers] = useState([]);
   const [creating, setCreating] = useState(false);
 
-  async function getConnections() {
-    const json = await fetchJson('GET', '/api/connections');
-    if (json.error) {
-      message.error(json.error);
-    } else {
-      const connections = json.data;
-      connections.unshift({
-        id: '__EVERY_CONNECTION__',
-        name: 'Every Connection',
-      });
-      setConnections(connections);
-    }
-  }
+  let { data: connectionsRes } = useSWR('/api/connections');
+  const connections = [
+    {
+      id: '__EVERY_CONNECTION__',
+      name: 'Every Connection',
+    },
+  ].concat(connectionsRes ? connectionsRes.data : []);
 
-  useEffect(() => {
-    getConnections();
-  }, []);
-
-  async function getUsers() {
-    const json = await fetchJson('GET', '/api/users');
-    if (json.error) {
-      message.error(json.error);
-    } else {
-      const users = json.data;
-      users.unshift({
-        id: '__EVERYONE__',
-        email: 'Everyone',
-      });
-      setUsers(users);
-    }
-  }
-
-  useEffect(() => {
-    getUsers();
-  }, []);
+  let { data: usersRes } = useSWR('/api/users');
+  const users = [
+    {
+      id: '__EVERYONE__',
+      email: 'Everyone',
+    },
+  ].concat(usersRes ? usersRes.data : []);
 
   const setConnectionAccessValue = (key, value) => {
     setConnectionAccessEdits((prev) => ({ ...prev, [key]: value }));

--- a/client/src/connectionAccesses/ConnectionAccessList.js
+++ b/client/src/connectionAccesses/ConnectionAccessList.js
@@ -19,8 +19,8 @@ function ConnectionAccessList({ currentUser }) {
     url = url + '?includeInactives=true';
   }
 
-  let { data: caRes, mutate } = useSWR(url);
-  const connectionAccesses = caRes ? caRes.data : [];
+  let { data: caData, mutate } = useSWR(url);
+  const connectionAccesses = caData || [];
 
   const toggleShowInactives = () => {
     setShowInactives(!showInactives);
@@ -44,7 +44,7 @@ function ConnectionAccessList({ currentUser }) {
           }
         })
       : connectionAccesses.filter((item) => item.id !== connectionAccessId);
-    mutate({ data: updated });
+    mutate(updated);
     if (json.error) {
       return message.error('Expire Failed: ' + json.error.toString());
     }
@@ -56,7 +56,7 @@ function ConnectionAccessList({ currentUser }) {
 
   const handleConnectionAccessSaved = (connectionAccess) => {
     const updated = [connectionAccess].concat(connectionAccesses);
-    mutate({ data: updated });
+    mutate(updated);
     setShowAccessCreate(false);
   };
 

--- a/client/src/connectionAccesses/ConnectionAccessList.js
+++ b/client/src/connectionAccesses/ConnectionAccessList.js
@@ -1,39 +1,26 @@
-import React, { useEffect, useState } from 'react';
-import { connect } from 'unistore/react';
 import humanizeDuration from 'humanize-duration';
+import React, { useState } from 'react';
+import useSWR from 'swr';
+import { connect } from 'unistore/react';
 import Button from '../common/Button';
 import DeleteConfirmButton from '../common/DeleteConfirmButton';
 import ListItem from '../common/ListItem';
+import message from '../common/message';
 import Text from '../common/Text';
 import fetchJson from '../utilities/fetch-json';
-import message from '../common/message';
 import ConnectionAccessCreateDrawer from './ConnectionAccessCreateDrawer';
 
 function ConnectionAccessList({ currentUser }) {
-  const [connectionAccesses, setConnectionAccesses] = useState([]);
   const [showInactives, setShowInactives] = useState(false);
-  const [expiredConnectionAccessId, setExpiredConnectionAccessId] = useState(
-    null
-  );
-  const [newConnectionAccessId, setNewConnectionAccessId] = useState(null);
   const [showAccessCreate, setShowAccessCreate] = useState(false);
 
-  useEffect(() => {
-    async function getConnectionAccesses() {
-      let url = `/api/connection-accesses`;
-      if (showInactives) {
-        url = url + '?includeInactives=true';
-      }
-      const json = await fetchJson('GET', url);
-      if (json.error) {
-        message.error(json.error);
-      } else {
-        setConnectionAccesses(json.data);
-      }
-    }
+  let url = `/api/connection-accesses`;
+  if (showInactives) {
+    url = url + '?includeInactives=true';
+  }
 
-    getConnectionAccesses();
-  }, [showInactives, newConnectionAccessId, expiredConnectionAccessId]);
+  let { data: caRes, mutate } = useSWR(url);
+  const connectionAccesses = caRes ? caRes.data : [];
 
   const toggleShowInactives = () => {
     setShowInactives(!showInactives);
@@ -48,10 +35,19 @@ function ConnectionAccessList({ currentUser }) {
       'PUT',
       `/api/connection-accesses/${connectionAccessId}/expire`
     );
+    const updated = showInactives
+      ? connectionAccesses.map((item) => {
+          if (item.id === connectionAccessId) {
+            return json.data;
+          } else {
+            return item;
+          }
+        })
+      : connectionAccesses.filter((item) => item.id !== connectionAccessId);
+    mutate({ data: updated });
     if (json.error) {
       return message.error('Expire Failed: ' + json.error.toString());
     }
-    setExpiredConnectionAccessId(connectionAccessId);
   };
 
   const handleCreateDrawerClose = () => {
@@ -59,8 +55,9 @@ function ConnectionAccessList({ currentUser }) {
   };
 
   const handleConnectionAccessSaved = (connectionAccess) => {
+    const updated = [connectionAccess].concat(connectionAccesses);
+    mutate({ data: updated });
     setShowAccessCreate(false);
-    setNewConnectionAccessId(connectionAccess.id);
   };
 
   return (

--- a/client/src/connections/ConnectionForm.js
+++ b/client/src/connections/ConnectionForm.js
@@ -1,6 +1,7 @@
 import SuccessIcon from 'mdi-react/CheckboxMarkedCircleOutlineIcon';
 import CloseCircleOutlineIcon from 'mdi-react/CloseCircleOutlineIcon';
 import React, { useEffect, useState } from 'react';
+import useSWR from 'swr';
 import Button from '../common/Button';
 import ErrorBlock from '../common/ErrorBlock.js';
 import FormExplain from '../common/FormExplain';
@@ -19,25 +20,14 @@ const TEXTAREA = 'TEXTAREA';
 
 function ConnectionForm({ connectionId, onConnectionSaved }) {
   const [connectionEdits, setConnectionEdits] = useState({});
-  const [drivers, setDrivers] = useState([]);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
   const [tested, setTested] = useState(false);
   const [testError, setTestError] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  async function getDrivers() {
-    const json = await fetchJson('GET', '/api/drivers');
-    if (json.error) {
-      message.error(json.error);
-    } else {
-      setDrivers(json.data);
-    }
-  }
-
-  useEffect(() => {
-    getDrivers();
-  }, []);
+  let { data: drivers } = useSWR('/api/drivers');
+  drivers = drivers || [];
 
   async function getConnection(connectionId) {
     if (connectionId) {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,22 +1,28 @@
 import './css/reset.css';
 import '@reach/dialog/styles.css';
 import '@reach/menu-button/styles.css';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { SWRConfig } from 'swr';
+import { Provider } from 'unistore/react';
+import { MessageDisplayer } from './common/message';
 import './css/index.css';
 import './css/react-split-pane.css';
 import './css/vendorOverrides.css';
-import React from 'react';
-import ReactDOM from 'react-dom';
 import Routes from './Routes';
 import unistoreStore from './stores/unistoreStore';
-import { Provider } from 'unistore/react';
-import { MessageDisplayer } from './common/message';
+import swrFetcher from './utilities/swr-fetcher';
 
 ReactDOM.render(
   <Provider store={unistoreStore}>
-    <>
+    <SWRConfig
+      value={{
+        fetcher: swrFetcher,
+      }}
+    >
       <Routes />
       <MessageDisplayer />
-    </>
+    </SWRConfig>
   </Provider>,
   document.getElementById('root')
 );

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -20,7 +20,6 @@ import Select from '../common/Select';
 import SpinKitCube from '../common/SpinKitCube.js';
 import Text from '../common/Text';
 import fetchJson from '../utilities/fetch-json';
-import swrFetcher from '../utilities/swr-fetcher';
 import styles from './QueryList.module.css';
 import QueryPreview from './QueryPreview';
 
@@ -107,10 +106,10 @@ function QueryListDrawer({ onClose, visible }) {
     }
   }, [visible, initialUrl, getQueries]);
 
-  let { data: tagsRes } = useSWR('/api/tags', swrFetcher);
+  let { data: tagsRes } = useSWR('/api/tags');
   const tags = tagsRes ? tagsRes.data : [];
 
-  let { data: connectionsRes } = useSWR('/api/connections', swrFetcher);
+  let { data: connectionsRes } = useSWR('/api/connections');
   const connections = connectionsRes ? connectionsRes.data : [];
 
   const deleteQuery = async (queryId) => {

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -108,11 +108,11 @@ function QueryListDrawer({ onClose, visible }) {
     }
   }, [visible, initialUrl, getQueries]);
 
-  let { data: tagsRes } = useSWR('/api/tags');
-  const tags = tagsRes ? tagsRes.data : [];
+  let { data: tagData } = useSWR('/api/tags');
+  const tags = tagData || [];
 
-  let { data: connectionsRes } = useSWR('/api/connections');
-  const connections = connectionsRes ? connectionsRes.data : [];
+  let { data: connectionsData } = useSWR('/api/connections');
+  const connections = connectionsData || [];
 
   const deleteQuery = async (queryId) => {
     const { error } = await fetchJson('DELETE', `/api/queries/${queryId}`);

--- a/client/src/queries/QueryListDrawer.js
+++ b/client/src/queries/QueryListDrawer.js
@@ -79,6 +79,8 @@ function QueryListDrawer({ onClose, visible }) {
   const getQueries = useCallback(
     (url) => {
       setLoading(true);
+      // This cannot use SWR at this time
+      // as we need to use links and manage state
       fetchJson('GET', url).then((response) => {
         const { data, links, error } = response;
         setLoading(false);

--- a/client/src/queryEditor/toolbar/QueryTagsModal.js
+++ b/client/src/queryEditor/toolbar/QueryTagsModal.js
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import useSWR from 'swr';
 import { connect } from 'unistore/react';
-import { setQueryState } from '../../stores/queries';
 import Modal from '../../common/Modal';
 import MultiSelect from '../../common/MultiSelect';
-import fetchJson from '../../utilities/fetch-json';
+import { setQueryState } from '../../stores/queries';
 
 function mapStateToProps(state) {
   return {
@@ -16,20 +16,8 @@ const ConnectedQueryTagsModal = connect(mapStateToProps, { setQueryState })(
 );
 
 function QueryTagsModal({ tags, visible, onClose, setQueryState }) {
-  const [options, setOptions] = useState([]);
-
-  useEffect(() => {
-    if (visible) {
-      fetchJson('GET', '/api/tags').then((response) => {
-        const { data } = response;
-        if (data) {
-          const options = data.map((tag) => ({ name: tag, id: tag }));
-          setOptions(options);
-        }
-      });
-    }
-  }, [visible]);
-
+  const { data: tagsData } = useSWR(visible ? '/api/tags' : null);
+  const options = (tagsData || []).map((tag) => ({ name: tag, id: tag }));
   const selectedItems = tags.map((tag) => ({ name: tag, id: tag }));
 
   const handleChange = (selectedItems) => {

--- a/client/src/utilities/swr-fetcher.js
+++ b/client/src/utilities/swr-fetcher.js
@@ -1,9 +1,9 @@
 import fetchJson from './fetch-json';
 
 export default async function swrFetcher(url) {
-  const { data, links, error } = await fetchJson('GET', url);
+  const { data, error } = await fetchJson('GET', url);
   if (error) {
     throw error;
   }
-  return { data, links };
+  return data;
 }


### PR DESCRIPTION
Uses SWR for a lot of `fetchJson('GET', '...')` requests. SWR does a lot of nifty things like caching, deduplication, optimistic updates through `mutate` if desired, and more. 

Some `GET` requests are not converted to use SWR. Anything in the `store` files are left alone, as they'll be handled as a separate effort.

For paginated cases like the queries list, `fetchJson` is still used, as we need to manage the links and cache separately. 