### PR TITLE
Updates for SAML

### DIFF
--- a/client/src/SignIn.js
+++ b/client/src/SignIn.js
@@ -93,9 +93,15 @@ function SignIn({ config, refreshAppContext }) {
     </div>
   );
 
+  function createMarkupForSamlLink() {
+    return { __html: config.samlLinkHtml };
+  }
+
   const samlForm = (
     <div>
-      <a href={config.baseUrl + '/auth/saml'}>Sign in with ADFS</a>
+      <a href={config.baseUrl + '/auth/saml'}>
+        <span dangerouslySetInnerHTML={createMarkupForSamlLink()} />
+      </a>
     </div>
   );
 

--- a/config-example.ini
+++ b/config-example.ini
@@ -68,6 +68,9 @@ publicUrl=""
 ; By default query results are limited to 50,000 records.
 queryResultMaxRows="50000"
 
+; SAML authentication - provide HTML for the sign-in link.
+samlLinkHtml=""
+
 ; SAML authentication context URL
 samlAuthContext=""
 

--- a/config-example.ini
+++ b/config-example.ini
@@ -71,6 +71,13 @@ queryResultMaxRows="50000"
 ; SAML authentication - provide HTML for the sign-in link.
 samlLinkHtml=""
 
+; Auto create a user record if it does not exist when new user is detected via SAML authentication
+samlAutoSignUp=false
+
+; Default role to assign user created when `samlAutoSignUp` is turned on. 
+; By default this is an empty-string and not used, expecting a role to be provided via header-mapping.
+samlDefaultRole=""
+
 ; SAML authentication context URL
 samlAuthContext=""
 

--- a/config-example.json
+++ b/config-example.json
@@ -22,6 +22,7 @@
   "port": 80,
   "publicUrl": "",
   "queryResultMaxRows": 50000,
+  "samlLinkHtml": "",
   "samlAuthContext": "",
   "samlCallbackUrl": "",
   "samlCert": "",

--- a/config-example.json
+++ b/config-example.json
@@ -23,6 +23,8 @@
   "publicUrl": "",
   "queryResultMaxRows": 50000,
   "samlLinkHtml": "",
+  "samlAutoSignUp": false,
+  "samlDefaultRole": "",
   "samlAuthContext": "",
   "samlCallbackUrl": "",
   "samlCert": "",

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -89,8 +89,12 @@ SAML-based  authentication can be enabled by setting the necessary environment v
 - `SAML_CERT`
 - `SAML_ENTRY_POINT`
 - `SAML_ISSUER`
+- `SQLPAD_SAML_AUTO_SIGN_UP`
+- `SQLPAD_SAML_DEFAULT_ROLE`
 - `PUBLIC_URL`
 - `DISABLE_USERPASS_AUTH`=`true` (optional - disables plain local user logins)
+
+SQLPad users do not need to be added ahead of time, and may be created on the fly using `samlAutoSignUp`. Whenever a new user is detected (unable to match to existing user email), a user record will be added to SQLPad's user table and a user signed in. By default users are not auto-created and must otherwise be added ahead of time.
 
 ## Whitelist Domains for User Administration
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -83,6 +83,7 @@ For OAuth to be useful this usually involves the following:
 
 SAML-based  authentication can be enabled by setting the necessary environment variables:
 
+- `SAML_LINK_HTML`
 - `SAML_AUTH_CONTEXT`
 - `SAML_CALLBACK_URL`
 - `SAML_CERT`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,13 @@ SAML Issuer
 - Key: `samlIssuer`
 - Env: `SAML_ISSUER`
 
+## samlLinkHtml
+
+HTML code for the sign-in link used for starting SAML authentication. The default is `Sign in with SSO`
+
+- Key: `samlLinkHtml`
+- Env: `SAML_LINK_HTML`
+
 ## serviceTokenSecret
 
 Secret to sign the generated Service Tokens

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,21 @@ HTML code for the sign-in link used for starting SAML authentication. The defaul
 - Key: `samlLinkHtml`
 - Env: `SAML_LINK_HTML`
 
+## samlAutoSignUp
+
+Auto create a user record if it does not exist when new user is detected via SAML
+
+- Key: `samlAutoSignUp`
+- Env: `SQLPAD_SAML_AUTO_SIGN_UP`
+- Default: `false`
+
+## samlDefaultRole
+
+Default role to assign user created when `samlAutoSignUp` is turned on. By default this is an empty-string and not used, expecting a role to be provided via header-mapping.
+
+- Key: `samlDefaultRole`
+- Env: `SQLPAD_SAML_DEFAULT_ROLE`
+
 ## serviceTokenSecret
 
 Secret to sign the generated Service Tokens

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -211,6 +211,11 @@ const configItems = [
     default: '',
   },
   {
+    key: 'samlLinkHtml',
+    envVar: 'SAML_LINK_HTML',
+    default: 'Sign in with SSO',
+  },
+  {
     key: 'allowConnectionAccessToEveryone',
     envVar: 'SQLPAD_ALLOW_CONNECTION_ACCESS_TO_EVERYONE',
     default: true,

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -216,6 +216,16 @@ const configItems = [
     default: 'Sign in with SSO',
   },
   {
+    key: 'samlAutoSignUp',
+    envVar: 'SQLPAD_SAML_AUTO_SIGN_UP',
+    default: false,
+  },
+  {
+    key: 'samlDefaultRole',
+    envVar: 'SQLPAD_SAML_DEFAULT_ROLE',
+    default: 'editor',
+  },
+  {
     key: 'allowConnectionAccessToEveryone',
     envVar: 'SQLPAD_ALLOW_CONNECTION_ACCESS_TO_EVERYONE',
     default: true,

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -31,6 +31,7 @@ router.get(
         localAuthConfigured: !config.get('disableUserpassAuth'),
         publicUrl: config.get('publicUrl'),
         samlConfigured: Boolean(config.get('samlEntryPoint')),
+        samlLinkHtml: config.get('samlLinkHtml'),
         smtpConfigured: config.smtpConfigured(),
       },
       version: packageJson.version,

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -24,6 +24,7 @@ const expectedConfigKeys = [
   'googleAuthConfigured',
   'localAuthConfigured',
   'samlConfigured',
+  'samlLinkHtml',
 ];
 
 describe('api/app', function () {


### PR DESCRIPTION
1. The first commit in this PR allows renaming the "Sign in with ADFS" (used for SAML auth) with something else, i.e. "Sign in with NASA". The env variable `SAML_LINK_HTML` can include html so operator can add for example company (or a not-for-profit organization ) logo.

2. If I understand correctly, the SAML auth works only for users already added to the database. This PR adds env variable configuration `SQLPAD_SAML_AUTO_SIGN_UP` and `SQLPAD_SAML_DEFAULT_ROLE` which lets you admit all SAML users and assign roles. 