### PR TITLE
Restrict runQuery return to essential fields

### DIFF
--- a/server/lib/get-columns.js
+++ b/server/lib/get-columns.js
@@ -27,10 +27,10 @@ function isNumeric(value) {
 }
 
 /**
- * Iterate over collection of rows and derive metadata
+ * Iterate over collection of rows and derive column metadata
  * @param {array<object>} rows
  */
-module.exports = function getMeta(rows) {
+module.exports = function getColumns(rows) {
   const meta = {};
 
   rows.forEach((row) => {
@@ -140,5 +140,7 @@ module.exports = function getMeta(rows) {
     });
   });
 
-  return meta;
+  return Object.entries(meta).map(([key, value]) => {
+    return { ...value, name: key };
+  });
 };

--- a/server/test/lib/get-columns.js
+++ b/server/test/lib/get-columns.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
-const getMeta = require('../../lib/get-meta.js');
+const getColumns = require('../../lib/get-columns.js');
 
 const d1 = new Date();
 const d2 = new Date(new Date().getTime() + 60000);
 const noTime = new Date('2019-01-01T00:00:00.000Z');
 
-describe('lib/get-meta.js', function () {
+describe('lib/get-columns.js', function () {
   it('returns expected results', function () {
     const rows = [
       // To ensure nulls are handled appropriately start and end with them
@@ -51,7 +51,7 @@ describe('lib/get-meta.js', function () {
       },
     ];
 
-    const meta = getMeta(rows);
+    const meta = getColumns(rows);
 
     assert.equal(meta.alwaysNull.datatype, null, 'null');
 

--- a/server/test/lib/get-columns.js
+++ b/server/test/lib/get-columns.js
@@ -51,36 +51,40 @@ describe('lib/get-columns.js', function () {
       },
     ];
 
-    const meta = getColumns(rows);
+    const columns = getColumns(rows);
+    const cMap = {};
+    columns.forEach((c) => {
+      cMap[c.name] = c;
+    });
 
-    assert.equal(meta.alwaysNull.datatype, null, 'null');
+    assert.equal(cMap.alwaysNull.datatype, null, 'null');
 
-    assert.equal(meta.accountNumber.datatype, 'string', 'accountNumber');
+    assert.equal(cMap.accountNumber.datatype, 'string', 'accountNumber');
     assert.equal(
-      meta.accountNumber.maxValueLength,
+      cMap.accountNumber.maxValueLength,
       6,
       'accountNumber.maxValueLength'
     );
 
-    assert.equal(meta.decimalString.datatype, 'number', 'decimalString');
-    assert.equal(meta.decimalString.max, 0.999, 'decimalString.max');
-    assert.equal(meta.decimalString.min, 0.111, 'decimalString.min');
+    assert.equal(cMap.decimalString.datatype, 'number', 'decimalString');
+    assert.equal(cMap.decimalString.max, 0.999, 'decimalString.max');
+    assert.equal(cMap.decimalString.min, 0.111, 'decimalString.min');
 
-    assert.equal(meta.number.datatype, 'number', 'number.datatype');
-    assert.equal(meta.number.max, 30, 'number.max');
-    assert.equal(meta.number.min, 0, 'number.min');
+    assert.equal(cMap.number.datatype, 'number', 'number.datatype');
+    assert.equal(cMap.number.max, 30, 'number.max');
+    assert.equal(cMap.number.min, 0, 'number.min');
 
-    assert.equal(meta.string.datatype, 'string', 'string.datatype');
-    assert.equal(meta.string.maxValueLength, 7, 'string.maxValueLength');
+    assert.equal(cMap.string.datatype, 'string', 'string.datatype');
+    assert.equal(cMap.string.maxValueLength, 7, 'string.maxValueLength');
 
-    assert.equal(meta.datetime.datatype, 'datetime', 'datetime.datatype');
-    assert.equal(meta.datetime.max.getTime(), d2.getTime(), 'datetime.max');
-    assert.equal(meta.datetime.min.getTime(), d1.getTime(), 'datetime.min');
+    assert.equal(cMap.datetime.datatype, 'datetime', 'datetime.datatype');
+    assert.equal(cMap.datetime.max.getTime(), d2.getTime(), 'datetime.max');
+    assert.equal(cMap.datetime.min.getTime(), d1.getTime(), 'datetime.min');
 
-    assert.equal(meta.numberString.datatype, 'number', 'numberString.datatype');
-    assert.equal(meta.numberString.max, 100, 'numberString.max');
-    assert.equal(meta.numberString.min, 0, 'numberString.min');
+    assert.equal(cMap.numberString.datatype, 'number', 'numberString.datatype');
+    assert.equal(cMap.numberString.max, 100, 'numberString.max');
+    assert.equal(cMap.numberString.min, 0, 'numberString.min');
 
-    assert.equal(meta.date.datatype, 'date', 'date.datatype');
+    assert.equal(cMap.date.datatype, 'date', 'date.datatype');
   });
 });


### PR DESCRIPTION
Limits the queryResult return value of runQuery to essential fields. Timing data, meta, and fields array are now available elsewhere. 