### PR TITLE
Add Client implementation for MySQL driver

### DIFF
--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -139,11 +139,12 @@ class Client {
     );
 
     return new Promise((resolve, reject) => {
+      // TODO - use fields from driver to return columns
+      // eslint-disable-next-line no-unused-vars
       return this.client.query(limitedQuery, (error, rows, fields) => {
         if (error) {
           return reject(error);
         }
-        console.log(fields);
         if (rows.length === maxRowsPlusOne) {
           return resolve({ rows: rows.slice(0, maxRows), incomplete: true });
         }

--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -1,6 +1,7 @@
+/* eslint-disable no-await-in-loop */
 const fs = require('fs');
 const mysql = require('mysql');
-const appLog = require('../../lib/app-log');
+const sqlLimiter = require('sql-limiter');
 const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'mysql';
@@ -31,124 +32,144 @@ function getSchemaSql(database) {
   `;
 }
 
+class Client {
+  constructor(connection) {
+    this.connection = connection;
+    this.client = null; // AKA myConnection
+  }
+
+  /**
+   * Establish db client connection if not already connected
+   */
+  async connect() {
+    if (this.client) {
+      return;
+    }
+    const { connection } = this;
+
+    const myConfig = {
+      host: connection.host,
+      port: connection.port ? connection.port : 3306,
+      user: connection.username,
+      password: connection.password,
+      database: connection.database,
+      insecureAuth: connection.mysqlInsecureAuth,
+      timezone: 'Z',
+      supportBigNumbers: true,
+      ssl: connection.mysqlSsl,
+      multipleStatements: !connection.denyMultipleStatements,
+      preQueryStatements: connection.preQueryStatements,
+    };
+
+    // TODO cache key/cert values
+    if (connection.mysqlKey && connection.mysqlCert) {
+      myConfig.ssl = {
+        key: fs.readFileSync(connection.mysqlKey),
+        cert: fs.readFileSync(connection.mysqlCert),
+      };
+      if (connection.mysqlCA) {
+        myConfig.ssl['ca'] = fs.readFileSync(connection.mysqlCA);
+      }
+    }
+
+    this.client = mysql.createConnection(myConfig);
+
+    await new Promise((resolve, reject) => {
+      this.client.connect(async (err) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
+    });
+
+    // Run pre query statements
+    // Statements split by JS because MySQL multipleStatements is turned off
+    if (myConfig.preQueryStatements) {
+      // sqlLimiter may return empty statements so they should be stripped out
+      const statements = sqlLimiter
+        .getStatements(connection.preQueryStatements)
+        .map((s) => sqlLimiter.removeTerminator(s))
+        .filter((s) => s && s.trim() !== '');
+
+      for (const statement of statements) {
+        await new Promise((resolve, reject) => {
+          this.client.query(statement, (err) => {
+            if (err) {
+              return reject(err);
+            }
+            return resolve();
+          });
+        });
+      }
+    }
+  }
+
+  /**
+   * Disconnect the underlying client if connected
+   */
+  async disconnect() {
+    if (this.client) {
+      return new Promise((resolve, reject) => {
+        this.client.end((error) => {
+          if (error) {
+            return reject(error);
+          }
+          resolve();
+        });
+      });
+    }
+  }
+
+  /**
+   * Run query using underlying connection
+   * @param {string} query
+   */
+  async runQuery(query) {
+    if (!this.client) {
+      throw new Error('Must be connected');
+    }
+
+    const { maxRows } = this.connection;
+    const maxRowsPlusOne = maxRows + 1;
+    const limitedQuery = sqlLimiter.limit(
+      query,
+      ['limit', 'fetch'],
+      maxRowsPlusOne
+    );
+
+    return new Promise((resolve, reject) => {
+      return this.client.query(limitedQuery, (error, rows, fields) => {
+        if (error) {
+          return reject(error);
+        }
+        console.log(fields);
+        if (rows.length === maxRowsPlusOne) {
+          return resolve({ rows: rows.slice(0, maxRows), incomplete: true });
+        }
+        return resolve({ rows, incomplete: false });
+      });
+    });
+  }
+}
+
 /**
  * Run query for connection
  * Should return { rows, incomplete }
  * @param {string} query
  * @param {object} connection
  */
-function runQuery(query, connection) {
-  const myConfig = {
-    host: connection.host,
-    port: connection.port ? connection.port : 3306,
-    user: connection.username,
-    password: connection.password,
-    database: connection.database,
-    insecureAuth: connection.mysqlInsecureAuth,
-    timezone: 'Z',
-    supportBigNumbers: true,
-    ssl: connection.mysqlSsl,
-    multipleStatements: !connection.denyMultipleStatements,
-    preQueryStatements: connection.preQueryStatements,
-  };
-  // TODO cache key/cert values
-  if (connection.mysqlKey && connection.mysqlCert) {
-    myConfig.ssl = {
-      key: fs.readFileSync(connection.mysqlKey),
-      cert: fs.readFileSync(connection.mysqlCert),
-    };
-    if (connection.mysqlCA) {
-      myConfig.ssl['ca'] = fs.readFileSync(connection.mysqlCA);
-    }
+async function runQuery(query, connection) {
+  const client = new Client(connection);
+  await client.connect();
+  try {
+    const result = await client.runQuery(query);
+    await client.disconnect();
+    return result;
+  } catch (error) {
+    await client.disconnect();
+    throw error;
   }
-
-  return new Promise((resolve, reject) => {
-    const myConnection = mysql.createConnection(myConfig);
-    let incomplete = false;
-    const rows = [];
-
-    myConnection.connect((err) => {
-      if (err) {
-        return reject(err);
-      }
-      let queryError;
-      let resultsSent = false;
-
-      function continueOn() {
-        if (!resultsSent) {
-          resultsSent = true;
-          if (queryError) {
-            return reject(queryError);
-          }
-          return resolve({ rows, incomplete });
-        }
-      }
-
-      function _runQuery(
-        query,
-        params = { addRowsToResults: true, closeConnection: true }
-      ) {
-        const myQuery = myConnection.query(query);
-        myQuery
-          .on('error', function (err) {
-            // Handle error,
-            // an 'end' event will be emitted after this as well
-            // so we'll call the callback there.
-            queryError = err;
-          })
-          .on('result', function (row) {
-            if (params.addRowsToResults) {
-              // If we haven't hit the max yet add row to results
-              if (rows.length < connection.maxRows) {
-                return rows.push(row);
-              }
-
-              // Too many rows
-              incomplete = true;
-
-              // Stop the query stream
-              myConnection.pause();
-
-              // Destroy the underlying connection
-              // Calling end() will wait and eventually time out
-              if (params.closeConnection) {
-                myConnection.destroy();
-              }
-              continueOn();
-            }
-          })
-          .on('end', function () {
-            // all rows have been received
-            // This will not fire if we end the connection early
-            // myConnection.end()
-            // myConnection.destroy()
-            if (params.closeConnection) {
-              myConnection.end((error) => {
-                if (error) {
-                  appLog.error(error, 'Error ending MySQL connection');
-                }
-                continueOn();
-              });
-            }
-          });
-      }
-
-      // Run pre query statements
-      // Statements split by JS because MySQL multipleStatements is turned off
-      if (myConfig.preQueryStatements) {
-        myConfig.preQueryStatements
-          .trim()
-          .split(';')
-          .forEach((q) => {
-            if (q)
-              _runQuery(q, { addRowsToResults: false, closeConnection: false });
-          });
-      }
-
-      // Run actual query
-      _runQuery(query);
-    });
-  });
 }
 
 /**
@@ -243,4 +264,5 @@ module.exports = {
   getSchema,
   runQuery,
   testConnection,
+  Client,
 };

--- a/server/routes/test-connection.js
+++ b/server/routes/test-connection.js
@@ -10,7 +10,10 @@ const ConnectionClient = require('../lib/connection-client');
  * @param {Res} res
  */
 async function testConnection(req, res) {
-  const connectionClient = new ConnectionClient(req.body, req.user);
+  const connectionClient = new ConnectionClient(
+    { ...req.body, maxRows: 1 },
+    req.user
+  );
   // testConnection will throw if configuration is invalid
   // This is expected
   // An assumption is made that this is due to user-input error

--- a/server/test/api/drivers.js
+++ b/server/test/api/drivers.js
@@ -27,6 +27,6 @@ describe('api/drivers', function () {
 
     const mysql = drivers.find((i) => i.id === 'mysql');
     assert(mysql);
-    assert.strictEqual(mysql.supportsConnectionClient, false);
+    assert.strictEqual(mysql.supportsConnectionClient, true);
   });
 });


### PR DESCRIPTION
Adds `Client` implementation to MySQL driver, enabling support for multi-statement transaction mode.

To ensure connection remains open, this also utilizes `sql-limiter` to enforce sql limits as opposed to streaming data destroying the connection.

Fixes #695 