### PR TITLE
Postgres: Use sql-limiter to limit queries and remove pg-cursor

### DIFF
--- a/server/drivers/postgres/test.js
+++ b/server/drivers/postgres/test.js
@@ -57,23 +57,6 @@ describe('drivers/postgres', function () {
       });
   });
 
-  // This isn't officially supported across all drivers
-  // Official multiple statement support will start to look much different
-  // This is a test for legacy allowed postgres behavior
-  it('runQuery multiple statements', async function () {
-    const query = `
-      SELECT * FROM generate_series(1, 10) g1;
-      SELECT * FROM generate_series(1, 10) g2;
-    `;
-    const results = await postgres.runQuery(query, connection);
-    assert.strictEqual(results.incomplete, false);
-    assert.strictEqual(results.rows.length, 20);
-    assert.strictEqual(results.rows[0].g1, 1);
-    assert.strictEqual(results.rows[0].g2, undefined);
-    assert.strictEqual(results.rows[10].g1, undefined);
-    assert.strictEqual(results.rows[10].g2, 1);
-  });
-
   it('Client cannot connect more than once', async function () {
     const client = new postgres.Client(connection);
     await client.connect();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4526,11 +4526,6 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.3.tgz",
       "integrity": "sha512-I/KCSQGmOrZx6sMHXkOs2MjddrYcqpza3Dtsy0AjIgBr/bZiPJRK9WhABXN1Uy1UDazRbi9gZEzO2sAhL5EqiQ=="
     },
-    "pg-cursor": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.2.1.tgz",
-      "integrity": "sha512-C0DKcb8do7Mv9tTQvrB+hxPYgJ6FCKnu1CjPMb0txYHW+zULpOH0B01MNtjQA4nrhHJ4Qs1Nf58BGEc158wXIA=="
-    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -74,7 +74,6 @@
     "passport-local": "^1.0.0",
     "passport-saml": "^1.3.3",
     "pg": "^8.2.1",
-    "pg-cursor": "^2.2.1",
     "pino": "^6.3.2",
     "query-string": "^6.13.1",
     "request": "^2.88.2",


### PR DESCRIPTION
This removes pg-cursor and instead uses `sql-limiter` to enforce query result row limits. This same approach is used for MySQL, SQLite, and ODBC SQLPad drivers. 

Removing pg-cursor use should also potentially assist with #637 and #383 

