### PR TITLE
don't prompt for LDAP if not configured

### DIFF
--- a/client/src/SignIn.js
+++ b/client/src/SignIn.js
@@ -39,12 +39,20 @@ function SignIn() {
     return;
   }
 
+  function PlaceholderForUsername() {
+    if (config.ldapConfigured) {
+      return 'Username or e-mail address';
+    } else {
+      return 'e-mail address';
+    }
+  }
+
   const localForm = (
     <form onSubmit={signIn}>
       <Input
         name="email"
         type="email"
-        placeholder="LDAP User / Email"
+        placeholder={PlaceholderForUsername()}
         onChange={(e) => setEmail(e.target.value)}
         required
       />

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -33,6 +33,7 @@ async function getApp(req, res) {
       samlConfigured: Boolean(config.get('samlEntryPoint')),
       samlLinkHtml: config.get('samlLinkHtml'),
       smtpConfigured: config.smtpConfigured(),
+      ldapConfigured: config.get('enableLdapAuth'),
     },
     version: packageJson.version,
   });

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -25,6 +25,7 @@ const expectedConfigKeys = [
   'localAuthConfigured',
   'samlConfigured',
   'samlLinkHtml',
+  'ldapConfigured',
 ];
 
 describe('api/app', function () {


### PR DESCRIPTION
Users should not see the word LDAP if LDAP authentications is not configured in.

Well actually - users should not see the word LDAP ever - so I just used "username"