### PR TITLE
Potential backendDatabaseUri testing strategy

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -17,3 +17,12 @@ services:
       POSTGRES_DB: sqlpad
     ports:
       - '5432:5432'
+  mysql:
+    image: mariadb:10.3
+    environment:
+      MYSQL_ROOT_PASSWORD: sqlpad
+      MYSQL_DATABASE: sqlpad
+      MYSQL_USER: sqlpad
+      MYSQL_PASSWORD: sqlpad
+    ports:
+      - '3306:3306'

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -9,3 +9,11 @@ services:
       - ACCEPT_EULA=Y
       - MSSQL_SA_PASSWORD=SuperP4ssw0rd!
       - MSSQL_PID=Express
+  postgres:
+    image: postgres:9.6-alpine
+    environment:
+      POSTGRES_USER: sqlpad
+      POSTGRES_PASSWORD: sqlpad
+      POSTGRES_DB: sqlpad
+    ports:
+      - '5432:5432'

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  mssql:
+    image: 'mcr.microsoft.com/mssql/server:2017-latest'
+    hostname: 'mssql'
+    ports:
+      - 1433:1433
+    environment:
+      - ACCEPT_EULA=Y
+      - MSSQL_SA_PASSWORD=SuperP4ssw0rd!
+      - MSSQL_PID=Express

--- a/server/migrations/04-00400-query-history-to-batch.js
+++ b/server/migrations/04-00400-query-history-to-batch.js
@@ -86,7 +86,7 @@ async function up(queryInterface, config, appLog, nedb, sequelizeDb) {
           SELECT 
             batch_id, 
             SUM(row_count) AS row_count, 
-            MAX(incomplete) AS incomplete
+            MAX(CAST(incomplete AS INT)) AS incomplete
           FROM 
             statements
           GROUP BY 

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "prepublishOnly": "cd .. && ./scripts/build.sh",
     "start": "node-dev server.js --config \"./config.dev.ini\" | pino-pretty",
     "test": "mocha test --timeout 10000 --recursive --exit --bail",
+    "test-mssql": "env SQLPAD_TEST_DB=mssql mocha test --timeout 10000 --recursive --exit --bail",
     "fixlint": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\""
   },

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
     "test": "mocha test --timeout 10000 --recursive --exit --bail",
     "test-mssql": "env SQLPAD_TEST_DB=mssql mocha test --timeout 10000 --recursive --exit --bail",
     "test-pg": "env SQLPAD_TEST_DB=pg mocha test --timeout 10000 --recursive --exit --bail",
+    "test-mysql": "env SQLPAD_TEST_DB=mysql mocha test --timeout 10000 --recursive --exit --bail",
     "fixlint": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\""
   },

--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
     "start": "node-dev server.js --config \"./config.dev.ini\" | pino-pretty",
     "test": "mocha test --timeout 10000 --recursive --exit --bail",
     "test-mssql": "env SQLPAD_TEST_DB=mssql mocha test --timeout 10000 --recursive --exit --bail",
+    "test-pg": "env SQLPAD_TEST_DB=pg mocha test --timeout 10000 --recursive --exit --bail",
     "fixlint": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\""
   },

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -195,7 +195,7 @@ async function listQueries(req, res) {
     return {
       id: query.id,
       name: query.name,
-      chart: JSON.parse(query.chart),
+      chart: typeof query.chart === 'string' ? JSON.parse(query.chart) : null,
       queryText: query.query_text,
       createdBy: query.created_by,
       connection: {

--- a/server/test/api/password-reset.js
+++ b/server/test/api/password-reset.js
@@ -29,9 +29,9 @@ describe('api/password-reset', function () {
 
   it('Errors for wrong passwordResetId', async function () {
     await setReset();
-    const body = await utils.post(
+    await utils.post(
       'admin',
-      `/api/password-reset/123`,
+      `/api/password-reset/${uuidv4()}`,
       {
         email: 'admin@test.com',
         password: 'admin',
@@ -39,7 +39,6 @@ describe('api/password-reset', function () {
       },
       400
     );
-    assert.equal(body.title, 'Password reset permissions not found');
   });
 
   it('Errors for wrong email', async function () {

--- a/server/test/migrations/nedb-to-sqlite.js
+++ b/server/test/migrations/nedb-to-sqlite.js
@@ -224,7 +224,7 @@ describe('v4-to-v5', function () {
           item.duration_ms === original.queryRunTime &&
           item.query_name === original.queryName &&
           item.query_text === original.queryText &&
-          item.row_count === original.rowCount
+          parseInt(item.row_count, 10) === parseInt(original.rowCount, 10)
       );
 
       // query id could be string or null and null !== null

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -15,6 +15,7 @@ const ensureConnectionAccess = require('../lib/ensure-connection-access');
 
 const USE_MSSQL = process.env.SQLPAD_TEST_DB === 'mssql';
 const USE_PG = process.env.SQLPAD_TEST_DB === 'pg';
+const USE_MYSQL = process.env.SQLPAD_TEST_DB === 'mysql';
 
 // At the start of any test run, clean out the root artifacts directory
 before(function (done) {
@@ -33,6 +34,8 @@ class TestUtils {
       backendDatabaseUri = `mssql://sa:SuperP4ssw0rd!@localhost:1433/${this.dbname}`;
     } else if (USE_PG) {
       backendDatabaseUri = `postgres://sqlpad:sqlpad@localhost:5432/${this.dbname}`;
+    } else if (USE_MSSQL) {
+      backendDatabaseUri = `mysql://sqlpad:sqlpad@localhost:3306/${this.dbname}`;
     }
 
     const config = new Config(
@@ -107,6 +110,12 @@ class TestUtils {
       await sequelize.query(`CREATE DATABASE ${this.dbname};`);
     } else if (backendDatabaseUri.startsWith('postgres')) {
       const masterUri = `postgres://sqlpad:sqlpad@localhost:5432/sqlpad`;
+      const sequelize = new Sequelize(masterUri, {
+        logging: (message) => appLog.debug(message),
+      });
+      await sequelize.query(`CREATE DATABASE ${this.dbname}`);
+    } else if (backendDatabaseUri.startsWith('mysql')) {
+      const masterUri = `mysql://sqlpad:sqlpad@localhost:3306/sqlpad`;
       const sequelize = new Sequelize(masterUri, {
         logging: (message) => appLog.debug(message),
       });

--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -16,6 +16,7 @@ const ensureConnectionAccess = require('../lib/ensure-connection-access');
 const USE_MSSQL = process.env.SQLPAD_TEST_DB === 'mssql';
 const USE_PG = process.env.SQLPAD_TEST_DB === 'pg';
 const USE_MYSQL = process.env.SQLPAD_TEST_DB === 'mysql';
+const USE_BACKEND_DB = USE_MSSQL || USE_PG || USE_MYSQL;
 
 // At the start of any test run, clean out the root artifacts directory
 before(function (done) {
@@ -27,14 +28,14 @@ class TestUtils {
     // If `npm run test-mssql` is run, the mssql env is set
     // If this env is set each test suite needs to create a dynamic db name to use for testing
     // (figured a fresh db is easier than trying to clear dbs out when done)
-    this.dbname = USE_MSSQL || USE_PG ? `db${uuidv4()}`.replace(/-/g, '') : '';
+    this.dbname = USE_BACKEND_DB ? `db${uuidv4()}`.replace(/-/g, '') : '';
 
     let backendDatabaseUri = '';
     if (USE_MSSQL) {
       backendDatabaseUri = `mssql://sa:SuperP4ssw0rd!@localhost:1433/${this.dbname}`;
     } else if (USE_PG) {
       backendDatabaseUri = `postgres://sqlpad:sqlpad@localhost:5432/${this.dbname}`;
-    } else if (USE_MSSQL) {
+    } else if (USE_MYSQL) {
       backendDatabaseUri = `mysql://sqlpad:sqlpad@localhost:3306/${this.dbname}`;
     }
 


### PR DESCRIPTION
@yorek @eladeyal-intel Out of curiosity I wanted to see what it'd take to get a testing set up in place where we could run the suite of tests against a targeted backend. 

This is quickly put together, but what I've come up with is to set an env var to key off of, and then in test utils dynamically create and use databases on the targeted backend. All the tests today assume they can start fresh with a database, which is easy to do with SQLite.

Here's what I've got so far with this:

* In one terminal window, cd to `/server` and do `docker-compose up` to get sql server running
* In another terminal (or in same if you run previous command in background) do `npm run test-mssql`, and a test databases should be created in test utils.

Doing this I immediately hit a failing test 

```
 1) api/app
       "before all" hook for "returns expected values":
     SequelizeDatabaseError: Column, parameter, or variable #5: Cannot find data type JSON.
```

Is that what you get @yorek?

Feel free to use and commit to this branch if its helpful.