### PR TITLE
multiple backends testing improved

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build
+      - name: Build for ${{ matrix.node-version }}
         run: scripts/build.sh
 
       - name: Store artifacts
@@ -31,48 +31,10 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
 
-    services:
-#      postgres:
-#        image: postgres:10.8
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#          POSTGRES_DB: pgbd
-#        ports:
-#          - 5432:5432
-#        # needed because the postgres container does not provide a healthcheck
-#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      mariadb:
-        image: mariadb:10.3
-        ports:
-          - 13306:3306
-        env:
-          MYSQL_USER: user
-          MYSQL_PASSWORD: password
-          MYSQL_DATABASE: db
-          MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=5
-
-      mssql:
-        image: mcr.microsoft.com/mssql/server:2017-CU8-ubuntu
-        env:
-          ACCEPT_EULA: Y
-          SA_PASSWORD: SuperP4ssw0rd!
-          MSSQL_PID: Developer
-        ports:
-          - 1433:1433
-
     strategy:
       fail-fast: false # if one job fails, others will not be aborted
       matrix:
-        db_uri: [
-          'mssql://sa:SuperP4ssw0rd!@localhost:1433/dbname',
-#         'postgres://postgres:postgres@localhost:5432/pgdb',
-          'mysql://root:root@localhost:3306/db2',
-          'mariadb://root:password@localhost:13306/db',
-          ''
-        ]
+        backendtype: [ '', 'mssql','mysql', 'mariadb', 'postgres' ]
         node-version: [12.x]
 
     steps:
@@ -92,10 +54,12 @@ jobs:
           name: built_node${{ matrix.node-version }}
           path: server/public
 
-      - name: Enable mysql server included in ubuntu-20.04 image
-        run: sudo systemctl start mysql.service
+      - name: Enable backend server
+        if: ${{ matrix.backendtype }}
+        run: |
+          docker-compose -f server/docker-compose.yml up -d ${{ matrix.backendtype }}
+          # Wait until container becomes healthy
+          docker-compose -f server/docker-compose.yml events | grep --max-count 1 'health_status: healthy'
 
       - name: Test
-        env: 
-          SQLPAD_BACKEND_DB_URI: ${{ matrix.db_uri }}
-        run: npm run test --prefix server
+        run: npm run test${{ matrix.backendtype }} --prefix server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,32 @@ name: test
 on: [push, pull_request]
 
 jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Build
+        run: scripts/build.sh
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: built_node${{ matrix.node-version }}
+          path: server/public
+
   test:
+    needs: build
     runs-on: ubuntu-20.04
 
     services:
@@ -58,8 +83,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build
-        run: scripts/build.sh
+      - name: Install node modules
+        run: npm ci --prefix server
+
+      - name: Download built artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: built_node${{ matrix.node-version }}
+          path: server/public
 
       - name: Enable mysql server included in ubuntu-20.04 image
         run: sudo systemctl start mysql.service

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       - ACCEPT_EULA=Y
       - MSSQL_SA_PASSWORD=SuperP4ssw0rd!
       - MSSQL_PID=Express
+    healthcheck:
+        test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "SuperP4ssw0rd!", "-Q", "SELECT 1" ]
+        interval: 3s
+        timeout: 3s
+        retries: 10
+
   postgres:
     image: postgres:9.6-alpine
     environment:
@@ -17,12 +23,39 @@ services:
       POSTGRES_DB: sqlpad
     ports:
       - '5432:5432'
-  mysql:
+    healthcheck: 
+      test: ["CMD", "pg_isready"]
+      interval: 5s 
+      timeout: 2s
+      retries: 10
+
+  mariadb:
     image: mariadb:10.3
-    environment:
-      MYSQL_ROOT_PASSWORD: sqlpad
-      MYSQL_DATABASE: sqlpad
-      MYSQL_USER: sqlpad
-      MYSQL_PASSWORD: sqlpad
     ports:
-      - '3306:3306'
+      - 13306:3306
+    environment:
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: db
+      MYSQL_ROOT_PASSWORD: password
+    healthcheck: 
+      test: ["CMD", "mysqladmin", "ping"]
+      interval: 5s 
+      timeout: 2s
+      retries: 10
+        
+  mysql:
+    image: mysql:8
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: db2
+      MYSQL_ROOT_PASSWORD: root
+    healthcheck: 
+      test: ["CMD", "mysqladmin", "ping"]
+      interval: 5s 
+      timeout: 2s
+      retries: 10
+        

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,10 @@
     "prepublishOnly": "cd .. && ./scripts/build.sh",
     "start": "node-dev server.js --config \"./config.dev.ini\" | pino-pretty",
     "test": "mocha test --timeout 10000 --recursive --exit --bail",
+    "testmssql" : "env SQLPAD_BACKEND_DB_URI='mssql://sa:SuperP4ssw0rd!@localhost:1433/dbname' npm run test",
+    "testmysql" : "env SQLPAD_BACKEND_DB_URI='mysql://root:root@localhost:3306/db2' npm run test",
+    "testmariadb" : "env SQLPAD_BACKEND_DB_URI='mariadb://root:password@localhost:13306/db' npm run test",
+    "testpostgres" : "env SQLPAD_BACKEND_DB_URI='postgres://sqlpad:sqlpad@localhost:5432/sqlpad' npm run test",
     "fixlint": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\""
   },


### PR DESCRIPTION
1. Now things are built once, and the built artifact is used for multiple tests (which run in parallel)

2. Added tests, we have now mysql, mariadb, mssql, psql and sqlite. All but the last fail (but for interesting reasons)

3. Servers are no longer launched unnecessarily - so the mssql test will launch the mssql docker only.

3. I moved all the images into the server/docker-compose.yaml and they're not in the github action. This way we can reuse the same for dev. For script convenience , I changed yours "test-mysql" to "testmysql"
