### PR TITLE
remove MariaDB warnings

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
     "test": "mocha test --timeout 10000 --recursive --exit --bail",
     "testmssql" : "env SQLPAD_BACKEND_DB_URI='mssql://sa:SuperP4ssw0rd!@localhost:1433/dbname' npm run test",
     "testmysql" : "env SQLPAD_BACKEND_DB_URI='mysql://root:root@localhost:3306/db2' npm run test",
-    "testmariadb" : "env SQLPAD_BACKEND_DB_URI='mariadb://root:password@localhost:13306/db' npm run test",
+    "testmariadb" : "env SQLPAD_BACKEND_DB_URI='mariadb://root:password@localhost:13306/db?timezone=Etc%2FGMT0' npm run test",
     "testpostgres" : "env SQLPAD_BACKEND_DB_URI='postgres://sqlpad:sqlpad@localhost:5432/sqlpad' npm run test",
     "fixlint": "eslint --fix \"**/*.js\"",
     "lint": "eslint \"**/*.js\""


### PR DESCRIPTION
This changes the "DB name randomization" thing to be more robust, and then we can specify the timezone as part of the backend URI, so we can get rid on these warnings which are caused by sequalize + mariadb driver.

`warning: please use IANA standard timezone format ('Etc/GMT0')`

I did nothing to remove the warnings in production. For now it seems that there is a valid workaround by editing the timezone in the URI. There can be other  options - I've seen mentions of the `TZ` or `DB_TIMEZONE` environment variables; and since it's a backend DB we may be able to hardcode it to UTC somewhere/