### PR TITLE
Add JSON datatype to created test db

### DIFF
--- a/server/test/utils.js
+++ b/server/test/utils.js
@@ -103,11 +103,17 @@ class TestUtils {
           throw e;
         }
       }
+      await sequelize.close();
 
+      // If dealing with SQL Server, create a JSON data type in database just created
       if (backendDatabaseUri.startsWith('mssql:')) {
+        const sequelize = new Sequelize(backendDatabaseUri, {
+          logging: (message) => appLog.debug(message),
+        });
         await sequelize.query(
           `CREATE TYPE [dbo].[JSON] FROM [NVARCHAR](MAX) NULL;`
         );
+        await sequelize.close();
       }
     }
 


### PR DESCRIPTION
For MSSQL test - adds JSON datatype to newly created database used for testing.

SQL Server tests are still broken after this change. Sequelize logs a unique constraint validation when trying to create test users. I suspect the error code is incorrect because I can't find what unique constraint is being violated, and found this stack overflow comment in my search for what is actually going on https://stackoverflow.com/a/60604358

Will merge this to get the test setup more functional.

For anyone interested in running mssql tests:

```sh
cd server
docker-compose up mssql
npm run testmssql
```