### PR TITLE
Fix password_reset_id unique constraint for mssql

### DIFF
--- a/server/lib/migration-utils.js
+++ b/server/lib/migration-utils.js
@@ -7,8 +7,15 @@
  * @param {String} tableName
  * @param {String} indexName
  * @param {Array<String>} fields - array of field names
+ * @param {object} [options] - additional options to apply to addIndex
  */
-async function addOrReplaceIndex(queryInterface, tableName, indexName, fields) {
+async function addOrReplaceIndex(
+  queryInterface,
+  tableName,
+  indexName,
+  fields,
+  options = {}
+) {
   const indexes = await queryInterface.showIndex(tableName);
 
   const found = indexes.find((index) => index.name === indexName);
@@ -18,6 +25,7 @@ async function addOrReplaceIndex(queryInterface, tableName, indexName, fields) {
     return queryInterface.addIndex(tableName, {
       fields,
       name: indexName,
+      ...options,
     });
   }
 
@@ -45,6 +53,7 @@ async function addOrReplaceIndex(queryInterface, tableName, indexName, fields) {
     await queryInterface.addIndex(tableName, {
       fields,
       name: indexName,
+      ...options,
     });
   }
 }

--- a/server/migrations/04-00200-nedb-sqlite-tables.js
+++ b/server/migrations/04-00200-nedb-sqlite-tables.js
@@ -328,6 +328,8 @@ async function up(queryInterface, config, appLog, nedb) {
         users_email: {
           fields: ['email'],
         },
+        // This is problematic for mssql as password_reset_id is nullable
+        // This is removed and replaced with a filtered unique index on non-null values
         users_password_reset_id: {
           fields: ['password_reset_id'],
         },

--- a/server/migrations/04-00600-password-reset-id-unique.js
+++ b/server/migrations/04-00600-password-reset-id-unique.js
@@ -10,7 +10,11 @@ const migrationUtils = require('../lib/migration-utils');
  */
 // eslint-disable-next-line no-unused-vars
 async function up(queryInterface, config, appLog, nedb, sequelizeDb) {
-  await queryInterface.removeConstraint('users', 'users_password_reset_id');
+  try {
+    await queryInterface.removeConstraint('users', 'users_password_reset_id');
+  } catch (error) {
+    // ignore error. constraint may not exist depending on backend database
+  }
 
   await migrationUtils.addOrReplaceIndex(
     queryInterface,

--- a/server/migrations/04-00600-password-reset-id-unique.js
+++ b/server/migrations/04-00600-password-reset-id-unique.js
@@ -1,0 +1,33 @@
+const Sequelize = require('sequelize');
+const migrationUtils = require('../lib/migration-utils');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ * @param {object} sequelizeDb - sequelize instance
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb, sequelizeDb) {
+  await queryInterface.removeConstraint('users', 'users_password_reset_id');
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'users',
+    'users_password_reset_id',
+    ['password_reset_id'],
+    {
+      unique: true,
+      where: {
+        password_reset_id: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+}
+
+module.exports = {
+  up,
+};

--- a/server/test/api/batches.js
+++ b/server/test/api/batches.js
@@ -106,6 +106,8 @@ describe('api/batches', function () {
     assert.equal(statement2.status, 'finished');
     assert.equal(statement2.rowCount, 2);
 
+    assert(Array.isArray(statement2.columns), 'statement.columns is an array');
+
     let column = statement2.columns[0];
     assert.equal(column.name, 'id');
     assert.equal(column.datatype, 'number');


### PR DESCRIPTION
SQL Server seems to not like repeat null values in a unique constraint.

This fixes the password_reset_id unique constraint by adding a migration to remove the existing constraint and replace with a filtered index.

FYI @yorek @eladeyal-intel 