### PR TITLE
Fix MSSQL JSON and queries list API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false # if one job fails, others will not be aborted
       matrix:
-        backendtype: ['', 'mssql', 'mysql', 'mariadb', 'postgres']
+        backendtype: [ '', 'mssql','mysql', 'mariadb', 'postgres' ]
         node-version: [12.x]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false # if one job fails, others will not be aborted
       matrix:
-        backendtype: [ '', 'mssql','mysql', 'mariadb', 'postgres' ]
+        backendtype: ['', 'mssql', 'mysql', 'mariadb', 'postgres']
         node-version: [12.x]
 
     steps:

--- a/server/migrations/04-00200-nedb-sqlite-tables.js
+++ b/server/migrations/04-00200-nedb-sqlite-tables.js
@@ -330,9 +330,10 @@ async function up(queryInterface, config, appLog, nedb) {
         },
         // This is problematic for mssql as password_reset_id is nullable
         // This is removed and replaced with a filtered unique index on non-null values
-        users_password_reset_id: {
-          fields: ['password_reset_id'],
-        },
+        // This needs to be commented out to allow migration check to pass for mssql
+        // users_password_reset_id: {
+        //   fields: ['password_reset_id'],
+        // },
       },
     }
   );

--- a/server/migrations/04-00700-fix-acl-unique-constraints.js
+++ b/server/migrations/04-00700-fix-acl-unique-constraints.js
@@ -1,0 +1,75 @@
+const Sequelize = require('sequelize');
+const migrationUtils = require('../lib/migration-utils');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ * @param {object} sequelizeDb - sequelize instance
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb, sequelizeDb) {
+  async function tryRemove(tableName, constraintName) {
+    try {
+      await queryInterface.removeConstraint(tableName, constraintName);
+    } catch (error) {
+      // ignore error. constraint may not exist depending on backend database
+    }
+  }
+
+  // Try removing existing query_acl unique constraints
+  // They need to be updated for non-null values for SQL Server compat
+  await tryRemove('query_acl', 'query_acl_user_email_query_id_key');
+  await tryRemove('query_acl', 'query_acl_group_id_query_id_key');
+  await tryRemove('query_acl', 'query_acl_user_id_query_id_key');
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'query_acl',
+    'query_acl_user_email_query_id_key',
+    ['user_email', 'query_id'],
+    {
+      unique: true,
+      where: {
+        user_email: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'query_acl',
+    'query_acl_group_id_query_id_key',
+    ['group_id', 'query_id'],
+    {
+      unique: true,
+      where: {
+        group_id: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'query_acl',
+    'query_acl_user_id_query_id_key',
+    ['user_id', 'query_id'],
+    {
+      unique: true,
+      where: {
+        user_id: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+}
+
+module.exports = {
+  up,
+};

--- a/server/models/batches.js
+++ b/server/models/batches.js
@@ -1,4 +1,5 @@
 const sqlLimiter = require('sql-limiter');
+const ensureJson = require('./ensure-json');
 
 class Batches {
   /**
@@ -16,12 +17,18 @@ class Batches {
       return;
     }
     batch = batch.toJSON();
+    batch.chart = ensureJson(batch.chart);
 
     const statements = await this.sequelizeDb.Statements.findAll({
       where: { batchId: id },
       order: [['sequence', 'ASC']],
     });
-    batch.statements = statements.map((s) => s.toJSON());
+    batch.statements = statements.map((s) => {
+      s = s.toJSON();
+      s.columns = ensureJson(s.columns);
+      s.error = ensureJson(s.error);
+      return s;
+    });
 
     return batch;
   }

--- a/server/models/ensure-json.js
+++ b/server/models/ensure-json.js
@@ -1,0 +1,18 @@
+const appLog = require('../lib/app-log');
+
+/**
+ * If value is string try and parse JSON
+ * Required to follow up on JSON fields when using SQL Server, as they are returned as string
+ * @param {*} value
+ */
+module.exports = function ensureJson(value) {
+  let final = value;
+  if (typeof value === 'string') {
+    try {
+      final = JSON.parse(value);
+    } catch (error) {
+      appLog.warn(error, 'Error parsing JSON for SQL Server');
+    }
+  }
+  return final;
+};

--- a/server/models/queries.js
+++ b/server/models/queries.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const ensureJson = require('./ensure-json');
 /*
 "chart": {
     "chartType": "line",
@@ -29,6 +30,7 @@ class Queries {
       return;
     }
     query = query.toJSON();
+    query.chart = ensureJson(query.chart);
     const tags = await this.sequelizeDb.QueryTags.findAll({
       attributes: ['tag'],
       where: { queryId: id },
@@ -59,6 +61,7 @@ class Queries {
       if (queryTags) {
         query.tags = queryTags.map((qt) => qt.tag);
       }
+      query.chart = ensureJson(query.chart);
       return query;
     });
     return queries;

--- a/server/models/schema-info.js
+++ b/server/models/schema-info.js
@@ -1,3 +1,5 @@
+const ensureJson = require('./ensure-json');
+
 class SchemaInfo {
   /**
    * @param {import('../sequelize-db')}
@@ -21,7 +23,7 @@ class SchemaInfo {
       return;
     }
 
-    return doc.data;
+    return ensureJson(doc.data);
   }
 
   /**

--- a/server/models/statements.js
+++ b/server/models/statements.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const { Op } = require('sequelize');
+const ensureJson = require('./ensure-json');
 const writeFile = util.promisify(fs.writeFile);
 const readFile = util.promisify(fs.readFile);
 const unlink = util.promisify(fs.unlink);
@@ -26,6 +27,8 @@ class Statements {
     if (!statement) {
       return;
     }
+    statement.columns = ensureJson(statement.columns);
+    statement.error = ensureJson(statement.error);
     return statement.toJSON();
   }
 
@@ -34,7 +37,12 @@ class Statements {
       where: { batchId },
       order: [['sequence', 'ASC']],
     });
-    items = items.map((item) => item.toJSON());
+    items = items.map((item) => {
+      const i = item.toJSON();
+      i.columns = ensureJson(i.columns);
+      i.error = ensureJson(i.error);
+      return i;
+    });
     return items;
   }
 

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -1,4 +1,5 @@
 const passhash = require('../lib/passhash.js');
+const ensureJson = require('./ensure-json.js');
 
 class Users {
   /**
@@ -40,20 +41,28 @@ class Users {
     const user = await this.sequelizeDb.Users.findOne({
       where: { email: email.toLowerCase() },
     });
-    return user && user.toJSON();
+    if (user) {
+      let final = user.toJSON();
+      final.data = ensureJson(final.data);
+      return final;
+    }
   }
 
   async findOneById(id) {
     const user = await this.sequelizeDb.Users.findOne({ where: { id } });
-    return user && user.toJSON();
+    if (user) {
+      let final = user.toJSON();
+      final.data = ensureJson(final.data);
+      return final;
+    }
   }
 
   findOneByPasswordResetId(passwordResetId) {
     return this.sequelizeDb.Users.findOne({ where: { passwordResetId } });
   }
 
-  findAll() {
-    return this.sequelizeDb.Users.findAll({
+  async findAll() {
+    const users = await this.sequelizeDb.Users.findAll({
       attributes: [
         'id',
         'name',
@@ -65,6 +74,11 @@ class Users {
         'updatedAt',
       ],
       order: [['email']],
+    });
+
+    return users.map((user) => {
+      user.data = ensureJson(user.data);
+      return user;
     });
   }
 

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -61,7 +61,7 @@ router.delete('/api/queries/:id', mustBeAuthenticated, wrap(deleteQuery));
  * @param {Res} res
  */
 async function listQueries(req, res) {
-  const { models, user, query } = req;
+  const { models, user, query, config } = req;
   const {
     connectionId,
     tags,
@@ -151,8 +151,8 @@ async function listQueries(req, res) {
   }
 
   // sortBy takes direction (+/-) and fieldname of either +name, or -updatedAt
-  let sortByDirection;
-  let sortByField;
+  let sortByDirection = 'ASC';
+  let sortByField = 'name';
   if (sortBy && sortBy.startsWith('+')) {
     sortByDirection = 'ASC';
     sortByField = sortBy.slice(1);
@@ -167,17 +167,29 @@ async function listQueries(req, res) {
   if (sortByField && !allowedSortByFields.includes(sortByField)) {
     return res.utils.error('sortBy field must be "name" or "updatedAt"');
   }
-  if (sortByField) {
-    // sortByField is validated, no concern for SQL injection here
-    sql += ` ORDER BY queries.${
-      sortByField === 'updatedAt' ? 'updated_at' : 'name'
-    } ${sortByDirection}`;
-  }
-  if (limit) {
-    sql += ` LIMIT ${parseInt(limit, 10)}`;
-  }
-  if (offset) {
-    sql += ` OFFSET ${parseInt(offset, 10)}`;
+
+  // sortByField is validated, no concern for SQL injection here
+  sql += ` ORDER BY queries.${
+    sortByField === 'updatedAt' ? 'updated_at' : 'name'
+  } ${sortByDirection}`;
+
+  const parsedOffset = parseInt(offset, 10) || 0;
+  const parsedLimit = parseInt(limit, 10);
+
+  if (config.get('backendDatabaseUri').startsWith('mssql')) {
+    if (limit) {
+      sql += `
+        OFFSET ${parsedOffset} ROWS
+        FETCH NEXT ${parsedLimit} ROWS ONLY
+      `;
+    }
+  } else {
+    if (limit) {
+      sql += ` LIMIT ${parsedLimit}`;
+    }
+    if (offset) {
+      sql += ` OFFSET ${parsedOffset}`;
+    }
   }
 
   let queries = await models.sequelizeDb.sequelize.query(sql, {

--- a/server/test/migrations/nedb-to-sqlite.js
+++ b/server/test/migrations/nedb-to-sqlite.js
@@ -84,6 +84,9 @@ describe('v4-to-v5', function () {
       assert.equal(query.connectionId, original.connectionId, 'connectionId');
       assert.equal(query.queryText, original.queryText);
       if (original.chartConfiguration) {
+        if (typeof query.chart === 'string') {
+          query.chart = JSON.parse(query.chart);
+        }
         assert.deepEqual(query.chart, original.chartConfiguration);
       }
       assert.equal(query.createdBy, original.createdBy, 'createdBy');


### PR DESCRIPTION
Adds work around for lack of proper JSON support in SQL Server. 

While the JSON datatype can be added to SQL Server as a string, Sequelize does not parse that string to an object. As a solution, the field checked and parsed in application code after the fact. 

This isn't great, but it works for now.

This also fixes a SQL incompatibility in the queries list API route to address the fact that SQL Server does not support LIMIT/OFFSET. 