### PR TITLE
use ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch.


### PR DESCRIPTION
We were using ubuntu-20.04 when we thought to use the integrated mysql server. Ubuntu-latest is still older but I guess it's better to use the default versioninstead of futuristic preview.