### PR TITLE
Add OIDC authorization strategy

### DIFF
--- a/client/src/SignIn.js
+++ b/client/src/SignIn.js
@@ -8,6 +8,7 @@ import message from './common/message';
 import Spacer from './common/Spacer';
 import { api } from './utilities/fetch-json.js';
 import useAppContext from './utilities/use-app-context';
+import ButtonLink from './common/ButtonLink';
 
 function SignIn() {
   const [email, setEmail] = useState('');
@@ -115,12 +116,32 @@ function SignIn() {
     </div>
   );
 
+  const oidcForm = (
+    <div>
+      <Spacer />
+      <ButtonLink
+        variant="primary"
+        style={{
+          width: '100%',
+          textAlign: 'center',
+        }}
+        href={config.baseUrl + '/auth/oidc'}
+      >
+        <div
+          className="w-100"
+          dangerouslySetInnerHTML={{ __html: config.oidcLinkHtml }}
+        />
+      </ButtonLink>
+    </div>
+  );
+
   return (
     <div style={{ width: '300px', textAlign: 'center', margin: '100px auto' }}>
       <h1>SQLPad</h1>
       {config.localAuthConfigured && localForm}
       {config.googleAuthConfigured && googleForm}
       {config.samlConfigured && samlForm}
+      {config.oidcConfigured && oidcForm}
     </div>
   );
 }

--- a/client/src/common/ButtonLink.js
+++ b/client/src/common/ButtonLink.js
@@ -5,19 +5,46 @@ import Tooltip from './Tooltip';
 
 const ICON_SIZE = 20;
 
-const ButtonLink = ({ className, children, icon, tooltip, ...rest }) => {
+const ButtonLink = ({
+  className,
+  children,
+  icon,
+  tooltip,
+  to,
+  href,
+  variant,
+  ...rest
+}) => {
   const classNames = [styles.btnLink];
+
+  if (variant === 'primary') {
+    classNames.push(styles.primary);
+  } else if (variant === 'ghost') {
+    classNames.push(styles.ghost);
+  }
+
   if (className) {
     classNames.push(className);
   }
 
-  const link = (
-    <Link className={classNames.join(' ')} {...rest}>
-      {icon && React.cloneElement(icon, { size: ICON_SIZE }, null)}
-      {children && icon && <span style={{ width: 4 }} />}
-      {children}
-    </Link>
-  );
+  let link;
+  if (href) {
+    link = (
+      <a href={href} className={classNames.join(' ')} {...rest}>
+        {icon && React.cloneElement(icon, { size: ICON_SIZE }, null)}
+        {children && icon && <span style={{ width: 4 }} />}
+        {children}
+      </a>
+    );
+  } else {
+    link = (
+      <Link to={to} className={classNames.join(' ')} {...rest}>
+        {icon && React.cloneElement(icon, { size: ICON_SIZE }, null)}
+        {children && icon && <span style={{ width: 4 }} />}
+        {children}
+      </Link>
+    );
+  }
 
   if (tooltip) {
     return (

--- a/client/src/common/ButtonLink.module.css
+++ b/client/src/common/ButtonLink.module.css
@@ -54,3 +54,48 @@
   border: 1px solid transparent;
   border-color: #d9d9d9;
 }
+
+.primary {
+  color: #fff;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 0 rgb(9, 100, 185, 0.5);
+}
+
+.primary:hover,
+.primary:focus {
+  color: #fff;
+  background-color: var(--primary-light-color);
+  border-color: var(--secondary-color);
+}
+
+.primary:active {
+  color: #fff;
+  background-color: var(--primary-dark-color);
+  border-color: var(--secondary-dark-color);
+}
+
+.ghost {
+  color: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 1px 0 transparent;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.ghost:hover,
+.ghost:focus {
+  color: rgba(255, 255, 255, 0.85);
+  background-color: transparent;
+}
+
+.ghost:active {
+  color: rgba(255, 255, 255, 1);
+  background-color: transparent;
+}
+
+.ghost:disabled,
+.ghost[disabled] {
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -77,6 +77,41 @@ For OAuth to be useful this usually involves the following:
 - `PUBLIC_URL`=`http://localhost`
 - `DISABLE_USERPASS_AUTH`=`true` (optional - disables plain local user logins)
 
+## OpenID Connect
+
+OpenID Connect authentication can be enabled by setting the following required environment variables:
+
+```sh
+# localhost used in dev
+PUBLIC_URL = "http://localhost:3010"
+SQLPAD_OIDC_CLIENT_ID = "actual-client-id"
+SQLPAD_OIDC_CLIENT_SECRET = "actual-client-secret"
+# URLs will vary by provider
+SQLPAD_OIDC_ISSUER = "https://some.openidprovider.com/oauth2/default"
+SQLPAD_OIDC_AUTHORIZATION_URL = "https://some.openidprovider.com/oauth2/default/v1/authorize"
+SQLPAD_OIDC_TOKEN_URL = "https://some.openidprovider.com/oauth2/default/v1/token"
+SQLPAD_OIDC_USER_INFO_URL = "https://some.openidprovider.okta.com/oauth2/default/v1/userinfo"
+```
+
+The callback redirect URI used by SQLPad is `<baseurl>/auth/oidc/callback`.
+
+For the above configuration, assuming `SQLPAD_BASE_URL = "/sqlpad"`, the callback URI configured with the provider should be `http://localhost:3010/sqlpad/auth/oidc/callback`.
+
+The contents of the OpenID sign in button can be customized with the following
+
+```sh
+SQLPAD_OIDC_LINK_HTML = "text or inner html here"
+```
+
+Prior to authenticating via OpenID, users must still be added to SQLPad with their email address used to log in.
+
+This can be bypassed by using allowed domains to auto-add users for emails belonging to certain domains.
+
+```sh
+# space delimited list of domains to allow
+SQLPAD_ALLOWED_DOMAINS = "mycompany.com"
+```
+
 ## SAML
 
 SAML-based authentication can be enabled by setting the necessary environment variables:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -485,3 +485,52 @@ Password for LDAP user used for LDAP lookup
 
 - Key: `ldapPassword`
 - Env: `LDAP_PASSWORD`
+
+## OpenID Connect
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>SQLPAD_OIDC_CLIENT_ID</code></td>
+      <td>Client ID</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><code>SQLPAD_OIDC_CLIENT_SECRET</code></td>
+      <td>Client secret</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><code>SQLPAD_OIDC_ISSUER</code></td>
+      <td>Issuer</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><code>SQLPAD_OIDC_AUTHORIZATION_URL</code></td>
+      <td>Authorization URL</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><code>SQLPAD_OIDC_TOKEN_URL</code></td>
+      <td>Token URL</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><code>SQLPAD_OIDC_USER_INFO_URL</code></td>
+      <td>User info URL</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><code>SQLPAD_OIDC_LINK_HTML</code></td>
+      <td>Inner HTML for OpenID sign in button customization</td>
+      <td>Sign in with OpenID</td>
+    </tr>
+  </tbody>
+</table>

--- a/server/app.js
+++ b/server/app.js
@@ -124,6 +124,7 @@ async function makeApp(config, models) {
     require('./routes/signup.js'),
     require('./routes/signin.js'),
     require('./routes/google-auth.js'),
+    require('./routes/auth-oidc.js'),
     require('./routes/saml.js'),
   ];
 

--- a/server/auth-strategies/index.js
+++ b/server/auth-strategies/index.js
@@ -6,6 +6,7 @@ const google = require('./google');
 const jwtServiceToken = require('./jwt-service-token');
 const ldap = require('./ldap');
 const local = require('./local');
+const oidc = require('./oidc');
 const saml = require('./saml');
 
 // The serializeUser/deserializeUser functions apply regardless of the strategy used.
@@ -46,6 +47,7 @@ async function authStrategies(config, models) {
   jwtServiceToken(config);
   ldap(config);
   local(config);
+  oidc(config);
   saml(config);
 }
 

--- a/server/auth-strategies/oidc.js
+++ b/server/auth-strategies/oidc.js
@@ -1,0 +1,104 @@
+const passport = require('passport');
+const OidcStrategy = require('passport-openidconnect').Strategy;
+const appLog = require('../lib/app-log');
+const checkAllowedDomains = require('../lib/check-allowed-domains.js');
+
+async function passportOidcStrategyHandler(
+  req,
+  issuer,
+  sub,
+  profile,
+  accessToken,
+  refreshToken,
+  done
+) {
+  const { models, config, appLog } = req;
+  const _json = profile._json || {};
+
+  // _json.sub appears to be an id. Is it? Should .sub be used for SQLPad user id?
+  // Unsure if email ever doesn't exist if email claim is requested,
+  // but just in case fall back to preferred_username
+  const email = _json.email || _json.preferred_username;
+  const name = _json.name;
+
+  if (!email) {
+    appLog.debug('OIDC email not provided');
+    return done(null, false, {
+      message: 'email not provided',
+    });
+  }
+
+  try {
+    let [openAdminRegistration, user] = await Promise.all([
+      models.users.adminRegistrationOpen(),
+      models.users.findOneByEmail(email),
+    ]);
+
+    if (user) {
+      if (user.disabled) {
+        appLog.debug(`OIDC User ${email} is disabled`);
+        return done(null, false);
+      }
+      user.signupAt = new Date();
+      const newUser = await models.users.update(user.id, {
+        name,
+        signupAt: new Date(),
+      });
+      appLog.debug(`OIDC User ${email} updated`);
+      return done(null, newUser);
+    }
+    const allowedDomains = config.get('allowedDomains');
+    if (openAdminRegistration || checkAllowedDomains(allowedDomains, email)) {
+      const newUser = await models.users.create({
+        name,
+        email,
+        role: openAdminRegistration ? 'admin' : 'editor',
+        signupAt: new Date(),
+      });
+      appLog.debug(`OIDC User ${email} created`);
+      return done(null, newUser);
+    }
+    // at this point we don't have an error, but authentication is invalid
+    // per passport docs, we call done() here without an error
+    // instead passing false for user and a message why
+    appLog.debug(`OIDC User ${email} not allowed`);
+    return done(null, false, {
+      message: "You haven't been invited by an admin yet.",
+    });
+  } catch (error) {
+    done(error, null);
+  }
+}
+
+/**
+ * Adds OIDC auth strategy if OIDC auth is configured
+ * @param {object} config
+ */
+function enableOidc(config) {
+  if (config.oidcConfigured()) {
+    appLog.info('Enabling OIDC authentication strategy.');
+
+    const baseUrl = config.get('baseUrl');
+    const publicUrl = config.get('publicUrl');
+
+    passport.use(
+      'oidc',
+      new OidcStrategy(
+        {
+          passReqToCallback: true,
+          issuer: config.get('oidcIssuer'),
+          authorizationURL: config.get('oidcAuthorizationUrl'),
+          tokenURL: config.get('oidcTokenUrl'),
+          userInfoURL: config.get('oidcUserInfoUrl'),
+          clientID: config.get('oidcClientId'),
+          clientSecret: config.get('oidcClientSecret'),
+          callbackURL: publicUrl + baseUrl + '/auth/oidc/callback',
+          scope: 'openid profile email',
+        },
+        passportOidcStrategyHandler
+      )
+    );
+  }
+}
+
+module.exports = enableOidc;

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -10,3 +10,17 @@ SQLPAD_DEFAULT_CONNECTION_ID = devdbdriverid123
 SQLPAD_CONNECTIONS__devdbdriverid123__driver = sqlite
 SQLPAD_CONNECTIONS__devdbdriverid123__name = dev connection from config
 SQLPAD_CONNECTIONS__devdbdriverid123__filename = "./test/fixtures/sales.sqlite"
+
+# OIDC connect config
+# Implementation used okta tutorial for testing/dev
+# https://developer.okta.com/blog/2018/05/18/node-authentication-with-passport-and-oidc
+# allowed domains not necessary, but is honored for oidc
+# 
+# SQLPAD_ALLOWED_DOMAINS = "gmail.com other.com"
+# PUBLIC_URL = "http://localhost:3010"
+# SQLPAD_OIDC_CLIENT_ID = CLIENT_ID
+# SQLPAD_OIDC_CLIENT_SECRET = SECRET
+# SQLPAD_OIDC_ISSUER = "https://dev-350224.okta.com/oauth2/default"
+# SQLPAD_OIDC_AUTHORIZATION_URL = "https://dev-350224.okta.com/oauth2/default/v1/authorize"
+# SQLPAD_OIDC_TOKEN_URL = "https://dev-350224.okta.com/oauth2/default/v1/token"
+# SQLPAD_OIDC_USER_INFO_URL = "https://dev-350224.okta.com/oauth2/default/v1/userinfo"

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -366,6 +366,41 @@ const configItems = [
     envVar: 'SQLPAD_AUTH_PROXY_HEADERS',
     default: '',
   },
+  {
+    key: 'oidcClientId',
+    envVar: 'SQLPAD_OIDC_CLIENT_ID',
+    default: '',
+  },
+  {
+    key: 'oidcClientSecret',
+    envVar: 'SQLPAD_OIDC_CLIENT_SECRET',
+    default: '',
+  },
+  {
+    key: 'oidcIssuer',
+    envVar: 'SQLPAD_OIDC_ISSUER',
+    default: '',
+  },
+  {
+    key: 'oidcAuthorizationUrl',
+    envVar: 'SQLPAD_OIDC_AUTHORIZATION_URL',
+    default: '',
+  },
+  {
+    key: 'oidcTokenUrl',
+    envVar: 'SQLPAD_OIDC_TOKEN_URL',
+    default: '',
+  },
+  {
+    key: 'oidcUserInfoUrl',
+    envVar: 'SQLPAD_OIDC_USER_INFO_URL',
+    default: '',
+  },
+  {
+    key: 'oidcLinkHtml',
+    envVar: 'SQLPAD_OIDC_LINK_HTML',
+    default: 'Sign in with Open ID',
+  },
 ];
 
 module.exports = configItems;

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -399,7 +399,7 @@ const configItems = [
   {
     key: 'oidcLinkHtml',
     envVar: 'SQLPAD_OIDC_LINK_HTML',
-    default: 'Sign in with Open ID',
+    default: 'Sign in with OpenID',
   },
 ];
 

--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -165,6 +165,18 @@ class Config {
     );
   }
 
+  oidcConfigured() {
+    return Boolean(
+      this.all.publicUrl &&
+        this.all.oidcClientId &&
+        this.all.oidcClientSecret &&
+        this.all.oidcIssuer &&
+        this.all.oidcAuthorizationUrl &&
+        this.all.oidcTokenUrl &&
+        this.all.oidcUserInfoUrl
+    );
+  }
+
   /**
    * Get connections from config.
    * These are provided at runtime and not upserted

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4298,6 +4298,17 @@
         "utils-merge": "1.x.x"
       }
     },
+    "passport-openidconnect": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/passport-openidconnect/-/passport-openidconnect-0.0.2.tgz",
+      "integrity": "sha1-5Ij4vbOGyan9OckdWrjIgBVugVM=",
+      "requires": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "request": "^2.75.0",
+        "webfinger": "0.4.x"
+      }
+    },
     "passport-saml": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/passport-saml/-/passport-saml-1.3.3.tgz",
@@ -5460,6 +5471,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "step": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/step/-/step-0.0.6.tgz",
+      "integrity": "sha1-FD54SaXX0/SgiP4pr5SRUhbu7eI="
+    },
     "stream-events": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
@@ -6142,6 +6158,25 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/vertica/-/vertica-0.5.5.tgz",
       "integrity": "sha1-tSZlmq0xBMIzIaNa6TY4pMDTX1M="
+    },
+    "webfinger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webfinger/-/webfinger-0.4.2.tgz",
+      "integrity": "sha1-NHem2XeZRhiWA5/P/GULc0aO520=",
+      "requires": {
+        "step": "0.0.x",
+        "xml2js": "0.1.x"
+      },
+      "dependencies": {
+        "xml2js": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
+          "integrity": "sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=",
+          "requires": {
+            "sax": ">=0.1.1"
+          }
+        }
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -78,6 +78,7 @@
     "passport-http": "^0.3.0",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
+    "passport-openidconnect": "0.0.2",
     "passport-saml": "^1.3.3",
     "pg": "^8.2.1",
     "pino": "^6.3.2",

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -36,6 +36,8 @@ async function getApp(req, res) {
       samlLinkHtml: config.get('samlLinkHtml') || config.get('samlLinkHtml_d'),
       smtpConfigured: config.smtpConfigured(),
       ldapConfigured: config.get('enableLdapAuth'),
+      oidcConfigured: config.oidcConfigured(),
+      oidcLinkHtml: config.get('oidcLinkHtml'),
     },
     version: packageJson.version,
   });

--- a/server/routes/auth-oidc.js
+++ b/server/routes/auth-oidc.js
@@ -1,0 +1,21 @@
+require('../typedefs');
+const passport = require('passport');
+const router = require('express').Router();
+
+/**
+ * @param {Req} req
+ * @param {Res} res
+ * @param {Function} next
+ */
+function handleOidcCallback(req, res, next) {
+  const baseUrl = req.config.get('baseUrl');
+  passport.authenticate('oidc', {
+    successRedirect: baseUrl + '/',
+    failureRedirect: baseUrl + '/signin',
+  })(req, res, next);
+}
+
+router.get('/auth/oidc', passport.authenticate('oidc'));
+router.get('/auth/oidc/callback', handleOidcCallback);
+
+module.exports = router;

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -26,6 +26,8 @@ const expectedConfigKeys = [
   'samlConfigured',
   'samlLinkHtml',
   'ldapConfigured',
+  'oidcConfigured',
+  'oidcLinkHtml',
 ];
 
 describe('api/app', function () {


### PR DESCRIPTION
Adds OIDC auth strategy. Follows existing patterns from Google auth, where allowed domains is considered. Allows for sign in button customization similar to SAML.

Okta was used for testing. They even have a guide for setting things up: https://developer.okta.com/blog/2018/05/18/node-authentication-with-passport-and-oidc

I'm not too familiar with how standardized OIDC is. Are `email` and `profile` claims always present? Is the shape of profile standardized? Does this need to be configurable?

TODO: Documentation 

closes #443 