### PR TITLE
Use ENV for docker image defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ COPY --from=build /sqlpad/docker-entrypoint /
 COPY --from=build /sqlpad/server .
 
 ENV NODE_ENV production
+ENV SQLPAD_DB_PATH /var/lib/sqlpad
+ENV SQLPAD_PORT 3000
 EXPOSE 3000
 ENTRYPOINT ["/docker-entrypoint"]
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec node /usr/app/server.js --dbPath ${SQLPAD_DB_PATH:-/var/lib/sqlpad} --port 3000 $@
+exec node /usr/app/server.js $@


### PR DESCRIPTION
Use ENV for docker image defaults. This allows docker port to be overridden 

fixes #771