### PR TITLE
Remove unused httpsPort

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,14 +172,6 @@ Google Client Secret used for OAuth setup. Authorized redirect URI for sqlpad is
 - Key: `googleClientSecret`
 - Env: `SQLPAD_GOOGLE_CLIENT_SECRET`
 
-## httpsPort
-
-Port for SQLPad to listen on.
-
-- Key: `httpsPort`
-- Env: `SQLPAD_HTTPS_PORT`
-- Default: `443`
-
 ## ip
 
 IP address to bind to. By default SQLPad will listen from all available addresses (0.0.0.0).
@@ -207,11 +199,11 @@ A string of text used to encrypt connection user and password values when stored
 
 ## port
 
-Port for SQLPad to listen on.
+Port for SQLPad to listen on. Used for both HTTP and HTTPS.
 
 - Key: `port`
 - Env: `SQLPAD_PORT`
-- Default: `80`
+- Default: `80` in code / `3000` in Docker Hub image
 
 ## publicUrl
 

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -50,11 +50,6 @@ const configItems = [
     default: false,
   },
   {
-    key: 'httpsPort',
-    envVar: 'SQLPAD_HTTPS_PORT',
-    default: 443,
-  },
-  {
     key: 'dbPath',
     envVar: 'SQLPAD_DB_PATH',
     default: '',

--- a/server/server.js
+++ b/server/server.js
@@ -80,7 +80,6 @@ makeDb(config);
 const baseUrl = config.get('baseUrl');
 const ip = config.get('ip');
 const port = config.get('port');
-const httpsPort = config.get('port');
 const certPassphrase = config.get('certPassphrase');
 const keyPath = config.get('keyPath');
 const certPath = config.get('certPath');
@@ -176,15 +175,15 @@ async function startServer() {
   // determine if key pair exists for certs
   if (keyPath && certPath) {
     // https only
-    const _port = await detectPortOrSystemd(httpsPort);
-    if (!isFdObject(_port) && parseInt(httpsPort, 10) !== parseInt(_port, 10)) {
+    const _port = await detectPortOrSystemd(port);
+    if (!isFdObject(_port) && parseInt(port, 10) !== parseInt(_port, 10)) {
       appLog.info(
         'Port %d already occupied. Using port %d instead.',
-        httpsPort,
+        port,
         _port
       );
       // TODO FIXME XXX  Persist the new port to the in-memory store.
-      // config.set('httpsPort', _port)
+      // config.set('port', _port)
     }
 
     const privateKey = fs.readFileSync(keyPath, 'utf8');

--- a/server/test/lib/config.js
+++ b/server/test/lib/config.js
@@ -135,7 +135,7 @@ describe('lib/config/fromFile', function () {
 describe('lib/config', function () {
   it('.get() should get a value provided by default', function () {
     const config = new Config({}, {});
-    assert.equal(config.get('httpsPort'), 443, 'httpsPort=443');
+    assert.equal(config.get('ip'), '0.0.0.0');
   });
 
   it('.get() should only accept key in config items', function () {


### PR DESCRIPTION
Removes unused `SQLPAD_HTTPS_PORT`. This config variable is not actually used, with `SQLPAD_PORT` being used for HTTPS if set up instead.

closes #770 