### PR TITLE
Capture and return odbc driver error when establishing connection client

### DIFF
--- a/server/drivers/unixodbc/index.js
+++ b/server/drivers/unixodbc/index.js
@@ -116,7 +116,18 @@ class Client {
       cn = cn + ';Pwd=' + password;
     }
 
-    this.client = await odbc.connect(cn);
+    try {
+      this.client = await odbc.connect(cn);
+    } catch (error) {
+      // unixodb error has additional info about why the error occurred
+      // It has an array of objects with messages.
+      // If that exists send an error with the first message.
+      if (Array.isArray(error.odbcErrors)) {
+        const e = error.odbcErrors[0];
+        throw new Error(e.message);
+      }
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
Captures the underlying database driver error when problem connecting to database, and returns it when establishing connection client.

Previously this error was a generic ODBC connection error. The odbcErrors array has the messaging that is more relevant for end user.