### PR TITLE
Deprecate email and slack

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,6 +6,7 @@
   - [Seed Data](/seed-data.md)
   - [Connection Templates](/connection-templates.md)
   - [Logging](/logging.md)
+  - [Webhooks](/webhooks.md)
 - API
   - [Overview](/api-overview.md)
   - [Batches & Statements](/api-batches.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,53 +279,32 @@ Minutes to keep a session active. Will extended by this amount each request.
 
 ## slackWebhook
 
-Supply incoming Slack webhook URL to post query when saved.
+!> Deprecated. To be removed in v6. Use webhooks and implement preferred communication instead.
 
-- Key: `slackWebhook`
-- Env: `SQLPAD_SLACK_WEBHOOK`
+```bash
+# Supply incoming Slack webhook URL to post query when saved.
+SQLPAD_SLACK_WEBHOOK = ""
+```
 
-## smtpFrom
+## SMTP
 
-From email address for SMTP. Required in order to send invitation emails.
+!> Deprecated. To be removed in v6. Use webhooks and implement preferred communication instead.
 
-- Key: `smtpFrom`
-- Env: `SQLPAD_SMTP_FROM`
-
-## smtpHost
-
-Host address for SMTP. Required in order to send invitation emails.
-
-- Key: `smtpHost`
-- Env: `SQLPAD_SMTP_HOST`
-
-## smtpPassword
-
-Password for SMTP.
-
-- Key: `smtpPassword`
-- Env: `SQLPAD_SMTP_PASSWORD`
-
-## smtpPort
-
-Port for SMTP. Required in order to send invitation emails.
-
-- Key: `smtpPort`
-- Env: `SQLPAD_SMTP_PORT`
-
-## smtpSecure
-
-Toggle to use secure connection when using SMTP.
-
-- Key: `smtpSecure`
-- Env: `SQLPAD_SMTP_SECURE`
-- Default: `true`
-
-## smtpUser
-
-Username for SMTP. Required in order to send invitation emails.
-
-- Key: `smtpUser`
-- Env: `SQLPAD_SMTP_USER`
+```bash
+# From email address for SMTP. Required in order to send invitation emails.
+SQLPAD_SMTP_FROM = ""
+# Host address for SMTP. Required in order to send invitation emails.
+SQLPAD_SMTP_HOST = ""
+# Password for SMTP.
+SQLPAD_SMTP_PASSWORD = ""
+# Port for SMTP. Required in order to send invitation emails.
+SQLPAD_SMTP_PORT = ""
+# Toggle to use secure connection when using SMTP.
+# Defaults to true
+SQLPAD_SMTP_SECURE = "true"
+# Username for SMTP. Required in order to send invitation emails.
+SQLPAD_SMTP_USER = ""
+```
 
 ## systemdSocket
 

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -266,36 +266,50 @@ const configItems = [
     key: 'slackWebhook',
     envVar: 'SQLPAD_SLACK_WEBHOOK',
     default: '',
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'smtpFrom',
     envVar: 'SQLPAD_SMTP_FROM',
     default: '',
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'smtpHost',
     envVar: 'SQLPAD_SMTP_HOST',
     default: '',
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'smtpPort',
     envVar: 'SQLPAD_SMTP_PORT',
     default: '',
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'smtpSecure',
     envVar: 'SQLPAD_SMTP_SECURE',
     default: true,
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'smtpUser',
     envVar: 'SQLPAD_SMTP_USER',
     default: '',
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'smtpPassword',
     envVar: 'SQLPAD_SMTP_PASSWORD',
     default: '',
+    deprecated:
+      'To be removed in v6. Use webhooks and implement preferred communication instead.',
   },
   {
     key: 'whitelistedDomains',

--- a/server/lib/email.js
+++ b/server/lib/email.js
@@ -1,6 +1,10 @@
 const nodemailer = require('nodemailer');
 const appLog = require('./app-log');
 
+/**
+ * TODO: Deprecated. Remove in v6. Replaced with webhooks
+ * @param {*} config
+ */
 function makeEmail(config) {
   /**
    * Get full sqlpad url

--- a/server/lib/push-query-to-slack.js
+++ b/server/lib/push-query-to-slack.js
@@ -1,6 +1,12 @@
 const appLog = require('./app-log');
 const request = require('request');
 
+/**
+ * TODO: Deprecated. Remove in v6. Replaced with webhooks
+ * @param {*} config
+ * @param {*} query
+ * @param {*} user
+ */
 function pushQueryToSlack(config, query, user) {
   const SLACK_WEBHOOK = config.get('slackWebhook');
   if (SLACK_WEBHOOK) {


### PR DESCRIPTION
This functionality is not tested, and can be owned by end users of SQLPad by utilizing webhooks. 