### PR TITLE
Use bash snippets for configuration documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,63 +195,6 @@ By default query results are limited to 50,000 records.
 - Env: `SQLPAD_QUERY_RESULT_MAX_ROWS`
 - Default: `50000`
 
-## samlAuthContext
-
-SAML authentication context URL. A sensible value is: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`.
-
-- Key: `samlAuthContext`
-- Env: `SQLPAD_SAML_AUTH_CONTEXT`
-
-## samlCallbackUrl
-
-SAML callback URL. It will generally be constructed from the deployment's internet address and the fixed route, for example: https://mysqlpad.com/login/callback
-
-- Key: `samlCallbackUrl`
-- Env: `SQLPAD_SAML_CALLBACK_URL`
-
-## samlCert
-
-SAML certificate in Base64
-
-- Key: `samlCert`
-- Env: `SQLPAD_SAML_CERT`
-
-## samlEntryPoint
-
-SAML Entry point URL
-
-- Key: `samlEntryPoint`
-- Env: `SQLPAD_SAML_ENTRY_POINT`
-
-## samlIssuer
-
-SAML Issuer
-
-- Key: `samlIssuer`
-- Env: `SQLPAD_SAML_ISSUER`
-
-## samlLinkHtml
-
-HTML code for the sign-in link used for starting SAML authentication. The default is `Sign in with SSO`
-
-- Key: `samlLinkHtml`
-- Env: `SQLPAD_SAML_LINK_HTML`
-
-## samlAutoSignUp
-
-Auto create a user record if it does not exist when new user is detected via SAML
-
-- Key: `samlAutoSignUp`
-- Env: `SQLPAD_SAML_AUTO_SIGN_UP`
-- Default: `false`
-
-## samlDefaultRole
-
-Default role to assign user created when `samlAutoSignUp` is turned on. Accepted values are `editor` and `admin`. Default value is `editor`.
-
-- Key: `samlDefaultRole`
-- Env: `SQLPAD_SAML_DEFAULT_ROLE`
-
 ## serviceTokenSecret
 
 Secret to sign the generated Service Tokens.
@@ -470,6 +413,127 @@ HTTPS may be configured to be used by SQLPad directly. However if performance be
 - `SQLPAD_HTTPS_CERT_PATH`: Absolute path to where SSL certificate is stored
 - `SQLPAD_HTTPS_KEY_PATH`: Absolute path to where SSL certificate key is stored
 - `SQLPAD_HTTPS_CERT_PASSPHRASE`: Passphrase for your SSL certification file
+
+## SAML
+
+```bash
+# SAML authentication context URL.
+# A sensible value is: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`
+SQLPAD_SAML_AUTH_CONTEXT = ""
+
+# SAML callback URL.
+# It will generally be constructed from the deployment's internet address and the fixed route.
+# For example: `https://mysqlpad.com/login/callback`.
+SQLPAD_SAML_CALLBACK_URL = ""
+
+# SAML certificate in Base64
+SQLPAD_SAML_CERT = ""
+
+# Entry point url
+SQLPAD_SAML_ENTRY_POINT = ""
+
+SQLPAD_SAML_ISSUER = ""
+
+# HTML code for the sign-in link used for starting SAML authentication.
+SQLPAD_SAML_LINK_HTML = "Sign in with SSO"
+
+# Auto create a user record if it does not exist when new user is detected via SAML.
+SQLPAD_SAML_AUTO_SIGN_UP = "false"
+
+# Default role to assign user created when SQLPAD_SAML_AUTO_SIGN_UP is turned on.
+# Accepted values are `editor` and `admin`.
+SQLPAD_SAML_DEFAULT_ROLE = "editor"
+```
+
+**SQLPAD_SAML_AUTH_CONTEXT**
+
+SAML authentication context URL. A sensible value is: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`.
+
+**SQLPAD_SAML_CALLBACK_URL**
+
+SAML callback URL. It will generally be constructed from the deployment's internet address and the fixed route, for example: `https://mysqlpad.com/login/callback`.
+
+**SQLPAD_SAML_CERT**
+
+SAML certificate in Base64
+
+**SQLPAD_SAML_ENTRY_POINT**
+
+SAML entry point URL
+
+**SQLPAD_SAML_ISSUER**
+
+SAML Issuer
+
+**SQLPAD_SAML_LINK_HTML**
+
+HTML code for the sign-in link used for starting SAML authentication.
+
+Default: `Sign in with SSO`
+
+**SQLPAD_SAML_AUTO_SIGN_UP**
+
+Auto create a user record if it does not exist when new user is detected via SAML.
+
+Default: `false`
+
+**SQLPAD_SAML_DEFAULT_ROLE**
+
+Default role to assign user created when SQLPAD_SAML_AUTO_SIGN_UP is turned on. Accepted values are `editor` and `admin`.
+
+Default: `editor`
+
+<table>
+  <thead>
+    <tr>
+      <th>key</th>
+      <th>description</th>
+      <th>default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>SQLPAD_SAML_AUTH_CONTEXT</td>
+      <td>SAML authentication context URL. A sensible value is: <code>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_CALLBACK_URL</td>
+      <td>SAML callback URL. It will generally be constructed from the deployment's internet address and the fixed route, for example: <code>https://mysqlpad.com/login/callback</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_CERT</td>
+      <td>SAML certificate in Base64</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_ENTRY_POINT</td>
+      <td>SAML Entry point URL</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_ISSUER</td>
+      <td>SAML Issuer</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_LINK_HTML</td>
+      <td>HTML code for the sign-in link used for starting SAML authentication.</td>
+      <td>Sign in with SSO</td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_AUTO_SIGN_UP</td>
+      <td>Auto create a user record if it does not exist when new user is detected via SAML.</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <td>SQLPAD_SAML_DEFAULT_ROLE</td>
+      <td>Default role to assign user created when SQLPAD_SAML_AUTO_SIGN_UP is turned on. Accepted values are <code>editor</code> and <code>admin</code>.</td>
+      <td>editor</td>
+    </tr>
+  </tbody>
+</table>
 
 ## OpenID Connect
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ A [config file example](https://github.com/rickbergfalk/sqlpad/blob/master/confi
 # IP address to bind to. By default SQLPad will listen from all available addresses (0.0.0.0).
 SQLPAD_IP = "0.0.0.0"
 
-# Port to listen on. Used for both HTTP and HTTPS
+# Port to listen on. Used for both HTTP and HTTPS.
 # Defaults to 80 in code, 3000 in Docker Hub Image
 SQLPAD_PORT = 3000
 
@@ -38,13 +38,13 @@ PUBLIC_URL = ""
 # the queries page would be `https://mysqlpad.com/sqlpad/queries`
 SQLPAD_BASE_URL = ""
 
-# Passphrase to encrypt sensitive connection information (like user & password) when stored on disk
+# Passphrase to encrypt sensitive connection information (like user & password) when stored in backing database.
 SQLPAD_PASSPHRASE = "At least the sensitive bits won't be plain text?"
 
-# HTTP server timeout as number of seconds. Extend as necessary for long running queries.
+# HTTP server timeout as number of seconds.
 SQLPAD_TIMEOUT_SECONDS = 300
 
-# Minutes to keep a session active. Will extended by this amount each request.
+# Minutes to keep a session active. Session will be extended by this amount each request.
 SQLPAD_SESSION_MINUTES = 60
 
 # Name used for cookie. If running multiple SQLPads on same domain, set to different values.

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,5 +29,6 @@
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,5 +28,6 @@
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
 </body>
 </html>

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -136,7 +136,7 @@ Fires whenever a batch finished running. Payload contains summary information fo
 
 **Payload Body**:
 
-```js
+```json
 {
   "action": "batch_finished",
   "sqlpadUrl": "",


### PR DESCRIPTION
Uses bash snippets for configuration documentation.

I'm not 100% set on how config documentation is organized just yet, but I think this is an improvement over what was there previously. 

Now that config is driven by environment variables or an .env file, we can greatly simplify the docs by just focusing on the environment variable keys. `.env` files also allow comments, following sh/bash syntax.

This allows us to change the docs to include bash snippets, which are not only convenient to copy/paste, but also open up syntax highlighting as well.
