### PR TITLE
Fix Mysql2 transaction support

### DIFF
--- a/server/drivers/mysql/test.js
+++ b/server/drivers/mysql/test.js
@@ -72,4 +72,13 @@ describe('drivers/mysql', function () {
         assert(error.toString().indexOf('missing_table') > -1);
       });
   });
+
+  it('Client handles client interface', async function () {
+    const client = new mysql.Client(connection);
+    await client.connect();
+    await client.runQuery('START TRANSACTION');
+    await client.runQuery('SELECT 1 AS val');
+    await client.runQuery('ROLLBACK');
+    await client.disconnect();
+  });
 });

--- a/server/drivers/mysql2/index.js
+++ b/server/drivers/mysql2/index.js
@@ -113,7 +113,7 @@ class Client {
 
     // TODO - use fields from driver to return columns
     // eslint-disable-next-line no-unused-vars
-    const [rows, fields] = await this.client.execute(limitedQuery);
+    const [rows, fields] = await this.client.query(limitedQuery);
 
     if (rows.length >= maxRowsPlusOne) {
       return { rows: rows.slice(0, maxRows), incomplete: true };

--- a/server/drivers/mysql2/test.js
+++ b/server/drivers/mysql2/test.js
@@ -72,4 +72,13 @@ describe('drivers/mysql2', function () {
         assert(error.toString().indexOf('missing_table') > -1);
       });
   });
+
+  it('Client handles client interface', async function () {
+    const client = new mysql2.Client(connection);
+    await client.connect();
+    await client.runQuery('START TRANSACTION');
+    await client.runQuery('SELECT 1 AS val');
+    await client.runQuery('ROLLBACK');
+    await client.disconnect();
+  });
 });


### PR DESCRIPTION
Uses `.query` method instead of `.execute` for mysql2 driver, as `.execute` automatically prepares statements, which doesn't work for all SQL statements. 

Fixes #802 