### PR TITLE
mysql connections are interactive (#810)

### DIFF
--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -59,6 +59,7 @@ class Client {
       supportBigNumbers: true,
       ssl: connection.mysqlSsl,
       preQueryStatements: connection.preQueryStatements,
+      flags: '+INTERACTIVE',
     };
 
     // TODO cache key/cert values

--- a/server/drivers/mysql2/index.js
+++ b/server/drivers/mysql2/index.js
@@ -52,6 +52,7 @@ class Client {
       insecureAuth: connection.mysqlInsecureAuth,
       timezone: 'Z',
       supportBigNumbers: true,
+      flags: '+INTERACTIVE',
     };
     if (connection.mysqlSsl) {
       myConfig.ssl = {};


### PR DESCRIPTION
INTERACTIVE - Indicates to the MySQL server this is an "interactive" client. This will use the interactive timeouts on the MySQL server and report as interactive in the process list. (Default off)

https://www.npmjs.com/package/mysql/v/2.18.1