### PR TITLE
Fix query editor not clearing on new query

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11158,9 +11158,9 @@
       }
     },
     "react-ace": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.1.1.tgz",
-      "integrity": "sha512-dL0w6GwtnS1opsOoWhJaF7rF7xCM+NOEOfePmDfiaeU+EyZQ6nRWDBgyzKsuiB3hyXH3G9D6FX37ur/LKUdKjA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.0.0.tgz",
+      "integrity": "sha512-wcVlnffzKif2ejHCvTpawYS5jglTCsIUmLENo4hiwPU0vViKl/xuKp9afjKEQHzjLua9NfzbH8gA79GzGpmSnA==",
       "requires": {
         "ace-builds": "^1.4.6",
         "diff-match-patch": "^1.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.7.2",
     "query-string": "^6.13.1",
     "react": "^16.13.1",
-    "react-ace": "^9.1.1",
+    "react-ace": "9.0.0",
     "react-dom": "^16.13.1",
     "react-draggable": "^4.4.3",
     "react-measure": "^2.3.0",


### PR DESCRIPTION
This is a known react-ace issue. Downgrading to 9.0.0 restores expected functionality.

https://github.com/securingsincity/react-ace/issues/894