### PR TITLE
Show error message in result zone when presto query throws error.

### DIFF
--- a/server/drivers/clickhouse/_clickhouse.js
+++ b/server/drivers/clickhouse/_clickhouse.js
@@ -36,7 +36,9 @@ function send(config, query) {
       headers: getHeaders(config),
     }
   )
-    .then((response) => response.json())
+    .then((response) =>
+      response.ok ? response.json() : { error: response.text() }
+    )
     .then((statement) => handleStatementAndGetMore(results, statement, config));
 }
 
@@ -50,11 +52,11 @@ function updateResults(results, statement) {
   return results;
 }
 
-function handleStatementAndGetMore(results, statement, config) {
+async function handleStatementAndGetMore(results, statement, config) {
   if (statement.error) {
     // A lot of other error data available,
     // but error.message contains the detail on syntax issue
-    return Promise.reject(statement.error.message);
+    return Promise.reject(new Error(await statement.error));
   }
   results = updateResults(results, statement);
   if (!statement.nextUri) {

--- a/server/drivers/presto/_presto.js
+++ b/server/drivers/presto/_presto.js
@@ -51,7 +51,7 @@ function handleStatementAndGetMore(results, statement, config) {
   if (statement.error) {
     // A lot of other error data available,
     // but error.message contains the detail on syntax issue
-    return Promise.reject(statement.error.message);
+    return Promise.reject(new Error(statement.error.message));
   }
   results = updateResults(results, statement);
   if (!statement.nextUri) {


### PR DESCRIPTION
only one code modified, which can show error message in result zone when presto query throws error, so the editor know which place in sql and can grammatically correct.  