### PR TITLE
fix issue #823: for too long error messages and non-select ClickHouse  queries

### DIFF
--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -139,6 +139,7 @@ input {
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: scroll;
 
   font-size: 1.3rem;
   padding: 24px;

--- a/server/drivers/clickhouse/_clickhouse.js
+++ b/server/drivers/clickhouse/_clickhouse.js
@@ -63,7 +63,10 @@ async function handleStatementAndGetMore(results, statement, config) {
   } catch (e) {
     // Queries like 'insert/create table/drop table' SQLs have empty response body,
     // so it return the original body.
-    return statement;
+    return {
+      data: [{ result: statement || 'SUCCESS' }],
+      columns: [{ name: 'result', type: 'String' }],
+    };
   }
   results = updateResults(results, statement);
   if (!statement.nextUri) {

--- a/server/drivers/clickhouse/_clickhouse.js
+++ b/server/drivers/clickhouse/_clickhouse.js
@@ -62,8 +62,8 @@ async function handleStatementAndGetMore(results, statement, config) {
     statement = JSON.parse(statement);
   } catch (e) {
     // Queries like 'insert/create table/drop table' SQLs have empty response body,
-    // so it return the success message.
-    return Promise.reject(new Error(statement || 'Successfully Executed.'));
+    // so it return the original body.
+    return statement;
   }
   results = updateResults(results, statement);
   if (!statement.nextUri) {

--- a/server/drivers/clickhouse/_clickhouse.js
+++ b/server/drivers/clickhouse/_clickhouse.js
@@ -37,7 +37,7 @@ function send(config, query) {
     }
   )
     .then((response) =>
-      response.ok ? response.json() : { error: response.text() }
+      response.ok ? response.text() : { error: response.text() }
     )
     .then((statement) => handleStatementAndGetMore(results, statement, config));
 }
@@ -57,6 +57,13 @@ async function handleStatementAndGetMore(results, statement, config) {
     // A lot of other error data available,
     // but error.message contains the detail on syntax issue
     return Promise.reject(new Error(await statement.error));
+  }
+  try {
+    statement = JSON.parse(statement);
+  } catch (e) {
+    // Queries like 'insert/create table/drop table' SQLs have empty response body,
+    // so it return the success message.
+    return Promise.reject(new Error(statement || 'Successfully Executed.'));
   }
   results = updateResults(results, statement);
   if (!statement.nextUri) {


### PR DESCRIPTION
fix Issue  #823 👍 
1. error message is too long to overflow the result region
2. return successfully when non-select queries query successfully