### PR TITLE
UI: Use connection schema API

### DIFF
--- a/client/src/schema/SchemaInfoLoader.ts
+++ b/client/src/schema/SchemaInfoLoader.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { loadSchemaInfo } from '../stores/editor-actions';
+import { loadSchema } from '../stores/editor-actions';
 import { useSelectedConnectionId } from '../stores/editor-store';
 
 /**
@@ -13,7 +13,7 @@ function SchemaInfoLoader() {
 
   useEffect(() => {
     if (selectedConnectionId) {
-      loadSchemaInfo(selectedConnectionId);
+      loadSchema(selectedConnectionId);
     }
   }, [selectedConnectionId]);
 

--- a/client/src/schema/SchemaSidebar.module.css
+++ b/client/src/schema/SchemaSidebar.module.css
@@ -1,40 +1,20 @@
-.schema {
-  cursor: default;
+.schemaItem {
   font-size: 12px;
   line-height: 22px;
   font-family: Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro,
     monospace;
-  user-select: none;
-}
-
-.table {
-  padding-left: 20px;
   cursor: default;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 12px;
-  line-height: 22px;
-  font-family: Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro,
-    monospace;
+}
+
+.expandable {
   user-select: none;
 }
 
-.schema:hover,
-.table:hover {
+.expandable:hover {
   background-color: #f4f4f4;
-}
-
-.column {
-  padding-left: 54px;
-  cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 12px;
-  line-height: 22px;
-  font-family: Monaco, Menlo, 'Ubuntu Mono', Consolas, source-code-pro,
-    monospace;
 }
 
 .schemaSpinner {

--- a/client/src/schema/SchemaSidebar.tsx
+++ b/client/src/schema/SchemaSidebar.tsx
@@ -44,13 +44,7 @@ function SchemaSidebar() {
   };
 
   const filteredSchemaInfo = searchSchemaInfo(connectionSchema || {}, search);
-  const schemaList = getSchemaList(filteredSchemaInfo);
-
-  // For windowed list rendering, we need to determine what is visible due to expanded parent
-  // Show item if every parent is expanded (or doesn't have a parent)
-  const visibleItems = schemaList.filter((row) =>
-    row.parentIds.every((id) => expanded[id])
-  );
+  const visibleItems = getSchemaList(filteredSchemaInfo, expanded);
 
   const Row: React.FunctionComponent<{
     index: number;

--- a/client/src/schema/SchemaSidebar.tsx
+++ b/client/src/schema/SchemaSidebar.tsx
@@ -22,7 +22,7 @@ import styles from './SchemaSidebar.module.css';
 import searchSchemaInfo from './searchSchemaInfo';
 
 const ICON_SIZE = 22;
-const ICON_STYLE = { marginBottom: -6, marginRight: -6, marginLeft: -4 };
+const ICON_STYLE = { marginBottom: -6, marginRight: 0, marginLeft: -6 };
 
 function SchemaSidebar() {
   const connectionId = useSelectedConnectionId();
@@ -51,66 +51,79 @@ function SchemaSidebar() {
     style: React.CSSProperties;
   }> = ({ index, style }) => {
     const row = visibleItems[index];
-    const Icon = expanded[row.id] ? OpenIcon : ClosedIcon;
 
     if (!row) {
       return null;
     }
 
-    if (row.type === 'schema') {
-      return (
-        <li
-          key={row.id}
-          className={styles.schema}
-          style={style}
-          onClick={() => toggleSchemaItem(connectionId, row)}
-        >
-          <Icon size={ICON_SIZE} style={ICON_STYLE} /> {row.name}
-        </li>
+    const classNames = [styles.schemaItem];
+
+    let icon = null;
+
+    const expandable = row.type === 'schema' || row.type === 'table';
+    if (expandable) {
+      classNames.push(styles.expandable);
+      icon = expanded[row.id] ? (
+        <OpenIcon size={ICON_SIZE} style={ICON_STYLE} />
+      ) : (
+        <ClosedIcon size={ICON_SIZE} style={ICON_STYLE} />
       );
     }
 
-    if (row.type === 'table') {
-      return (
-        <li
-          key={row.id}
-          className={styles.table}
-          style={style}
-          onClick={() => toggleSchemaItem(connectionId, row)}
-        >
-          <Icon size={ICON_SIZE} style={ICON_STYLE} /> {row.name}
-        </li>
+    const indentationPadding = row.level * 20 + (!expandable ? 10 : 0);
+
+    const onClick = expandable
+      ? () => toggleSchemaItem(connectionId, row)
+      : undefined;
+
+    const description = row.description ? (
+      <Tooltip
+        key="colDesc"
+        label={row.description}
+        style={{
+          maxWidth: '300px',
+          whiteSpace: 'normal',
+        }}
+      >
+        <span>{row.description}</span>
+      </Tooltip>
+    ) : null;
+
+    const dataType = row.dataType ? <span>{row.dataType}</span> : null;
+
+    let secondary = null;
+    if (dataType && description) {
+      secondary = (
+        <Text type="secondary" style={{ paddingLeft: 8 }}>
+          {dataType} - {description}
+        </Text>
+      );
+    } else if (dataType) {
+      secondary = (
+        <Text type="secondary" style={{ paddingLeft: 8 }}>
+          {dataType}
+        </Text>
+      );
+    } else if (description) {
+      secondary = (
+        <Text type="secondary" style={{ paddingLeft: 8 }}>
+          {description}
+        </Text>
       );
     }
 
-    if (row.type === 'column') {
-      const secondary = [<span key="colType"> {row.dataType}</span>];
-
-      if (row.description) {
-        const description = (
-          <Tooltip
-            key="colDesc"
-            label={row.description}
-            style={{
-              maxWidth: '300px',
-              whiteSpace: 'normal',
-            }}
-          >
-            <span className={styles.description}> - {row.description}</span>
-          </Tooltip>
-        );
-        secondary.push(description);
-      }
-
-      return (
-        <li key={row.id} className={styles.column} style={style}>
-          {row.name}
-          <Text type="secondary">{secondary}</Text>
-        </li>
-      );
-    }
-
-    return null;
+    return (
+      <li
+        key={row.id}
+        className={classNames.join(' ')}
+        style={{ ...style, paddingLeft: indentationPadding }}
+        onClick={onClick}
+      >
+        {icon}
+        {row.name}
+        {secondary}
+      </li>
+    );
   };
 
   let content: ReactNode = null;

--- a/client/src/schema/SchemaSidebar.tsx
+++ b/client/src/schema/SchemaSidebar.tsx
@@ -41,7 +41,7 @@ function SchemaSidebar() {
   const { loading, schemaInfo, expanded, error } =
     (schema && schema[connectionId]) || {};
 
-  const filteredSchemaInfo = searchSchemaInfo(schemaInfo, search);
+  const filteredSchemaInfo = searchSchemaInfo(schemaInfo || {}, search);
   const schemaList = getSchemaList(filteredSchemaInfo);
 
   // For windowed list rendering, we need to determine what is visible due to expanded parent
@@ -56,9 +56,11 @@ function SchemaSidebar() {
   }> = ({ index, style }) => {
     const row = visibleItems[index];
     const Icon = expanded[row.id] ? OpenIcon : ClosedIcon;
+
     if (!row) {
       return null;
     }
+
     if (row.type === 'schema') {
       return (
         <li
@@ -71,6 +73,7 @@ function SchemaSidebar() {
         </li>
       );
     }
+
     if (row.type === 'table') {
       return (
         <li
@@ -83,6 +86,7 @@ function SchemaSidebar() {
         </li>
       );
     }
+
     if (row.type === 'column') {
       const secondary = [<span key="colType"> {row.dataType}</span>];
 
@@ -101,6 +105,7 @@ function SchemaSidebar() {
         );
         secondary.push(description);
       }
+
       return (
         <li
           key={`${row.schemaName}.${row.tableName}.${row.name}`}
@@ -112,6 +117,7 @@ function SchemaSidebar() {
         </li>
       );
     }
+
     return null;
   };
 

--- a/client/src/schema/SchemaSidebar.tsx
+++ b/client/src/schema/SchemaSidebar.tsx
@@ -66,7 +66,7 @@ function SchemaSidebar() {
     if (row.type === 'schema') {
       return (
         <li
-          key={row.name}
+          key={row.id}
           className={styles.schema}
           style={style}
           onClick={() => toggleSchemaItem(connectionId, row)}
@@ -79,7 +79,7 @@ function SchemaSidebar() {
     if (row.type === 'table') {
       return (
         <li
-          key={`${row.schemaName}.${row.name}`}
+          key={row.id}
           className={styles.table}
           style={style}
           onClick={() => toggleSchemaItem(connectionId, row)}
@@ -109,11 +109,7 @@ function SchemaSidebar() {
       }
 
       return (
-        <li
-          key={`${row.schemaName}.${row.tableName}.${row.name}`}
-          className={styles.column}
-          style={style}
-        >
+        <li key={row.id} className={styles.column} style={style}>
           {row.name}
           <Text type="secondary">{secondary}</Text>
         </li>

--- a/client/src/schema/getSchemaList.ts
+++ b/client/src/schema/getSchemaList.ts
@@ -8,13 +8,15 @@ interface SchemaListItem {
   id: string;
   // If a column item
   dataType?: string;
+  level: number;
 }
 
 /**
- * To render this schema tree with react-window we'll convert this to a normalized list of sorts
- * Because a tree is basically an indented list.
+ * To render this schema tree with react-window
+ * we need to convert this tree structure into an indented list
  *
  * @param connectionSchema
+ * @param expanded - id -> bool map of items that are expanded
  */
 export default function getSchemaList(
   connectionSchema: ConnectionSchema,
@@ -30,6 +32,7 @@ export default function getSchemaList(
         name: schema.name,
         description: schema.description,
         id: schemaId,
+        level: 0,
       });
       if (expanded[schemaId]) {
         schema.tables.forEach((table) => {
@@ -39,6 +42,7 @@ export default function getSchemaList(
             name: table.name,
             description: table.description,
             id: tableId,
+            level: 1,
           });
           if (expanded[tableId]) {
             table.columns.forEach((column) => {
@@ -49,6 +53,7 @@ export default function getSchemaList(
                 description: column.description,
                 dataType: column.dataType,
                 id: columnId,
+                level: 2,
               });
             });
           }
@@ -63,6 +68,7 @@ export default function getSchemaList(
         name: table.name,
         description: table.description,
         id: tableId,
+        level: 0,
       });
       if (expanded[tableId]) {
         table.columns.forEach((column) => {
@@ -73,6 +79,7 @@ export default function getSchemaList(
             description: column.description,
             dataType: column.dataType,
             id: columnId,
+            level: 1,
           });
         });
       }

--- a/client/src/schema/getSchemaList.ts
+++ b/client/src/schema/getSchemaList.ts
@@ -6,10 +6,7 @@ interface SchemaListItem {
   description?: string;
   id: string;
   parentIds: string[];
-  // If a table or column item
-  schemaName?: string;
   // If a column item
-  tableName?: string;
   dataType?: string;
 }
 
@@ -38,7 +35,6 @@ export default function getSchemaList(connectionSchema: ConnectionSchema) {
           type: 'table',
           name: table.name,
           description: table.description,
-          schemaName: schema.name,
           id: tableId,
           parentIds: [schemaId],
         });
@@ -49,11 +45,31 @@ export default function getSchemaList(connectionSchema: ConnectionSchema) {
             name: column.name,
             description: column.description,
             dataType: column.dataType,
-            tableName: table.name,
-            schemaName: schema.name,
             id: columnId,
             parentIds: [schemaId, tableId],
           });
+        });
+      });
+    });
+  } else if (connectionSchema.tables) {
+    connectionSchema.tables.forEach((table) => {
+      const tableId = table.name;
+      schemaList.push({
+        type: 'table',
+        name: table.name,
+        description: table.description,
+        id: tableId,
+        parentIds: [],
+      });
+      table.columns.forEach((column) => {
+        const columnId = `${table.name}.${column.name}`;
+        schemaList.push({
+          type: 'column',
+          name: column.name,
+          description: column.description,
+          dataType: column.dataType,
+          id: columnId,
+          parentIds: [tableId],
         });
       });
     });

--- a/client/src/schema/getSchemaList.ts
+++ b/client/src/schema/getSchemaList.ts
@@ -17,13 +17,13 @@ interface SchemaListItem {
  * To render this schema tree with react-window we'll convert this to a normalized list of sorts
  * Because a tree is basically an indented list.
  *
- * @param schemaInfo
+ * @param connectionSchema
  */
-export default function getSchemaList(schemaInfo: ConnectionSchema) {
+export default function getSchemaList(connectionSchema: ConnectionSchema) {
   const schemaList: SchemaListItem[] = [];
 
-  if (schemaInfo?.schemas) {
-    schemaInfo.schemas.forEach((schema) => {
+  if (connectionSchema?.schemas) {
+    connectionSchema.schemas.forEach((schema) => {
       const schemaId = schema.name;
       schemaList.push({
         type: 'schema',

--- a/client/src/schema/getSchemaList.ts
+++ b/client/src/schema/getSchemaList.ts
@@ -1,48 +1,56 @@
+import { ConnectionSchema } from '../types';
+
+interface SchemaListItem {
+  type: 'schema' | 'table' | 'column';
+  name: string;
+  description?: string;
+  id: string;
+  parentIds: string[];
+  // If a table or column item
+  schemaName?: string;
+  // If a column item
+  tableName?: string;
+  dataType?: string;
+}
+
 /**
  * To render this schema tree with react-window we'll convert this to a normalized list of sorts
- * Because a tree is basically an indented list...?
+ * Because a tree is basically an indented list.
  *
- * schemaInfo looks like
- * {
- *   schemaName: {
- *     tableName: [
- *       { column_name, column_description, data_type, table_name, table_schema }
- *     ]
- *   }
- * }
- *
- * @param {object} schemaInfo
+ * @param schemaInfo
  */
-export default function getSchemaList(schemaInfo: any) {
-  const schemaList: any = [];
+export default function getSchemaList(schemaInfo: ConnectionSchema) {
+  const schemaList: SchemaListItem[] = [];
 
-  if (schemaInfo) {
-    Object.keys(schemaInfo).forEach((schemaName) => {
-      const schemaId = schemaName;
+  if (schemaInfo?.schemas) {
+    schemaInfo.schemas.forEach((schema) => {
+      const schemaId = schema.name;
       schemaList.push({
         type: 'schema',
-        name: schemaName,
+        name: schema.name,
+        description: schema.description,
         id: schemaId,
         parentIds: [],
       });
-      Object.keys(schemaInfo[schemaName]).forEach((tableName) => {
-        const tableId = `${schemaName}.${tableName}`;
+      schema.tables.forEach((table) => {
+        const tableId = `${schema.name}.${table.name}`;
         schemaList.push({
           type: 'table',
-          name: tableName,
-          schemaName,
+          name: table.name,
+          description: table.description,
+          schemaName: schema.name,
           id: tableId,
           parentIds: [schemaId],
         });
-        schemaInfo[schemaName][tableName].forEach((column: any) => {
-          const columnId = `${schemaName}.${tableName}.${column.column_name}`;
+        table.columns.forEach((column) => {
+          const columnId = `${schema.name}.${table.name}.${column.name}`;
           schemaList.push({
             type: 'column',
-            name: column.column_name,
-            description: column.column_description,
-            dataType: column.data_type,
-            tableName,
-            schemaName,
+            name: column.name,
+            description: column.description,
+            dataType: column.dataType,
+            tableName: table.name,
+            schemaName: schema.name,
             id: columnId,
             parentIds: [schemaId, tableId],
           });

--- a/client/src/schema/searchSchemaInfo.ts
+++ b/client/src/schema/searchSchemaInfo.ts
@@ -1,11 +1,13 @@
-function searchTables(tableMap: any, searchRegEx: any) {
-  const res: { [key: string]: string } = {};
-  Object.keys(tableMap).forEach((tableName) => {
+import { ConnectionSchema, Schema, SchemaTable } from '../types';
+
+function searchTables(tables: SchemaTable[], searchRegEx: RegExp) {
+  const res: SchemaTable[] = [];
+  tables.forEach((table) => {
     if (
-      searchRegEx.test(tableName) ||
-      tableMap[tableName].some((col: any) => searchRegEx.test(col.column_name))
+      searchRegEx.test(table.name) ||
+      table.columns.some((col) => searchRegEx.test(col.name))
     ) {
-      res[tableName] = tableMap[tableName];
+      res.push(table);
     }
   });
   return res;
@@ -13,22 +15,24 @@ function searchTables(tableMap: any, searchRegEx: any) {
 
 /**
  * Search schemaInfo (the hierarchy object storage of schema data) for the search string passed in
- * @param {object} schemaInfo
- * @param {string} search
+ * @param schemaInfo
+ * @param  search
  */
-export default function searchSchemaInfo(schemaInfo: any, search: any) {
-  const filteredSchemaInfo: { [key: string]: any } = {};
+export default function searchSchemaInfo(
+  schemaInfo: ConnectionSchema,
+  search: string
+) {
+  const filteredSchemas: Schema[] = [];
   const searchRegEx = new RegExp(search, 'i');
 
-  if (schemaInfo) {
-    Object.keys(schemaInfo).forEach((schemaName) => {
-      const filteredTableMap = searchTables(
-        schemaInfo[schemaName],
-        searchRegEx
-      );
-      filteredSchemaInfo[schemaName] = filteredTableMap;
+  if (schemaInfo?.schemas) {
+    schemaInfo.schemas.forEach((schema) => {
+      const filteredTables = searchTables(schema.tables, searchRegEx);
+      const filteredSchema = { ...schema, tables: filteredTables };
+      filteredSchemas.push(filteredSchema);
     });
   }
+  // TODO what if only tables
 
-  return filteredSchemaInfo;
+  return { schemas: filteredSchemas } as ConnectionSchema;
 }

--- a/client/src/schema/searchSchemaInfo.ts
+++ b/client/src/schema/searchSchemaInfo.ts
@@ -14,19 +14,19 @@ function searchTables(tables: SchemaTable[], searchRegEx: RegExp) {
 }
 
 /**
- * Search schemaInfo (the hierarchy object storage of schema data) for the search string passed in
- * @param schemaInfo
+ * Search connectionSchema (the hierarchy object storage of schema data) for the search string passed in
+ * @param connectionSchema
  * @param  search
  */
 export default function searchSchemaInfo(
-  schemaInfo: ConnectionSchema,
+  connectionSchema: ConnectionSchema,
   search: string
 ) {
   const filteredSchemas: Schema[] = [];
   const searchRegEx = new RegExp(search, 'i');
 
-  if (schemaInfo?.schemas) {
-    schemaInfo.schemas.forEach((schema) => {
+  if (connectionSchema?.schemas) {
+    connectionSchema.schemas.forEach((schema) => {
       const filteredTables = searchTables(schema.tables, searchRegEx);
       const filteredSchema = { ...schema, tables: filteredTables };
       filteredSchemas.push(filteredSchema);

--- a/client/src/schema/searchSchemaInfo.ts
+++ b/client/src/schema/searchSchemaInfo.ts
@@ -25,14 +25,19 @@ export default function searchSchemaInfo(
   const filteredSchemas: Schema[] = [];
   const searchRegEx = new RegExp(search, 'i');
 
-  if (connectionSchema?.schemas) {
+  if (connectionSchema.schemas) {
     connectionSchema.schemas.forEach((schema) => {
       const filteredTables = searchTables(schema.tables, searchRegEx);
       const filteredSchema = { ...schema, tables: filteredTables };
       filteredSchemas.push(filteredSchema);
     });
+    return { schemas: filteredSchemas } as ConnectionSchema;
   }
-  // TODO what if only tables
 
-  return { schemas: filteredSchemas } as ConnectionSchema;
+  if (connectionSchema.tables) {
+    const filteredTables = searchTables(connectionSchema.tables, searchRegEx);
+    return { tables: filteredTables } as ConnectionSchema;
+  }
+
+  return connectionSchema;
 }

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -432,8 +432,7 @@ export async function loadSchemaInfo(connectionId: string, reload?: boolean) {
       },
     });
 
-    const qs = reload ? '?reload=true' : '';
-    const json = await api.get(`/api/schema-info/${connectionId}${qs}`);
+    const json = await api.getConnectionSchema(connectionId, reload);
     const { error, data } = json;
     if (error) {
       setSchema({
@@ -450,13 +449,17 @@ export async function loadSchemaInfo(connectionId: string, reload?: boolean) {
       }
       return;
     }
-    updateCompletions(data);
+    if (data?.schemas || data?.tables) {
+      updateCompletions(data);
+    } else {
+      updateCompletions({ schemas: [] });
+    }
 
     // Pre-expand schemas
     const expanded: { [key: string]: boolean } = {};
-    if (data) {
-      Object.keys(data).forEach((schemaName) => {
-        expanded[schemaName] = true;
+    if (data?.schemas) {
+      data.schemas.forEach((schema) => {
+        expanded[schema.name] = true;
       });
     }
 

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -441,6 +441,7 @@ export async function loadSchema(connectionId: string, reload?: boolean) {
 
     const json = await api.getConnectionSchema(connectionId, reload);
     const { error, data } = json;
+
     if (error) {
       setSchemaState(connectionId, {
         loading: false,

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -454,6 +454,7 @@ export async function loadSchema(connectionId: string, reload?: boolean) {
       }
       return;
     }
+
     if (data?.schemas || data?.tables) {
       updateCompletions(data);
     } else {

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -10,7 +10,7 @@ import {
 } from '../utilities/localQueryText';
 import runQueryViaBatch from '../utilities/runQueryViaBatch';
 import updateCompletions from '../utilities/updateCompletions';
-import { NEW_QUERY, useEditorStore } from './editor-store';
+import { NEW_QUERY, SchemaState, useEditorStore } from './editor-store';
 import { AppInfo, Connection } from '../types';
 
 export const initApp = async (
@@ -416,31 +416,36 @@ export function toggleSchema() {
   useEditorStore.setState({ showSchema: !showSchema });
 }
 
-export function setSchema(schema: any) {
-  useEditorStore.setState({ schema });
+export function setSchemaState(connectionId: string, schemaState: SchemaState) {
+  const { schemaStates } = useEditorStore.getState();
+  const update = {
+    ...schemaStates,
+    [connectionId]: schemaState,
+  };
+  useEditorStore.setState({ schemaStates: update });
 }
 
-export async function loadSchemaInfo(connectionId: string, reload?: boolean) {
-  const { showSchema, schema } = useEditorStore.getState();
+/**
+ * Get schema via API and store into editor store
+ * @param connectionId - connection id to get schema for
+ * @param reload - force cache refresh for schema
+ */
+export async function loadSchema(connectionId: string, reload?: boolean) {
+  const { showSchema, schemaStates } = useEditorStore.getState();
 
-  if (!schema[connectionId] || reload) {
-    setSchema({
-      ...schema,
-      [connectionId]: {
-        loading: true,
-        expanded: {},
-      },
+  if (!schemaStates[connectionId] || reload) {
+    setSchemaState(connectionId, {
+      loading: true,
+      expanded: {},
     });
 
     const json = await api.getConnectionSchema(connectionId, reload);
     const { error, data } = json;
     if (error) {
-      setSchema({
-        ...schema,
-        [connectionId]: {
-          loading: false,
-          error,
-        },
+      setSchemaState(connectionId, {
+        loading: false,
+        error,
+        expanded: {},
       });
       // If sidebar is not shown, send error notification
       // It is otherwise shown in sidebar where schema would be
@@ -463,27 +468,21 @@ export async function loadSchemaInfo(connectionId: string, reload?: boolean) {
       });
     }
 
-    setSchema({
-      ...schema,
-      [connectionId]: {
-        loading: false,
-        schemaInfo: data,
-        error: null,
-        expanded,
-      },
+    setSchemaState(connectionId, {
+      loading: false,
+      connectionSchema: data,
+      error: undefined,
+      expanded,
     });
   }
 }
 
 export function toggleSchemaItem(connectionId: string, item: { id: string }) {
-  const { schema } = useEditorStore.getState();
-  const connectionSchema = schema[connectionId];
+  const { schemaStates } = useEditorStore.getState();
+  const connectionSchema = schemaStates[connectionId];
   const open = !connectionSchema.expanded[item.id];
-  setSchema({
-    ...schema,
-    [connectionId]: {
-      ...connectionSchema,
-      expanded: { ...connectionSchema.expanded, [item.id]: open },
-    },
+  setSchemaState(connectionId, {
+    ...connectionSchema,
+    expanded: { ...connectionSchema.expanded, [item.id]: open },
   });
 }

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -1,4 +1,5 @@
 import create from 'zustand';
+import { ConnectionSchema } from '../types';
 
 export const NEW_QUERY = {
   id: '',
@@ -15,9 +16,16 @@ export const NEW_QUERY = {
   canDelete: true,
 };
 
+interface SchemaState {
+  loading: boolean;
+  schemaInfo?: ConnectionSchema;
+  error?: string;
+  expanded: { [key: string]: boolean };
+}
+
 type State = {
   showSchema: boolean;
-  schema: any;
+  schema: { [conectionId: string]: SchemaState };
   initialized: boolean;
   selectedConnectionId: string;
   connectionClient: any;

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -16,16 +16,16 @@ export const NEW_QUERY = {
   canDelete: true,
 };
 
-interface SchemaState {
+export interface SchemaState {
   loading: boolean;
-  schemaInfo?: ConnectionSchema;
+  connectionSchema?: ConnectionSchema;
   error?: string;
   expanded: { [key: string]: boolean };
 }
 
 type State = {
   showSchema: boolean;
-  schema: { [conectionId: string]: SchemaState };
+  schemaStates: { [conectionId: string]: SchemaState };
   initialized: boolean;
   selectedConnectionId: string;
   connectionClient: any;
@@ -44,7 +44,7 @@ type State = {
 
 export const useEditorStore = create<State>((set, get) => ({
   showSchema: true,
-  schema: {},
+  schemaStates: {},
   initialized: false,
   selectedConnectionId: '',
   connectionClient: null,
@@ -73,6 +73,12 @@ export function useShowSchema(): boolean {
   return useEditorStore((s) => s.showSchema);
 }
 
-export function useSchema() {
-  return useEditorStore((s) => s.schema);
+export function useSchemaState(connectionId?: string) {
+  return useEditorStore((s) => {
+    if (!connectionId || !s.schemaStates[connectionId]) {
+      const emptySchemaState: SchemaState = { loading: false, expanded: {} };
+      return emptySchemaState;
+    }
+    return s.schemaStates[connectionId];
+  });
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -184,3 +184,26 @@ export interface Driver {
   supportsConnectionClient: boolean;
   fields: DriverField[];
 }
+
+export interface TableColumn {
+  name: string;
+  description: string;
+  dataType: string;
+}
+
+export interface SchemaTable {
+  name: string;
+  description: string;
+  columns: TableColumn[];
+}
+
+export interface Schema {
+  name: string;
+  description: string;
+  tables: SchemaTable[];
+}
+
+export interface ConnectionSchema {
+  schemas?: Schema[];
+  tables?: SchemaTable[];
+}

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -7,6 +7,7 @@ import {
   Connection,
   ConnectionAccess,
   ConnectionDetail,
+  ConnectionSchema,
   Driver,
   Query,
   QueryDetail,
@@ -145,6 +146,20 @@ export const api = {
 
   deleteConnection(connectionId: string) {
     return api.delete(`/api/connections/${connectionId}`);
+  },
+
+  getConnectionSchema(connectionId: string, reload?: boolean) {
+    const qs = reload ? '?reload=true' : '';
+    return api.get<ConnectionSchema>(
+      `/api/connections/${connectionId}/schema${qs}`
+    );
+  },
+
+  useConnectionSchema(connectionId: string, reload?: boolean) {
+    const qs = reload ? '?reload=true' : '';
+    return useSWR<ConnectionSchema>(
+      `/api/connections/${connectionId}/schema${qs}`
+    );
   },
 
   useUsers() {

--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -45,13 +45,13 @@ type DottedMatchMap = {
  * @todo make more reacty
  * @todo make less naive/more intelligent (use a sql parser?)
  * @todo scoped to an editor instance instead of all instances
- * @param {schemaInfoObject} schemaInfo
+ * @param {schemaInfoObject} connectionSchema
  */
-function updateCompletions(schemaInfo: ConnectionSchema) {
+function updateCompletions(connectionSchema: ConnectionSchema) {
   debug('updating completions');
-  debug(schemaInfo);
+  debug(connectionSchema);
 
-  if (schemaInfo === null || schemaInfo === undefined) {
+  if (connectionSchema === null || connectionSchema === undefined) {
     return;
   }
 
@@ -82,7 +82,7 @@ function updateCompletions(schemaInfo: ConnectionSchema) {
     schemaTable: {},
   };
 
-  schemaInfo?.schemas?.forEach((schema) => {
+  connectionSchema?.schemas?.forEach((schema) => {
     schemaCompletions.push({
       name: schema.name,
       value: schema.name,

--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -45,7 +45,7 @@ type DottedMatchMap = {
  * @todo make more reacty
  * @todo make less naive/more intelligent (use a sql parser?)
  * @todo scoped to an editor instance instead of all instances
- * @param {schemaInfoObject} connectionSchema
+ * @param  connectionSchema
  */
 function updateCompletions(connectionSchema: ConnectionSchema) {
   debug('updating completions');


### PR DESCRIPTION
Updates UI to use the new connection schema API. The autocomplete code is partially updated to handle the new format, but isn't fully functional yet if the API returns only tables. This is planned for the Apache Pinot driver, but isn't implemented yet.

Instead of trying to enhance the autocomplete code, I'll have a follow-up PR that takes a larger refactor approach to help clean things up. 
