### PR TITLE
Autocomplete fixes and enhancements

### DIFF
--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -7,7 +7,7 @@ export default updateCompletions;
 // There's stuff below that logs to console a lot
 // documentation on this autocompletion is light
 // and you may find it helpful to print some vars out during dev
-const DEBUG_ON = true;
+const DEBUG_ON = false;
 
 function debug(...args: any) {
   if (DEBUG_ON) console.log.apply(null, args);

--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -103,7 +103,7 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
               type: 'column',
               value: column.name,
               score: 0,
-              meta: 'column',
+              meta: `${column.dataType} ${column.description || ''}`.trim(),
             };
           }
         );
@@ -114,7 +114,7 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
           type: 'table',
           value: table.name,
           score: 0,
-          meta: 'table',
+          meta: `table ${table.description || ''}`.trim(),
           schemaCompletion: schemaCompletion,
           columnCompletions,
         };
@@ -137,7 +137,7 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
           type: 'column',
           value: column.name,
           score: 0,
-          meta: 'column',
+          meta: `${column.dataType} ${column.description || ''}`.trim(),
         };
       });
 
@@ -147,7 +147,7 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
         type: 'table',
         value: table.name,
         score: 0,
-        meta: 'table',
+        meta: `table ${table.description || ''}`.trim(),
         columnCompletions,
       };
       initialTableWantedSuggestions.push(tableCompletion);

--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -311,7 +311,7 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
       if (dottedIdentifier && wanted === 'COLUMN') {
         let acCompletions = (columnDotMatches[dottedIdentifier] || []).map(
           (c) => {
-            return { ...c, score: 1 };
+            return { value: c.value, meta: c.meta, score: 1 };
           }
         );
 
@@ -319,7 +319,9 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
         // eg `SELECT schemaname.` should get tables
         if (priorKeyword === 'select') {
           acCompletions = acCompletions.concat(
-            tablesBySchema[dottedIdentifier]
+            (tablesBySchema[dottedIdentifier] || []).map((c) => {
+              return { value: c.value, meta: c.meta, score: 0 };
+            })
           );
         }
 
@@ -337,14 +339,26 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
           .concat(Object.values(foundTablesById))
           .concat(Object.values(columnsById))
           .map((c) => {
-            return { ...c, score: 1 };
+            return {
+              value: c.value,
+              meta: c.meta,
+              score: 1,
+            };
           });
 
         // Add schemas and tables not for found tables
         // user might be trying for a table prior to using it in SELECT
         // eg `SELECT schemaname` or `SELECT tablename` should be assisted
         if (priorKeyword === 'select') {
-          acCompletions = acCompletions.concat(initialTableWantedSuggestions);
+          acCompletions = acCompletions.concat(
+            initialTableWantedSuggestions.map((c) => {
+              return {
+                value: c.value,
+                meta: c.meta,
+                score: 0,
+              };
+            })
+          );
         }
 
         return callback(null, acCompletions);

--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -101,12 +101,7 @@ class TableIndex {
 }
 
 /**
- * Updates global completions for all ace editors in use.
- * First pass and kind of hacked together.
- *
- * @todo make more reacty
- * @todo make less naive/more intelligent (use a sql parser?)
- * @todo scoped to an editor instance instead of all instances
+ * Updates global completions for ace editors in use.
  * @param  connectionSchema
  */
 function updateCompletions(connectionSchema: ConnectionSchema) {
@@ -175,8 +170,6 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
       prefix: any,
       callback: any
     ) {
-      debug('getCompletions() -----------');
-
       // get tokens leading up to the cursor to figure out context
       // depending on where we are we either want tables or we want columns
       const tableWantedKeywords = ['from', 'join'];


### PR DESCRIPTION
The primary focus of this PR was to add support for connection schemas that only contain tables and columns (no schema hierarchy). In doing this work the old first pass at adding autocomplete was refactored and enhanced a bit.

* Adds schema/table suggestions in the SELECT clause prior to having tables listed in FROM clause. Requiring tables to be in the query first might not be intuitive, and doesn't flow with how someone writes SQL. 
* Adds lower-priority schema/table suggestions in column suggestion areas in addition to only those relevant for tables in the query.
* Fixes keyword detection if keyword is adjacent to paren or similar. For example `WHERE id IN (SELECT` would not detect `SELECT`

There are still enhancements that I would like to make, like adding table alias support, but that will need to come later with another pass. 

As is Ace is starting to feel a little slow, and I wonder how much completion logic can realistically be done in the completer callback like it is being done today.