### PR TITLE
Remove schema level from Pinot connection schema response

### DIFF
--- a/client/src/utilities/updateCompletions.ts
+++ b/client/src/utilities/updateCompletions.ts
@@ -57,8 +57,6 @@ type AceCompletion = {
   // Greyed out text to show in prompt. Used by Ace
   meta: string;
   // pointers to parent objects if applicable
-  schemaId?: string;
-  tableId?: string;
   schemaCompletion?: AceCompletion;
   columnCompletions?: AceCompletion[];
 };
@@ -166,9 +164,11 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
   }
 
   // Create a big regex for table patterns to find tables
-  const tableRegex = new RegExp(tablePatterns.join('|'), 'gi');
+  // This regex is /\b(table1|schema.table1|table2|schema.table2)\b/
+  // \b indicates a boundary, the parens and pipes mean "one of these values"
+  const tableRegex = new RegExp(`\\b(${tablePatterns.join('|')})\\b`, 'gi');
 
-  const keywordsRegex = /\bfrom|join|select|where|group|having|on\b/gi;
+  const keywordsRegex = /\b(from|join|select|where|group|having|on)\b/gi;
 
   const tableWantedKeywords = new Set(['from', 'join']);
   const columnWantedKeywords = new Set([
@@ -249,7 +249,7 @@ function updateCompletions(connectionSchema: ConnectionSchema) {
       // Try and derive based on basic matching
       // figure out if there are any schemas/tables referenced in query
       const allTokens: Set<string> = new Set(
-        session.getValue().match(tableRegex)
+        session.getValue().toLowerCase().match(tableRegex)
       );
 
       // First find any references of schemas or tables in tokens

--- a/server/drivers/pinot/index.js
+++ b/server/drivers/pinot/index.js
@@ -73,8 +73,6 @@ function testConnection(connection) {
 
 /**
  * Get schema for connection
- * TODO FIXME: PInot does not have a concept of schema, but SQLPad requires it at this time
- * SQLPad needs to be updated to support optional table_schema
  * @param {*} connection
  */
 async function getSchema(connection) {
@@ -87,7 +85,6 @@ async function getSchema(connection) {
     const schema = await pinot.getTableSchema(connection.controllerUrl, table);
     for (const dimension of schema.dimensionFieldSpecs) {
       columnRows.push({
-        table_schema: 'main',
         table_name: table,
         column_name: dimension.name,
         data_type: dimension.dataType,
@@ -96,7 +93,6 @@ async function getSchema(connection) {
     }
     for (const metric of schema.metricFieldSpecs) {
       columnRows.push({
-        table_schema: 'main',
         table_name: table,
         column_name: metric.name,
         data_type: metric.dataType,

--- a/server/test/drivers/utils.js
+++ b/server/test/drivers/utils.js
@@ -1,0 +1,148 @@
+const assert = require('assert');
+const utils = require('../../drivers/utils');
+
+describe('drivers/utils', function () {
+  it('formatSchemaQueryResults handles full row set', function () {
+    const rows = [
+      {
+        schema_name: 's1',
+        schema_description: 's1d',
+        table_name: 't1',
+        table_description: 't1d',
+        column_name: 'c1',
+        column_description: 'c1d',
+        data_type: 'dt1',
+      },
+      {
+        schema_name: 's1',
+        schema_description: 's1d',
+        table_name: 't1',
+        table_description: 't1d',
+        column_name: 'c2',
+        column_description: 'c2d',
+        data_type: 'dt2',
+      },
+      {
+        schema_name: 's2',
+        schema_description: 's2d',
+        table_name: 't1',
+        table_description: 't1d',
+        column_name: 'c1',
+        column_description: 'c1d',
+        data_type: 'dt1',
+      },
+    ];
+
+    const res = utils.formatSchemaQueryResults({ rows });
+
+    assert.deepStrictEqual(res, {
+      schemas: [
+        {
+          name: 's1',
+          description: 's1d',
+          tables: [
+            {
+              name: 't1',
+              description: 't1d',
+              columns: [
+                {
+                  name: 'c1',
+                  description: 'c1d',
+                  dataType: 'dt1',
+                },
+                {
+                  name: 'c2',
+                  description: 'c2d',
+                  dataType: 'dt2',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 's2',
+          description: 's2d',
+          tables: [
+            {
+              name: 't1',
+              description: 't1d',
+              columns: [
+                {
+                  name: 'c1',
+                  description: 'c1d',
+                  dataType: 'dt1',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('formatSchemaQueryResults handles original row and mixed case', function () {
+    const rows = [
+      {
+        table_schema: 's1',
+        SCHEMA_DESCRIPTION: 's1d',
+        table_name: 't1',
+        table_description: 't1d',
+        column_name: 'c1',
+        column_description: 'c1d',
+        data_type: 'dt1',
+      },
+    ];
+
+    const res = utils.formatSchemaQueryResults({ rows });
+
+    assert.deepStrictEqual(res, {
+      schemas: [
+        {
+          name: 's1',
+          description: 's1d',
+          tables: [
+            {
+              name: 't1',
+              description: 't1d',
+              columns: [
+                {
+                  name: 'c1',
+                  description: 'c1d',
+                  dataType: 'dt1',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('formatSchemaQueryResults handles only required fields', function () {
+    const rows = [
+      {
+        table_name: 't1',
+        column_name: 'c1',
+        data_type: 'dt1',
+      },
+    ];
+
+    const res = utils.formatSchemaQueryResults({ rows });
+
+    assert.deepStrictEqual(res, {
+      tables: [
+        {
+          name: 't1',
+          description: undefined,
+          columns: [
+            {
+              name: 'c1',
+              description: undefined,
+              dataType: 'dt1',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Now that a `connections/<id>/schema` response fully supports returning a `tables` array without a `schemas` array, the Pinot driver can be updated to no longer return a stubbed in schema that doesn't  actually exist in Pinot.

The `formatSchemaQueryResults` function is also refactored and updated to send descriptions for tables and schema, as well as be overall more efficient with just 1 pass through the query result rows to construct the hierarchy.

In working on this implementation a few bugs were teased out of the autocomplete work in a prior PR, fixing mixed case table name support, as well as fixing keyword detection. 