### PR TITLE
LDAP Auto Signup and RBAC - Take 2

### DIFF
--- a/client/src/SignIn.tsx
+++ b/client/src/SignIn.tsx
@@ -39,45 +39,21 @@ function SignIn() {
     return null;
   }
 
-  const ldapForm = (
-    <form onSubmit={signIn}>
-      <Input
-        name="email"
-        type="text"
-        placeholder="Username"
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          setEmail(e.target.value)
-        }
-        required
-      />
-      <Spacer />
-      <Input
-        name="password"
-        type="password"
-        placeholder="Password"
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          setPassword(e.target.value)
-        }
-        required
-      />
-      <Spacer size={2} />
-      <Button
-        style={{ width: '100%' }}
-        onClick={signIn}
-        htmlType="submit"
-        variant="primary"
-      >
-        Sign in
-      </Button>
-    </form>
-  );
+  let placeholderText = '';
+  if (config.ldapConfigured && config.localAuthConfigured) {
+    placeholderText = 'username or e-mail address';
+  } else if (config.ldapConfigured) {
+    placeholderText = 'username';
+  } else if (config.localAuthConfigured) {
+    placeholderText = 'e-mail address';
+  }
 
-  const localForm = (
+  const localLdapForm = (
     <form onSubmit={signIn}>
       <Input
         name="email"
         type="email"
-        placeholder="e-mail address"
+        placeholder={placeholderText}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           setEmail(e.target.value)
         }
@@ -103,18 +79,21 @@ function SignIn() {
         Sign in
       </Button>
       <Spacer />
-      <Link
-        style={{
-          display: 'inline-block',
-          width: '100%',
-          textAlign: 'center',
-        }}
-        to="/signup"
-      >
-        Sign Up
-      </Link>
 
-      {config.smtpConfigured ? (
+      {config.localAuthConfigured && (
+        <Link
+          style={{
+            display: 'inline-block',
+            width: '100%',
+            textAlign: 'center',
+          }}
+          to="/signup"
+        >
+          Sign Up
+        </Link>
+      )}
+
+      {config.localAuthConfigured && config.smtpConfigured ? (
         <Link to="/forgot-password">Forgot Password</Link>
       ) : null}
     </form>
@@ -166,8 +145,7 @@ function SignIn() {
   return (
     <div style={{ width: '300px', textAlign: 'center', margin: '100px auto' }}>
       <h1>SQLPad</h1>
-      {config.localAuthConfigured && localForm}
-      {config.ldapConfigured && ldapForm}
+      {(config.localAuthConfigured || config.ldapConfigured) && localLdapForm}
       {config.googleAuthConfigured && googleForm}
       {config.samlConfigured && samlForm}
       {config.oidcConfigured && oidcForm}

--- a/client/src/SignIn.tsx
+++ b/client/src/SignIn.tsx
@@ -41,11 +41,11 @@ function SignIn() {
 
   let placeholderText = '';
   if (config.ldapConfigured && config.localAuthConfigured) {
-    placeholderText = 'username or e-mail address';
+    placeholderText = 'username or email address';
   } else if (config.ldapConfigured) {
     placeholderText = 'username';
   } else if (config.localAuthConfigured) {
-    placeholderText = 'e-mail address';
+    placeholderText = 'email address';
   }
 
   const localLdapForm = (

--- a/client/src/SignIn.tsx
+++ b/client/src/SignIn.tsx
@@ -39,20 +39,45 @@ function SignIn() {
     return null;
   }
 
-  function PlaceholderForUsername() {
-    if (config?.ldapConfigured) {
-      return 'Username or e-mail address';
-    } else {
-      return 'e-mail address';
-    }
-  }
+  const ldapForm = (
+    <form onSubmit={signIn}>
+      <Input
+        name="email"
+        type="text"
+        placeholder="Username"
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setEmail(e.target.value)
+        }
+        required
+      />
+      <Spacer />
+      <Input
+        name="password"
+        type="password"
+        placeholder="Password"
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setPassword(e.target.value)
+        }
+        required
+      />
+      <Spacer size={2} />
+      <Button
+        style={{ width: '100%' }}
+        onClick={signIn}
+        htmlType="submit"
+        variant="primary"
+      >
+        Sign in
+      </Button>
+    </form>
+  );
 
   const localForm = (
     <form onSubmit={signIn}>
       <Input
         name="email"
         type="email"
-        placeholder={PlaceholderForUsername()}
+        placeholder="e-mail address"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           setEmail(e.target.value)
         }
@@ -142,6 +167,7 @@ function SignIn() {
     <div style={{ width: '300px', textAlign: 'center', margin: '100px auto' }}>
       <h1>SQLPad</h1>
       {config.localAuthConfigured && localForm}
+      {config.ldapConfigured && ldapForm}
       {config.googleAuthConfigured && googleForm}
       {config.samlConfigured && samlForm}
       {config.oidcConfigured && oidcForm}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -147,12 +147,13 @@ To assign roles via LDAP-RBAC, you may specify a profile attribute and value to 
 
 For example, if your LDAP implementation supports `memberOf`, you may decide to use group DN values. In this case two groups are needed, one for editors and one for admins.
 
-- `SQLPAD_LDAP_SEARCH_FILTER`=`'(&(|(memberOf=cn=sqlpad-editors,dc=example,dc=com)(memberOf=cn=sqlpad-admins,dc=example,dc=com))(uid={{username}}))'`
-- `SQLPAD_LDAP_ROLE_ADMIN_VALUE`=`'cn=sqlpad-editors,dc=example,dc=com'`
-- `SQLPAD_LDAP_ROLE_EDITOR_VALUE`=`'cn=sqlpad-admins,dc=example,dc=com'`
-- `SQLPAD_LDAP_ROLE_ATTRIBUTE`=`memberOf`
+```sh
+SQLPAD_LDAP_SEARCH_FILTER = "(&(|(memberOf=cn=sqlpad-editors,dc=example,dc=com)(memberOf=cn=sqlpad-admins,dc=example,dc=com))(uid={{username}}))"
+SQLPAD_LDAP_ROLE_ADMIN_FILTER = "(memberOf=cn=sqlpad-admins,dc=example,dc=com)"
+SQLPAD_LDAP_ROLE_EDITOR_FILTER = "(memberOf=cn=sqlpad-editors,dc=example,dc=com)"
+```
 
-At this time any top-level profile attribute is available. The attribute may contain a single value, or multiple values. If multiple, the admin/editor value must exist in the list (do not provide all listed values).
+The role filters will be combined with the `uid`/`sAMAccountName` filter depending on the profile returned. For example, the `SQLPAD_LDAP_ROLE_ADMIN_FILTER` above would become `(&(memberOf=cn=sqlpad-admins,dc=example,dc=com)(uid=username))` for OpenLDAP or `(&(memberOf=cn=sqlpad-admins,dc=example,dc=com)(sAMAccountName=username))` for ActiveDirectory.
 
 LDAP-based authentication can be enabled and used with local authencation together. When both LDAP and local authentication are enabled, LDAP users can sign in using their LDAP username (not an email address) and password, while local users may sign in using their email address and local password.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -138,21 +138,23 @@ LDAP-based authentication can be enabled by setting the necessary environment va
 - `SQLPAD_LDAP_SEARCH_BASE` - Base LDAP DN to search for users in, eg: `dc=domain,dc=com`.
 - `SQLPAD_LDAP_BIND_DN` - The bind user will be used to lookup information about other LDAP users.
 - `SQLPAD_LDAP_PASSWORD` - The password to bind with for the lookup user.
-- `SQLPAD_LDAP_SEARCH_FILTER` - LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory.  Use literal {{username}} to have the given username used in the search.
+- `SQLPAD_LDAP_SEARCH_FILTER` - LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory. Use literal {{username}} to have the given username used in the search.
 - `SQLPAD_USERPASS_AUTH_DISABLED`=`false` (need to enable local user logins)
 - `SQLPAD_LDAP_AUTO_SIGN_UP`=`true` (auto sign up ldap users)
 - `SQLPAD_LDAP_DEFAULT_ROLE`=`editor` (default ldap role)
 
-LDAP-RBAC , two groups are needed, editors and admins, for example sqlpad-admins , sqlpad-editors, the vars are repetitive, but given the ldap module limations, this is probably best approach to limit users and searches
+To assign roles via LDAP-RBAC, you may specify a profile attribute and value to look to for a particular role.
+
+For example, if your LDAP implementation supports `memberOf`, you may decide to use group DN values. In this case two groups are needed, one for editors and one for admins.
 
 - `SQLPAD_LDAP_SEARCH_FILTER`=`'(&(|(memberOf=cn=sqlpad-editors,dc=example,dc=com)(memberOf=cn=sqlpad-admins,dc=example,dc=com))(uid={{username}}))'`
-- `SQLPAD_LDAP_ADMIN_GROUP_DN`=`'cn=sqlpad-editors,dc=example,dc=com'`
-- `SQLPAD_LDAP_EDITOR_GROUP_DN`=`'cn=sqlpad-admins,dc=example,dc=com'`
-- `SQLPAD_LDAP_GROUP_ATTR`=`memberOf`
+- `SQLPAD_LDAP_ROLE_ADMIN_VALUE`=`'cn=sqlpad-editors,dc=example,dc=com'`
+- `SQLPAD_LDAP_ROLE_EDITOR_VALUE`=`'cn=sqlpad-admins,dc=example,dc=com'`
+- `SQLPAD_LDAP_ROLE_ATTRIBUTE`=`memberOf`
 
-* Modify memberOf attribute based on the LDAP
+At this time any top-level profile attribute is available. The attribute may contain a single value, or multiple values. If multiple, the admin/editor value must exist in the list (do not provide all listed values).
 
-LDAP-based authentication can be enabled and used with local authencation together. LDAP-based users need to be added and set relavant roles ahead of time. When LDAP-based authentication enabled, local user login/registration must be enabled. Users can sign in to SQLPad with an LDAP username (not an e-mail address) and LDAP password using LDAP-based authentication, and with an e-mail address and local password by local authencation.
+LDAP-based authentication can be enabled and used with local authencation together. When both LDAP and local authentication are enabled, LDAP users can sign in using their LDAP username (not an email address) and password, while local users may sign in using their email address and local password.
 
 ## Allowed Domains for User Administration
 

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -40,7 +40,6 @@ function queryLdap(client, searchBase, scope, filter) {
         return reject(err);
       }
 
-      // eslint-disable-next-line no-unused-vars
       res.on('searchEntry', function (entry) {
         results.push(entry.object);
       });

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -93,6 +93,8 @@ function enableLdap(config) {
           const adminRoleFilter = config.get('ldapRoleAdminFilter');
           const editorRoleFilter = config.get('ldapRoleEditorFilter');
 
+          // At least with test setup, jpegPhoto is gnarly output
+          // Remove prior to logging
           delete profile.jpegPhoto;
           appLog.debug(profile, 'Found user');
 
@@ -104,6 +106,7 @@ function enableLdap(config) {
           }
 
           // Derive a userId fiter based on profile that is found
+          // ActiveDirectory will have sAMAccountName, while OpenLDAP will have uid
           let userIdFilter = '';
           if (profile.sAMAccountName) {
             userIdFilter = `(sAMAccountName=${profile.sAMAccountName})`;
@@ -215,6 +218,10 @@ function enableLdap(config) {
             });
             return done(null, newUser);
           }
+
+          // If no user was found, and config does not allow initial log in or auto-creating users,
+          // Return not authorized
+          return done(null, false);
         } catch (error) {
           done(error);
         }

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -37,7 +37,7 @@ function enableLdap(config) {
         try {
           const { models } = req;
 
-          const uid = profile.uid.toLowerCase();
+          const uid = (profile.uid || profile.sAMAccountName).toLowerCase();
           const adminRoleValue = config.get('ldapRoleAdminValue');
           const editorRoleValue = config.get('ldapRoleEditorValue');
           const roleAttribute = config.get('ldapRoleAttribute');

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -37,9 +37,9 @@ function enableLdap(config) {
           const { models } = req;
 
           const uid = profile.uid.toLowerCase();
-          const adminGroup = config.get('sqlpadLadpAdminGroupDn');
-          const editorGroup = config.get('sqlpadLadpEditorGroupDn');
-          const ldapGroupAttr = config.get('sqlpadLdapGroupAttr');
+          const adminGroup = config.get('ldapRoleAdminValue');
+          const editorGroup = config.get('ldapRoleEditorValue');
+          const ldapGroupAttr = config.get('ldapRoleAttribute');
 
           // If all rbac configs are set,
           // update role later on if user is found and current role doesn't match

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -3,6 +3,12 @@ const ldap = require('ldapjs');
 const appLog = require('../lib/app-log');
 const LdapStrategy = require('passport-ldapauth');
 
+/**
+ * Convenience wrapper to promisify client.bind() function
+ * @param {*} client
+ * @param {string} bindDN
+ * @param {string} ldapPassword
+ */
 function bindClient(client, bindDN, ldapPassword) {
   return new Promise((resolve, reject) => {
     client.bind(bindDN, ldapPassword, function (err) {

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -139,9 +139,9 @@ function enableLdap(config) {
 
           let role = '';
 
-          // If all rbac configs are set,
-          // update role later on if user is found and current role doesn't match
-          let rbacByProfile = false;
+          // Create a variable to keep track if role is set by RBAC
+          // If it is, update role later on if user is found and current role doesn't match
+          let roleSetByRBAC = false;
 
           // If admin or editor role filters are specified, open a connection to LDAP server and run additional queries
           // Try to find a role by running searches with a restriction on user that was found
@@ -155,7 +155,7 @@ function enableLdap(config) {
             await bindClient(client, bindDN, bindCredentials);
 
             try {
-              rbacByProfile = true;
+              roleSetByRBAC = true;
 
               if (adminRoleFilter) {
                 const results = await queryLdap(
@@ -213,7 +213,7 @@ function enableLdap(config) {
             }
 
             // If user already exists but role doesn't match, update it
-            if (user.role !== role && rbacByProfile) {
+            if (user.role !== role && roleSetByRBAC) {
               const newUser = await models.users.update(user.id, {
                 role,
               });

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -24,3 +24,31 @@ SQLPAD_CONNECTIONS__devdbdriverid123__filename = "./test/fixtures/sales.sqlite"
 # SQLPAD_OIDC_AUTHORIZATION_URL = "https://dev-350224.okta.com/oauth2/default/v1/authorize"
 # SQLPAD_OIDC_TOKEN_URL = "https://dev-350224.okta.com/oauth2/default/v1/token"
 # SQLPAD_OIDC_USER_INFO_URL = "https://dev-350224.okta.com/oauth2/default/v1/userinfo"
+
+# LDAP testing config
+# This docker image can be used to test LDAP flow
+# https://github.com/rroemhild/docker-test-openldap
+
+# Disable userpass auth
+SQLPAD_USERPASS_AUTH_DISABLED=true
+SQLPAD_LDAP_AUTH_ENABLED=true
+SQLPAD_LDAP_AUTO_SIGN_UP=true
+SQLPAD_LDAP_DEFAULT_ROLE = "editor"
+# Below the details depend on setup
+SQLPAD_LDAP_URL="ldap://localhost:389"
+SQLPAD_LDAP_BIND_DN="cn=admin,dc=planetexpress,dc=com"
+SQLPAD_LDAP_PASSWORD="GoodNewsEveryone"
+# LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory. 
+# Use literal {{username}} to have the given username used in the search.
+SQLPAD_LDAP_SEARCH_FILTER="(uid={{username}})"
+SQLPAD_LDAP_SEARCH_BASE="dc=planetexpress,dc=com"
+# RBAC from LDAP
+# If memberOf is supported could do something like this
+# SQLPAD_LDAP_ADMIN_GROUP_DN="cn=admin_staff,ou=people,dc=planetexpress,dc=com"
+# SQLPAD_LDAP_EDITOR_GROUP_DN="cn=ship_crew,ou=people,dc=planetexpress,dc=com"
+# SQLPAD_LDAP_GROUP_ATTR="memberOf"
+# Otherwise target other attributes
+# Assuming the docker-test-openldap setup, professor/professor becomes an admin, fry/fry becomes an editor
+SQLPAD_LDAP_ADMIN_GROUP_DN="Owner"
+SQLPAD_LDAP_EDITOR_GROUP_DN="Delivery boy"
+SQLPAD_LDAP_GROUP_ATTR="employeeType"

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -43,12 +43,7 @@ SQLPAD_LDAP_PASSWORD="GoodNewsEveryone"
 SQLPAD_LDAP_SEARCH_FILTER="(uid={{username}})"
 SQLPAD_LDAP_SEARCH_BASE="dc=planetexpress,dc=com"
 # RBAC from LDAP
-# If memberOf is supported could do something like this
-# SQLPAD_LDAP_ADMIN_GROUP_DN="cn=admin_staff,ou=people,dc=planetexpress,dc=com"
-# SQLPAD_LDAP_EDITOR_GROUP_DN="cn=ship_crew,ou=people,dc=planetexpress,dc=com"
-# SQLPAD_LDAP_GROUP_ATTR="memberOf"
-# Otherwise target other attributes
 # Assuming the docker-test-openldap setup, professor/professor becomes an admin, fry/fry becomes an editor
-SQLPAD_LDAP_ADMIN_GROUP_DN="Owner"
-SQLPAD_LDAP_EDITOR_GROUP_DN="Delivery boy"
-SQLPAD_LDAP_GROUP_ATTR="employeeType"
+SQLPAD_LDAP_ROLE_ADMIN_VALUE="Owner"
+SQLPAD_LDAP_ROLE_EDITOR_VALUE="Delivery boy"
+SQLPAD_LDAP_ROLE_ATTRIBUTE="employeeType"

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -40,10 +40,10 @@ SQLPAD_CONNECTIONS__devdbdriverid123__filename = "./test/fixtures/sales.sqlite"
 # SQLPAD_LDAP_PASSWORD="GoodNewsEveryone"
 # # LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory. 
 # # Use literal {{username}} to have the given username used in the search.
+# # A fancier example might be something like (&(|(memberOf=cn=sqlpad-editors,dc=example,dc=com)(memberOf=cn=sqlpad-admins,dc=example,dc=com))(uid={{username}}))
 # SQLPAD_LDAP_SEARCH_FILTER="(uid={{username}})"
 # SQLPAD_LDAP_SEARCH_BASE="dc=planetexpress,dc=com"
 # # RBAC from LDAP
-# # Assuming the docker-test-openldap setup, professor/professor becomes an admin, fry/fry becomes an editor
-# SQLPAD_LDAP_ROLE_ADMIN_VALUE="Owner"
-# SQLPAD_LDAP_ROLE_EDITOR_VALUE="Delivery boy"
-# SQLPAD_LDAP_ROLE_ATTRIBUTE="employeeType"
+# # Assuming the docker-test-openldap setup, hermes/hermes becomes an admin, bender/bender becomes an editor
+# SQLPAD_LDAP_ROLE_ADMIN_FILTER = "(memberOf=cn=admin_staff,ou=people,dc=planetexpress,dc=com)"
+# SQLPAD_LDAP_ROLE_EDITOR_FILTER = "(memberOf=cn=ship_crew,ou=people,dc=planetexpress,dc=com)"

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -29,21 +29,21 @@ SQLPAD_CONNECTIONS__devdbdriverid123__filename = "./test/fixtures/sales.sqlite"
 # This docker image can be used to test LDAP flow
 # https://github.com/rroemhild/docker-test-openldap
 
-# Disable userpass auth
-SQLPAD_USERPASS_AUTH_DISABLED=true
-SQLPAD_LDAP_AUTH_ENABLED=true
-SQLPAD_LDAP_AUTO_SIGN_UP=true
-SQLPAD_LDAP_DEFAULT_ROLE = "editor"
-# Below the details depend on setup
-SQLPAD_LDAP_URL="ldap://localhost:389"
-SQLPAD_LDAP_BIND_DN="cn=admin,dc=planetexpress,dc=com"
-SQLPAD_LDAP_PASSWORD="GoodNewsEveryone"
-# LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory. 
-# Use literal {{username}} to have the given username used in the search.
-SQLPAD_LDAP_SEARCH_FILTER="(uid={{username}})"
-SQLPAD_LDAP_SEARCH_BASE="dc=planetexpress,dc=com"
-# RBAC from LDAP
-# Assuming the docker-test-openldap setup, professor/professor becomes an admin, fry/fry becomes an editor
-SQLPAD_LDAP_ROLE_ADMIN_VALUE="Owner"
-SQLPAD_LDAP_ROLE_EDITOR_VALUE="Delivery boy"
-SQLPAD_LDAP_ROLE_ATTRIBUTE="employeeType"
+# # Disable local userpass auth
+# SQLPAD_USERPASS_AUTH_DISABLED=true
+# SQLPAD_LDAP_AUTH_ENABLED=true
+# SQLPAD_LDAP_AUTO_SIGN_UP=true
+# SQLPAD_LDAP_DEFAULT_ROLE = "editor"
+# # Below the details depend on setup
+# SQLPAD_LDAP_URL="ldap://localhost:389"
+# SQLPAD_LDAP_BIND_DN="cn=admin,dc=planetexpress,dc=com"
+# SQLPAD_LDAP_PASSWORD="GoodNewsEveryone"
+# # LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory. 
+# # Use literal {{username}} to have the given username used in the search.
+# SQLPAD_LDAP_SEARCH_FILTER="(uid={{username}})"
+# SQLPAD_LDAP_SEARCH_BASE="dc=planetexpress,dc=com"
+# # RBAC from LDAP
+# # Assuming the docker-test-openldap setup, professor/professor becomes an admin, fry/fry becomes an editor
+# SQLPAD_LDAP_ROLE_ADMIN_VALUE="Owner"
+# SQLPAD_LDAP_ROLE_EDITOR_VALUE="Delivery boy"
+# SQLPAD_LDAP_ROLE_ATTRIBUTE="employeeType"

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -246,18 +246,13 @@ const configItems = [
     default: 'editor',
   },
   {
-    key: 'ldapRoleAdminValue',
-    envVar: 'SQLPAD_LDAP_ROLE_ADMIN_VALUE',
+    key: 'ldapRoleAdminFilter',
+    envVar: 'SQLPAD_LDAP_ROLE_ADMIN_FILTER',
     default: '',
   },
   {
-    key: 'ldapRoleEditorValue',
-    envVar: 'SQLPAD_LDAP_ROLE_EDITOR_VALUE',
-    default: '',
-  },
-  {
-    key: 'ldapRoleAttribute',
-    envVar: 'SQLPAD_LDAP_ROLE_ATTRIBUTE',
+    key: 'ldapRoleEditorFilter',
+    envVar: 'SQLPAD_LDAP_ROLE_EDITOR_FILTER',
     default: '',
   },
   {

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -246,19 +246,19 @@ const configItems = [
     default: 'editor',
   },
   {
-    key: 'sqlpadLadpAdminGroupDn',
-    envVar: 'SQLPAD_LDAP_ADMIN_GROUP_DN',
+    key: 'ldapRoleAdminValue',
+    envVar: 'SQLPAD_LDAP_ROLE_ADMIN_VALUE',
     default: '',
   },
   {
-    key: 'sqlpadLadpEditorGroupDn',
-    envVar: 'SQLPAD_LDAP_EDITOR_GROUP_DN',
+    key: 'ldapRoleEditorValue',
+    envVar: 'SQLPAD_LDAP_ROLE_EDITOR_VALUE',
     default: '',
   },
   {
-    key: 'sqlpadLdapGroupAttr',
-    envVar: 'SQLPAD_LDAP_GROUP_ATTR',
-    default: 'memberOf',
+    key: 'ldapRoleAttribute',
+    envVar: 'SQLPAD_LDAP_ROLE_ATTRIBUTE',
+    default: '',
   },
   {
     key: 'serviceTokenSecret_d',

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -358,6 +358,11 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3025,18 +3030,11 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "ldap-filter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.2.2.tgz",
-      "integrity": "sha1-8rhCvguG2jNSeYUFsx68rlkNd9A=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
+      "integrity": "sha1-KxTGiiqdQQTb28kQocqF/Riel5c=",
       "requires": {
-        "assert-plus": "0.1.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
-        }
+        "assert-plus": "^1.0.0"
       }
     },
     "ldapauth-fork": {
@@ -3051,6 +3049,48 @@
         "lru-cache": "^5.1.1"
       },
       "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        },
+        "extsprintf": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+        },
+        "ldap-filter": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.2.2.tgz",
+          "integrity": "sha1-8rhCvguG2jNSeYUFsx68rlkNd9A=",
+          "requires": {
+            "assert-plus": "0.1.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+            }
+          }
+        },
+        "ldapjs": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-1.0.2.tgz",
+          "integrity": "sha1-VE/3Ayt7g8aPBwEyjZKXqmlDQPk=",
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "^1.0.0",
+            "backoff": "^2.5.0",
+            "bunyan": "^1.8.3",
+            "dashdash": "^1.14.0",
+            "dtrace-provider": "~0.8",
+            "ldap-filter": "0.2.2",
+            "once": "^1.4.0",
+            "vasync": "^1.6.4",
+            "verror": "^1.8.1"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3058,31 +3098,40 @@
           "requires": {
             "yallist": "^3.0.2"
           }
+        },
+        "vasync": {
+          "version": "1.6.4",
+          "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
+          "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+          "requires": {
+            "verror": "1.6.0"
+          },
+          "dependencies": {
+            "verror": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+              "requires": {
+                "extsprintf": "1.2.0"
+              }
+            }
+          }
         }
       }
     },
     "ldapjs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-1.0.2.tgz",
-      "integrity": "sha1-VE/3Ayt7g8aPBwEyjZKXqmlDQPk=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.2.0.tgz",
+      "integrity": "sha512-9+ekbj97nxRYQMRgEm/HYFhFLWSRKah2PnReUfhfM5f62XBeUSFolB+AQ2Jij5tqowpksTnrdNCZLP6C+V3uag==",
       "requires": {
-        "asn1": "0.2.3",
+        "abstract-logging": "^2.0.0",
+        "asn1": "^0.2.4",
         "assert-plus": "^1.0.0",
         "backoff": "^2.5.0",
-        "bunyan": "^1.8.3",
-        "dashdash": "^1.14.0",
-        "dtrace-provider": "~0.8",
-        "ldap-filter": "0.2.2",
+        "ldap-filter": "^0.3.3",
         "once": "^1.4.0",
-        "vasync": "^1.6.4",
+        "vasync": "^2.2.0",
         "verror": "^1.8.1"
-      },
-      "dependencies": {
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-        }
       }
     },
     "leven": {
@@ -3634,9 +3683,9 @@
       }
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
     "nanoid": {
@@ -6065,26 +6114,11 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vasync": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
-      "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.0.tgz",
+      "integrity": "sha1-z951GGChWCLbOxMrxZsRakra8Bs=",
       "requires": {
-        "verror": "1.6.0"
-      },
-      "dependencies": {
-        "extsprintf": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
-          "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
-        },
-        "verror": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
-          "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
-          "requires": {
-            "extsprintf": "1.2.0"
-          }
-        }
+        "verror": "1.10.0"
       }
     },
     "verror": {

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "helmet": "^4.1.1",
     "ini": "^1.3.5",
     "jsonwebtoken": "^8.5.1",
+    "ldapjs": "^2.2.0",
     "lodash": "^4.17.20",
     "lru-cache": "^6.0.0",
     "mariadb": "^2.5.0",


### PR DESCRIPTION
I took at pass at updating and testing out #837, which led me down a path of running a local LDAP server via this docker image https://github.com/rroemhild/docker-test-openldap, and updating the implementation to be able to handle that. 

I'm not too familiar with LDAP, but from what I understand `memberOf` isn't standard, and might not always be available? 

With that in mind, I changed the config variables a bit to be more generic from the original implementation. To get dynamic role assignment via LDAP, you must set an attribute you want to look to, and values for each role. 

For example, assume the LDAP profile had a field called `employeeType`, with values `Manager` and `Individual contributor`, you could do something like the following:

```sh
SQLPAD_LDAP_ROLE_ATTRIBUTE="employeeType"
SQLPAD_LDAP_ROLE_ADMIN_VALUE="Manager"
SQLPAD_LDAP_ROLE_EDITOR_VALUE="Individual contributor"
```

Other config introduced here are auto sign up and default role. Default role is used if the role attribute/values missed

```sh
SQLPAD_LDAP_AUTO_SIGN_UP=true
SQLPAD_LDAP_DEFAULT_ROLE = "editor"
```

Also fixed in this PR - LDAP can be enabled and local auth disabled! I can't remember where this was at or what the plan was, but I do recall it being confusing.

@dengc367 @eladeyal-intel @skaravad any thoughts since you all are more familiar with LDAP than myself?