### PR TITLE
Fix LDAP role filters

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -141,7 +141,9 @@ LDAP-based authentication can be enabled by setting the necessary environment va
 - `SQLPAD_LDAP_SEARCH_FILTER` - LDAP search filter, e.g. `(uid={{username}})` in OpenLDAP or `(sAMAccountName={{username}})` in ActiveDirectory. Use literal {{username}} to have the given username used in the search.
 - `SQLPAD_USERPASS_AUTH_DISABLED`=`false` (need to enable local user logins)
 - `SQLPAD_LDAP_AUTO_SIGN_UP`=`true` (auto sign up ldap users)
-- `SQLPAD_LDAP_DEFAULT_ROLE`=`editor` (default ldap role)
+- `SQLPAD_LDAP_ROLE_ADMIN_FILTER` - LDAP filter used to determine if a user should be assigned SQLPad admin role
+- `SQLPAD_LDAP_ROLE_EDITOR_FILTER` - LDAP filter used to determine if a user should be assigned SQLPad editor role
+- `SQLPAD_LDAP_DEFAULT_ROLE`- Default role for users that do not match LDAP role filters. May be either `admin`, `editor`, `denied`, or empty. If `denied` or empty, a user _must_ match an LDAP role filter to be admitted into SQLPad, unless they are previously created as a SQLPad user in advanced.
 
 To assign roles via LDAP-RBAC, you may specify a profile attribute and value to look to for a particular role.
 
@@ -154,6 +156,19 @@ SQLPAD_LDAP_ROLE_EDITOR_FILTER = "(memberOf=cn=sqlpad-editors,dc=example,dc=com)
 ```
 
 The role filters will be combined with the `uid`/`sAMAccountName` filter depending on the profile returned. For example, the `SQLPAD_LDAP_ROLE_ADMIN_FILTER` above would become `(&(memberOf=cn=sqlpad-admins,dc=example,dc=com)(uid=username))` for OpenLDAP or `(&(memberOf=cn=sqlpad-admins,dc=example,dc=com)(sAMAccountName=username))` for ActiveDirectory.
+
+The above example could be simplified, as users that do not match a role filter will not be allowed in unless `SQLPAD_LDAP_DEFAULT_ROLE` is also set.
+
+```sh
+# Initial search filter authenticates anyone found in LDAP
+SQLPAD_LDAP_SEARCH_FILTER = "(uid={{username}})"
+# User must then match one of these filters
+SQLPAD_LDAP_ROLE_ADMIN_FILTER = "(memberOf=cn=sqlpad-admins,dc=example,dc=com)"
+SQLPAD_LDAP_ROLE_EDITOR_FILTER = "(memberOf=cn=sqlpad-editors,dc=example,dc=com)"
+# If a match is not found by role filter, default role will be used if set.
+# If not set, or set to "denied", the user will not be allowed in unless previously added manually in SQLPad UI
+SQLPAD_LDAP_DEFAULT_ROLE = "denied"
+```
 
 LDAP-based authentication can be enabled and used with local authencation together. When both LDAP and local authentication are enabled, LDAP users can sign in using their LDAP username (not an email address) and password, while local users may sign in using their email address and local password.
 

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -108,6 +108,7 @@ function enableLdap(config) {
           const { models } = req;
 
           if (!profile) {
+            appLog.debug(`No LDAP profile found for user ${req.body.email}`);
             return done(null, false, {
               message: 'wrong LDAP username or password',
             });
@@ -168,11 +169,13 @@ function enableLdap(config) {
 
             try {
               if (adminRoleFilter) {
+                const filter = `(&${userIdFilter}${adminRoleFilter})`;
+                appLog.debug(`Running LDAP search ${filter}`);
                 const results = await queryLdap(
                   client,
                   searchBase,
                   'sub',
-                  `(&${userIdFilter}${adminRoleFilter})`
+                  filter
                 );
                 if (results.length > 0) {
                   appLog.debug(
@@ -184,11 +187,13 @@ function enableLdap(config) {
 
               // If role wasn't found for admin, try running editor search
               if (!role && editorRoleFilter) {
+                const filter = `(&${userIdFilter}${editorRoleFilter})`;
+                appLog.debug(`Running LDAP search ${filter}`);
                 const results = await queryLdap(
                   client,
                   searchBase,
                   'sub',
-                  `(&${userIdFilter}${adminRoleFilter})`
+                  filter
                 );
                 if (results.length > 0) {
                   appLog.debug(

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -33,7 +33,8 @@ SQLPAD_CONNECTIONS__devdbdriverid123__filename = "./test/fixtures/sales.sqlite"
 # SQLPAD_USERPASS_AUTH_DISABLED=true
 # SQLPAD_LDAP_AUTH_ENABLED=true
 # SQLPAD_LDAP_AUTO_SIGN_UP=true
-# SQLPAD_LDAP_DEFAULT_ROLE = "editor"
+# # Do not allow any login that does not already exist or match RBAC filter
+# SQLPAD_LDAP_DEFAULT_ROLE = ""
 # # Below the details depend on setup
 # SQLPAD_LDAP_URL="ldap://localhost:389"
 # SQLPAD_LDAP_BIND_DN="cn=admin,dc=planetexpress,dc=com"

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -243,7 +243,7 @@ const configItems = [
   {
     key: 'ldapDefaultRole',
     envVar: 'SQLPAD_LDAP_DEFAULT_ROLE',
-    default: 'editor',
+    default: '',
   },
   {
     key: 'ldapRoleAdminFilter',


### PR DESCRIPTION
A couple fixes for LDAP role filters

* Fixes editor role filter so that is is no longer ignored
* Changes SQLPAD_LDAP_DEFAULT_ROLE so that if not provided, or set to `denied`, and a user does not match in an LDAP role filter, the user is not signed up.

Closes #861 