### PR TITLE
Add sync role checkbox for LDAP RBAC setups

### DIFF
--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -48,6 +48,7 @@ export interface AppInfo {
     editorWordWrap: boolean;
     googleAuthConfigured: string;
     ldapConfigured: boolean;
+    ldapRolesConfigured: boolean;
     localAuthConfigured: boolean;
     oidcConfigured: boolean;
     oidcLinkHtml: string;
@@ -141,6 +142,7 @@ export interface User {
   email: string;
   name: string;
   role: string;
+  syncAuthRole?: boolean | null;
   disabled: boolean;
   signupAt: string | Date;
   createdAt: string | Date;

--- a/client/src/users/InviteUserForm.tsx
+++ b/client/src/users/InviteUserForm.tsx
@@ -7,15 +7,18 @@ import message from '../common/message';
 import Select from '../common/Select';
 import Spacer from '../common/Spacer';
 import { api } from '../utilities/api';
+import useAppContext from '../utilities/use-app-context';
 
 interface Props {
   onInvited: () => void;
 }
 
 function InviteUserForm({ onInvited }: Props) {
+  const { config } = useAppContext();
   const [email, setEmail] = useState<string | null>(null);
   const [role, setRole] = useState<string | null>(null);
   const [isInviting, setIsInviting] = useState<boolean>(false);
+  const [syncAuthRole, setSyncAuthRole] = useState<boolean>(false);
 
   const onInviteClick = async (event: FormEvent) => {
     event.preventDefault();
@@ -23,6 +26,7 @@ function InviteUserForm({ onInvited }: Props) {
     const user = {
       email,
       role,
+      syncAuthRole,
     };
     setIsInviting(true);
     const json = await api.post('/api/users', user);
@@ -38,11 +42,12 @@ function InviteUserForm({ onInvited }: Props) {
 
   return (
     <div>
-      <p>
-        Users may only sign up if they have first been added. Once added, invite
-        them to continue the sign-up process on the{' '}
-        <Link to={'/signup'}>signup page</Link>.
-      </p>
+      {config?.localAuthConfigured && (
+        <p>
+          Once added, invite users to continue the sign-up process on the{' '}
+          <Link to={'/signup'}>signup page</Link>.
+        </p>
+      )}
       <form onSubmit={onInviteClick}>
         <label>
           Email
@@ -59,7 +64,7 @@ function InviteUserForm({ onInvited }: Props) {
         <Spacer size={2} />
 
         <label>
-          role
+          Role
           <Select
             name="role"
             value={role || ''}
@@ -76,6 +81,27 @@ function InviteUserForm({ onInvited }: Props) {
             Admins can manage database connections and users
           </FormExplain>
         </label>
+
+        {config?.ldapConfigured && config?.ldapRolesConfigured && (
+          <>
+            <Spacer size={2} />
+            <input
+              type="checkbox"
+              checked={syncAuthRole}
+              id="syncAuthRole"
+              name="syncAuthRole"
+              onChange={(e) => setSyncAuthRole(e.target.checked)}
+            />
+            <label htmlFor="syncAuthRole" style={{ marginLeft: 8 }}>
+              Sync role with LDAP auth
+            </label>
+            <FormExplain>
+              If LDAP Role filters are enabled, role assignment will be kept in
+              sync as users log in if checked. Users created by LDAP
+              auto-sign-up will have this turned on by default.
+            </FormExplain>
+          </>
+        )}
 
         <Spacer size={3} />
         <div>

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -151,7 +151,7 @@ LDAP-based authentication can be enabled by setting the necessary environment va
 
 To assign roles via LDAP-RBAC, you may specify additional LDAP user filters to ensure the user fits a particular role or group.
 
-?> Roles assigned via LDAP will sync on every login.
+?> Roles assigned via LDAP will sync on every login if user was created by auto sign up. This can be changed per-user in user add/edit UI forms.
 
 For example, if your LDAP implementation supports `memberOf`, you may decide to use group DN values. In this case two groups are needed, one for editors and one for admins.
 

--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -220,7 +220,12 @@ function enableLdap(config) {
             }
 
             // If a role was set by RBAC and user already exists, but role doesn't match, update it
-            if (roleSetByRBAC && role && user.role !== role) {
+            if (
+              roleSetByRBAC &&
+              role &&
+              user.syncAuthRole &&
+              user.role !== role
+            ) {
               const newUser = await models.users.update(user.id, {
                 role,
               });
@@ -245,6 +250,7 @@ function enableLdap(config) {
             const newUser = await models.users.create({
               email,
               role,
+              syncAuthRole: true,
               signupAt: new Date(),
             });
             return done(null, newUser);

--- a/server/config.dev.env
+++ b/server/config.dev.env
@@ -29,7 +29,7 @@ SQLPAD_CONNECTIONS__devdbdriverid123__filename = "./test/fixtures/sales.sqlite"
 # This docker image can be used to test LDAP flow
 # https://github.com/rroemhild/docker-test-openldap
 
-# # Disable local userpass auth
+# Disable local userpass auth
 # SQLPAD_USERPASS_AUTH_DISABLED=true
 # SQLPAD_LDAP_AUTH_ENABLED=true
 # SQLPAD_LDAP_AUTO_SIGN_UP=true

--- a/server/migrations/05-00800-auth-role.js
+++ b/server/migrations/05-00800-auth-role.js
@@ -1,0 +1,18 @@
+const Sequelize = require('sequelize');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} nedb - collection of nedb objects created in /lib/db.js
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, nedb) {
+  await queryInterface.addColumn('users', 'sync_auth_role', {
+    type: Sequelize.BOOLEAN,
+  });
+}
+
+module.exports = {
+  up,
+};

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -39,6 +39,9 @@ async function getApp(req, res) {
       smtpConfigured: config.smtpConfigured(),
       ldapConfigured:
         config.get('ldapAuthEnabled') || config.get('enableLdapAuth'),
+      ldapRolesConfigured: Boolean(
+        config.get('ldapRoleAdminFilter') || config.get('ldapRoleEditorFilter')
+      ),
       oidcConfigured: config.oidcConfigured(),
       oidcLinkHtml: config.get('oidcLinkHtml'),
       showServiceTokensUI: Boolean(

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -42,6 +42,7 @@ async function createUser(req, res) {
     role: req.body.role,
     name: req.body.name,
     data: req.body.data,
+    syncAuthRole: Boolean(req.body.syncAuthRole),
   });
 
   webhooks.userCreated(user);
@@ -98,6 +99,9 @@ async function updateUser(req, res) {
   }
   if (body.hasOwnProperty('disabled')) {
     updateUser.disabled = body.disabled;
+  }
+  if (body.hasOwnProperty('syncAuthRole')) {
+    updateUser.syncAuthRole = body.syncAuthRole;
   }
 
   const updatedUser = await models.users.update(params.id, updateUser);

--- a/server/sequelize-db/users.js
+++ b/server/sequelize-db/users.js
@@ -24,6 +24,9 @@ module.exports = function (sequelize) {
           isIn: [['admin', 'editor', 'viewer']],
         },
       },
+      syncAuthRole: {
+        type: DataTypes.BOOLEAN,
+      },
       name: {
         type: DataTypes.STRING,
       },

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -26,6 +26,7 @@ const expectedConfigKeys = [
   'samlConfigured',
   'samlLinkHtml',
   'ldapConfigured',
+  'ldapRolesConfigured',
   'oidcConfigured',
   'oidcLinkHtml',
   'showServiceTokensUI',


### PR DESCRIPTION
Adds a toggle to configure whether a user's role should be kept in sync with the LDAP role filters if used. 

This checkbox only appears if LDAP auth is enabled and role filters are used.

If auto sign up is turned on, users created via auto-sign-up will have this turned on. Users created manually will default to it being turned off (though it can be enabled during user creation time or afterwards)

Closes #861 