### PR TITLE
Use single job for connection client heartbeat

### DIFF
--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -20,7 +20,6 @@ export interface EditorSession {
   schemaExpansions: { [conectionId: string]: ExpandedMap };
   connectionId: string;
   connectionClient?: ConnectionClient;
-  connectionClientInterval?: any;
   runQueryInstanceId?: string;
   isRunning: boolean;
   isSaving: boolean;
@@ -64,7 +63,6 @@ export const useEditorStore = create<EditorStoreState>((set, get) => ({
       schemaExpansions: {},
       connectionId: '',
       connectionClient: undefined,
-      connectionClientInterval: undefined,
       runQueryInstanceId: undefined,
       isRunning: false,
       isSaving: false,


### PR DESCRIPTION
The prior implementation has a subtle race condition that is tricky to manage. Using a single job that constantly sends a heartbeat if there is something to beat for is much simpler.